### PR TITLE
Fix: Multiple UI and video processing bugs

### DIFF
--- a/frontend/src/routes/FileDetail.svelte
+++ b/frontend/src/routes/FileDetail.svelte
@@ -657,6 +657,14 @@
             
             // Refresh subtitle track with debounce
             refreshSubtitleTrack();
+            
+            // Clear cached processed videos so downloads will use updated transcript
+            try {
+              await axiosInstance.delete(`/api/files/${file.id}/cache`);
+              console.log('Cleared video cache to ensure downloads use updated transcript');
+            } catch (error) {
+              console.warn('Could not clear video cache:', error);
+            }
           }
         }
         


### PR DESCRIPTION
## Summary
This PR fixes three critical bugs identified during user testing related to video playback UI and download processing:

## Bugs Fixed

### 1. **Playhead Indicator Disappearing During Speaker Editing** 🎯
- **Issue**: Scrollbar playhead indicator disappeared when clicking "Edit Speakers" button
- **Cause**: Condition `\!isEditingSpeakers` was hiding the indicator during speaker editing
- **Fix**: Removed the condition to keep indicator visible during speaker editing
- **Impact**: Users can now see video position while editing speaker names

### 2. **Transcript Edits Not Reflected in Video Downloads** 📝
- **Issue**: Individual transcript segment edits weren't included in downloaded videos with embedded subtitles
- **Cause**: Cache wasn't being cleared after transcript updates (unlike speaker updates)
- **Fix**: Added cache clearing after transcript segment saves, matching speaker edit behavior
- **Impact**: Downloaded videos now include latest transcript changes

### 3. **Download Button Stuck on Consecutive Downloads** ⬇️ 
- **Issue**: Second download attempt would show "processing" spinner indefinitely
- **Cause**: WebSocket race condition - cached video completion messages arrived before frontend was ready
- **Fix**: Implemented intelligent monitoring system:
  - 100ms initialization delay prevents race conditions
  - Interval-based checking (every 1s) instead of fixed timeouts
  - Quick detection for cached videos (3s) vs actual processing (60s)
- **Impact**: Users can now download files consecutively without button getting stuck

## Technical Changes

### Files Modified:
- `frontend/src/components/TranscriptDisplay.svelte`
- `frontend/src/routes/FileDetail.svelte`

### Key Improvements:
- **Consistent behavior** between speaker edits and transcript edits
- **Faster feedback** for cached downloads (3s vs 30s)
- **Robust error handling** with automatic cleanup
- **Better UX** with maintained visual feedback

## Test Plan
- [x] Edit speakers - playhead indicator remains visible
- [x] Edit transcript segments - changes appear in downloads
- [x] Download video multiple times - button resets properly
- [x] Test both cached and new video processing scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)