### PR TITLE
fix: PyTorch 2.6+ compatibility and speaker diarization settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,26 @@ PLATFORMS=linux/amd64 ./scripts/docker-build-push.sh backend
 
 See [scripts/README.md](scripts/README.md) for detailed documentation.
 
+### Local Development Builds (No Docker Hub Push)
+
+When making code changes and testing locally without pushing to Docker Hub:
+
+```bash
+# Build backend image locally (always use --no-cache for code changes)
+cd ~/prj/src/OpenTranscribe
+docker build --no-cache -t davidamacey/opentranscribe-backend:latest -f backend/Dockerfile.prod backend/
+
+# Restart production with local image (use docker-compose.local.yml to prevent pulling)
+cd ~/prj/opentranscribe
+docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.local.yml up -d --force-recreate
+```
+
+**Important:**
+- `--no-cache` is required because Docker may cache the COPY layer even when files changed
+- `--force-recreate` ensures containers use the new image
+- `docker-compose.local.yml` sets `pull_policy: never` to prevent overwriting local images with Docker Hub versions
+- Never use `./opentranscribe.sh update` with local builds (it pulls from Docker Hub)
+
 ### Frontend Development
 ```bash
 # From frontend/ directory

--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -1,3 +1,18 @@
+# PyTorch 2.6+ compatibility fix - MUST be done BEFORE any ML library imports
+# Patch torch.load to default to weights_only=False for trusted HuggingFace models
+# This must be at the TOP of celery.py because Celery's include= imports task modules
+# which import pyannote/whisperx that cache torch.load at import time
+import torch
+_original_torch_load = torch.load
+
+def _patched_torch_load(*args, **kwargs):
+    # Handle both missing weights_only AND weights_only=None (which PyTorch 2.8 treats as True)
+    if kwargs.get("weights_only") is None:
+        kwargs["weights_only"] = False
+    return _original_torch_load(*args, **kwargs)
+
+torch.load = _patched_torch_load
+
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import task_postrun

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -96,6 +96,12 @@ class Settings(BaseSettings):
     PYANNOTE_MODEL: str = os.getenv("PYANNOTE_MODEL", "pyannote/speaker-diarization")
     HUGGINGFACE_TOKEN: Optional[str] = os.getenv("HUGGINGFACE_TOKEN", None)
 
+    # Speaker diarization settings
+    MIN_SPEAKERS: int = int(os.getenv("MIN_SPEAKERS", "1"))
+    MAX_SPEAKERS: int = int(os.getenv("MAX_SPEAKERS", "20"))
+    # NUM_SPEAKERS forces exact speaker count (overrides min/max if set)
+    NUM_SPEAKERS: Optional[int] = int(os.getenv("NUM_SPEAKERS")) if os.getenv("NUM_SPEAKERS") else None
+
     # LLM Configuration - Users configure through web UI, stored in database
     # These are system fallbacks for quick access when no user settings exist
     LLM_PROVIDER: str = os.getenv("LLM_PROVIDER", "")

--- a/backend/app/tasks/transcription/core.py
+++ b/backend/app/tasks/transcription/core.py
@@ -176,6 +176,9 @@ def transcribe_audio_task(self, file_uuid: str):
                     audio_file_path,
                     settings.HUGGINGFACE_TOKEN,
                     progress_callback=whisperx_progress_callback,
+                    min_speakers=settings.MIN_SPEAKERS,
+                    max_speakers=settings.MAX_SPEAKERS,
+                    num_speakers=settings.NUM_SPEAKERS,
                 )
 
                 # Check if transcription produced any valid content

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,27 @@
+# Local override to use locally-built images instead of pulling from Docker Hub
+# Use with: docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.local.yml up -d
+
+services:
+  backend:
+    pull_policy: never
+
+  celery-worker:
+    pull_policy: never
+
+  celery-download-worker:
+    pull_policy: never
+
+  celery-cpu-worker:
+    pull_policy: never
+
+  celery-nlp-worker:
+    pull_policy: never
+
+  celery-beat:
+    pull_policy: never
+
+  flower:
+    pull_policy: never
+
+  celery-worker-gpu-scaled:
+    pull_policy: never

--- a/frontend/scripts/download-fonts.js
+++ b/frontend/scripts/download-fonts.js
@@ -42,6 +42,11 @@ async function downloadPlyrIcons() {
     const plyrSvgPath = join(publicDir, 'plyr.svg');
     const plyrSvgUrl = 'https://cdn.plyr.io/3.7.8/plyr.svg';
 
+    // Create public directory if it doesn't exist
+    if (!existsSync(publicDir)) {
+      mkdirSync(publicDir, { recursive: true });
+    }
+
     console.log('Downloading Plyr icons...');
     const svgData = await downloadFile(plyrSvgUrl);
     writeFileSync(plyrSvgPath, svgData);

--- a/frontend/src/components/TranscriptDisplay.svelte
+++ b/frontend/src/components/TranscriptDisplay.svelte
@@ -951,6 +951,7 @@
   .transcript-display {
     max-height: 600px;
     overflow-y: auto;
+    overflow-x: hidden;
     position: relative;
   }
 
@@ -965,12 +966,14 @@
   .segment-row {
     display: flex;
     align-items: stretch;
+    min-width: 0; /* Allow flex container to shrink */
+    width: 100%;
   }
 
   .segment-content {
-    flex: 1;
+    flex: 1 1 0; /* Allow shrinking below content size */
     display: grid;
-    grid-template-columns: auto auto 1fr;
+    grid-template-columns: auto auto minmax(0, 1fr); /* minmax(0, 1fr) allows column to shrink */
     gap: 12px;
     align-items: center;
     padding: 8px 12px;
@@ -981,6 +984,9 @@
     transition: all 0.2s ease;
     border-radius: 4px;
     margin: 2px 4px;
+    min-width: 0; /* Allow grid to shrink */
+    max-width: 100%;
+    overflow: hidden;
   }
 
   .segment-content:hover {
@@ -1024,6 +1030,10 @@
     line-height: 1.4;
     position: relative;
     padding-left: 12px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    min-width: 0; /* Allow text to shrink in grid layout */
   }
 
   .segment-text::before {
@@ -1502,7 +1512,7 @@
 
   @media (max-width: 768px) {
     .segment-content {
-      grid-template-columns: auto auto 1fr;
+      grid-template-columns: auto auto minmax(0, 1fr);
       gap: 8px;
       padding: 8px;
     }


### PR DESCRIPTION
## Summary

- Add torch.load patch in celery.py for PyTorch 2.6+ weights_only=True change
- Must be at module top before any ML imports to catch cached torch.load refs
- Add MIN_SPEAKERS, MAX_SPEAKERS, NUM_SPEAKERS config settings
- NUM_SPEAKERS overrides min/max when set for exact speaker count control
- Pass speaker parameters through whisperx_service to diarization pipeline

## Test plan

- [ ] Verify transcription works with PyTorch 2.6+
- [ ] Test speaker diarization with custom min/max speaker settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)