### PR TITLE
fix: speaker labeling isolation and analytics reactivity

### DIFF
--- a/backend/app/models/media.py
+++ b/backend/app/models/media.py
@@ -65,6 +65,7 @@ class MediaFile(Base):
     # Relationships
     user = relationship("User", back_populates="media_files")
     transcript_segments = relationship("TranscriptSegment", back_populates="media_file", cascade="all, delete-orphan")
+    speakers = relationship("Speaker", back_populates="media_file", cascade="all, delete-orphan")
     comments = relationship("Comment", back_populates="media_file", cascade="all, delete-orphan")
     file_tags = relationship("FileTag", back_populates="media_file", cascade="all, delete-orphan")
     tasks = relationship("Task", back_populates="media_file", cascade="all, delete-orphan")
@@ -91,6 +92,7 @@ class Speaker(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    media_file_id = Column(Integer, ForeignKey("media_file.id", ondelete="CASCADE"), nullable=False)
     name = Column(String, nullable=False)  # Original name from diarization (e.g., "SPEAKER_01")
     display_name = Column(String, nullable=True)  # User-assigned name (e.g., "John Doe")
     uuid = Column(String, nullable=False, index=True)  # Unique identifier for the speaker
@@ -100,6 +102,7 @@ class Speaker(Base):
     
     # Relationships
     user = relationship("User", back_populates="speakers")
+    media_file = relationship("MediaFile", back_populates="speakers")
     transcript_segments = relationship("TranscriptSegment", back_populates="speaker")
 
 

--- a/backend/app/schemas/media.py
+++ b/backend/app/schemas/media.py
@@ -27,6 +27,7 @@ class SpeakerBase(BaseModel):
 
 class SpeakerCreate(SpeakerBase):
     user_id: int
+    media_file_id: int
     embedding_vector: Optional[List[float]] = None
 
 
@@ -40,6 +41,7 @@ class SpeakerUpdate(BaseModel):
 class Speaker(SpeakerBase):
     id: int
     user_id: int
+    media_file_id: int
     created_at: datetime
 
     class Config:

--- a/backend/app/tasks/transcription/core.py
+++ b/backend/app/tasks/transcription/core.py
@@ -118,7 +118,7 @@ def transcribe_audio_task(self, file_id: int):
                 unique_speakers = extract_unique_speakers(result["segments"])
                 
                 with session_scope() as db:
-                    speaker_mapping = create_speaker_mapping(db, user_id, unique_speakers)
+                    speaker_mapping = create_speaker_mapping(db, user_id, file_id, unique_speakers)
                 
                 processed_segments = process_segments_with_speakers(result["segments"], speaker_mapping)
                 

--- a/database/init_db.sql
+++ b/database/init_db.sql
@@ -76,12 +76,14 @@ CREATE TABLE IF NOT EXISTS file_tag (
 CREATE TABLE IF NOT EXISTS speaker (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES "user"(id),
+    media_file_id INTEGER NOT NULL REFERENCES media_file(id) ON DELETE CASCADE, -- Associate speaker with specific file
     name VARCHAR(255) NOT NULL, -- Original name from diarization (e.g., "SPEAKER_01")
     display_name VARCHAR(255) NULL, -- User-assigned name (e.g., "John Doe")
-    uuid VARCHAR(255) NOT NULL UNIQUE, -- Unique identifier for the speaker
+    uuid VARCHAR(255) NOT NULL, -- Unique identifier for the speaker
     verified BOOLEAN NOT NULL DEFAULT FALSE, -- Flag to indicate if the speaker has been verified by a user
     embedding_vector JSONB NULL, -- Speaker embedding as JSON array
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, media_file_id, name) -- Ensure unique speaker names per file per user
 );
 
 -- Transcript segments table


### PR DESCRIPTION
## Summary
Fixes critical speaker labeling issues where speakers from different videos were getting mixed up and analytics not updating properly.

## Key Changes
- **File-specific speakers**: Made speakers associated with specific media files instead of being global per user
- **Database schema**: Added `media_file_id` foreign key to speaker table with cascade delete
- **Clean filter sidebar**: Only shows speakers with meaningful names (excludes SPEAKER_XX patterns)
- **Consistent ordering**: Speakers always sorted by SPEAKER_XX numeric order
- **Real-time analytics**: Analytics section now updates immediately when speaker names are saved
- **Better validation**: Only saves meaningful speaker display names

## Issues Fixed
1. Speaker names from first video were being applied to subsequent videos
2. Filter sidebar showed confusing multiple "SPEAKER_01" entries
3. Analytics section required manual refresh to show updated speaker names
4. Speaker ordering was inconsistent after editing

## Test Plan
- [x] Upload multiple videos and verify speakers are isolated per file
- [x] Edit speaker names and verify analytics update immediately
- [x] Check filter sidebar only shows meaningful speaker names
- [x] Verify consistent SPEAKER_XX ordering across page reloads

🤖 Generated with [Claude Code](https://claude.ai/code)