### PR TITLE
fix: timestamp seeking functionality and video player improvements

### DIFF
--- a/frontend/src/components/CommentSection.svelte
+++ b/frontend/src/components/CommentSection.svelte
@@ -608,8 +608,8 @@
                 <button
                   type="button"
                   class="timestamp-link"
-                  on:click={() => dispatch('seekTo', comment.timestamp)}
-                  on:keydown={(e) => e.key === 'Enter' && dispatch('seekTo', comment.timestamp)}
+                  on:click={() => dispatch('seekTo', { time: comment.timestamp })}
+                  on:keydown={(e) => e.key === 'Enter' && dispatch('seekTo', { time: comment.timestamp })}
                   aria-label="Jump to timestamp {formatTimestamp(comment.timestamp)}"
                   title="Jump to {formatTimestamp(comment.timestamp)} in the video"
                 >

--- a/frontend/src/components/VideoPlayer.svelte
+++ b/frontend/src/components/VideoPlayer.svelte
@@ -19,7 +19,6 @@
     <!-- svelte-ignore a11y-media-has-caption -->
     <video id="player" playsinline controls>
       <source src={videoUrl} type="video/mp4" />
-      <!-- Captions disabled to avoid CORS issues -->
       Your browser does not support the video element.
     </video>
     
@@ -33,10 +32,10 @@
     {#if errorMessage}
       <p class="error-message">{errorMessage}</p>
       <button 
-      class="retry-button" 
-      on:click={handleRetry}
-      title="Retry loading the video file"
-    >Retry Loading Video</button>
+        class="retry-button" 
+        on:click={handleRetry}
+        title="Retry loading the video file"
+      >Retry Loading Video</button>
     {/if}
   {:else if file && file.status === 'completed'}
     <div class="no-preview">Video preview not available. You can try downloading the file.</div>

--- a/frontend/src/routes/FileDetail.svelte
+++ b/frontend/src/routes/FileDetail.svelte
@@ -326,6 +326,7 @@
     } catch (error) {
       console.error('Error initializing player:', error);
       errorMessage = 'Failed to initialize video player';
+      playerInitialized = false;
     }
   }
 
@@ -357,25 +358,7 @@
   // Event handlers for components
   function handleSegmentClick(event: any) {
     const startTime = event.detail.startTime;
-    if (player) {
-      player.currentTime = startTime;
-      
-      // Flash player controls briefly to show timestamp
-      const playerContainer = document.querySelector('.plyr');
-      if (playerContainer) {
-        playerContainer.classList.add('plyr--show-controls');
-        setTimeout(() => {
-          playerContainer.classList.remove('plyr--show-controls');
-        }, 3000); // Show controls for 3 seconds
-      }
-      
-      if (player.paused) {
-        const playPromise = player.play();
-        if (playPromise && typeof playPromise.catch === 'function') {
-          playPromise.catch(console.error);
-        }
-      }
-    }
+    seekToTime(startTime);
   }
 
   // Handle speaker name updates
@@ -705,9 +688,31 @@
   }
 
   function handleSeekTo(event: any) {
-    const time = event.detail.time;
+    const time = event.detail.time || event.detail;
+    seekToTime(time);
+  }
+
+  function seekToTime(time: number) {
     if (player) {
-      player.currentTime = time;
+      // Add 0.5 second padding before the target time for better context
+      const paddedTime = Math.max(0, time - 0.5);
+      player.currentTime = paddedTime;
+      
+      // Flash player controls briefly to show timestamp
+      const playerContainer = document.querySelector('.plyr');
+      if (playerContainer) {
+        playerContainer.classList.add('plyr--show-controls');
+        setTimeout(() => {
+          playerContainer.classList.remove('plyr--show-controls');
+        }, 3000); // Show controls for 3 seconds
+      }
+      
+      if (player.paused) {
+        const playPromise = player.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(console.error);
+        }
+      }
     }
   }
 
@@ -746,6 +751,8 @@
     if (player) {
       try {
         player.destroy();
+        player = null;
+        playerInitialized = false;
       } catch (err) {
         console.error('Error destroying player:', err);
       }


### PR DESCRIPTION
## Summary
- Fixed comment timestamp buttons that weren't properly seeking to video timestamps
- Added unified seek functionality with 0.5-second padding for better user context
- Enhanced visual feedback when seeking (player controls flash briefly)
- Improved video player cleanup and error handling

## Changes Made
- **CommentSection.svelte**: Fixed timestamp button event dispatch format
- **FileDetail.svelte**: Added unified `seekToTime` function with padding and visual feedback
- **VideoPlayer.svelte**: Minor code cleanup and formatting improvements

## Test Plan
- [x] Click timestamp buttons in comments to verify seeking works
- [x] Click transcript segment timestamps to verify seeking works
- [x] Verify 0.5s padding provides better context when seeking
- [x] Confirm visual feedback (controls flash) when seeking
- [x] Test that video auto-plays after seeking if it was paused

🤖 Generated with [Claude Code](https://claude.ai/code)