### PR TITLE
fix(auth): Fix HuggingFace gated model auth for pyannote diarization

### DIFF
--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -16,7 +16,21 @@ def _patched_torch_load(*args, **kwargs):
 
 torch.load = _patched_torch_load
 
-# Imports must come after torch.load patch to prevent caching issues
+# WhisperX 3.7.0 passes deprecated use_auth_token to newer huggingface_hub
+# which no longer accepts it. Patch hf_hub_download to convert the parameter.
+import huggingface_hub
+from huggingface_hub import hf_hub_download as _original_hf_hub_download
+
+
+def _patched_hf_hub_download(*args, **kwargs):
+    if "use_auth_token" in kwargs:
+        kwargs["token"] = kwargs.pop("use_auth_token")
+    return _original_hf_hub_download(*args, **kwargs)
+
+
+huggingface_hub.hf_hub_download = _patched_hf_hub_download
+
+# Imports must come after patches to prevent caching issues
 from celery import Celery  # noqa: E402
 from celery.schedules import crontab  # noqa: E402
 from celery.signals import task_postrun  # noqa: E402
@@ -100,8 +114,22 @@ celery_app.conf.update(
 # Signal handlers for proper database connection management
 @worker_process_init.connect
 def init_worker_process(**kwargs):
-    """Initialize worker process - dispose of any existing connections."""
+    """Initialize worker process - dispose of any existing connections and set auth tokens."""
+    import os
+
     from app.db.base import engine
+
+    # Register HF token so pyannote/whisperx can access gated models
+    if settings.HUGGINGFACE_TOKEN:
+        os.environ["HF_TOKEN"] = settings.HUGGINGFACE_TOKEN
+        try:
+            from huggingface_hub import login
+
+            login(token=settings.HUGGINGFACE_TOKEN, add_to_git_credential=False)
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).warning(f"HuggingFace login failed: {e}")
 
     engine.dispose()
 

--- a/backend/app/tasks/transcription/whisperx_service.py
+++ b/backend/app/tasks/transcription/whisperx_service.py
@@ -327,6 +327,22 @@ class WhisperXService:
 
             return diarize_segments  # type: ignore[no-any-return]
 
+        except AttributeError as e:
+            # Pipeline.from_pretrained() returns None when gated model access is denied,
+            # causing .to(device) to raise "'NoneType' object has no attribute 'to'"
+            if "'NoneType'" in str(e) and "'to'" in str(e):
+                logger.error(f"Diarization model failed to load (gated access): {e}")
+                raise PermissionError(
+                    "Speaker diarization model failed to load. This typically means "
+                    "your HuggingFace token does not have access to the required gated models. "
+                    "To fix: 1) Verify HUGGINGFACE_TOKEN is set in your .env file. "
+                    "2) Accept BOTH model agreements: "
+                    "https://huggingface.co/pyannote/segmentation-3.0 and "
+                    "https://huggingface.co/pyannote/speaker-diarization-3.1 "
+                    "3) Restart the application containers."
+                ) from e
+            raise
+
         except Exception as e:
             error_msg = str(e)
 


### PR DESCRIPTION
## Summary
- Transcription failed with `'NoneType' object has no attribute 'to'` due to pyannote gated model access denial
- **hf_hub_download patch**: WhisperX 3.7.0 passes removed `use_auth_token` param to newer `huggingface_hub`. Translates to new `token` param.
- **huggingface_hub.login() on worker init**: Gated pyannote models need more than just `HF_TOKEN` env var — `login()` registers the token and accepts gated terms.
- **AttributeError detection**: When gated access fails, pyannote returns `None` instead of raising. The `.to(device)` call on `None` gives an unhelpful error. Now detected and replaced with a message telling the user how to fix their HF token setup.

## Test plan
- [ ] Upload an audio file and verify transcription completes with diarization
- [ ] Set an invalid HUGGINGFACE_TOKEN, restart worker, upload file — verify UI shows clear gated model instructions