### PR TITLE
fix: add --cpu flag for explicit CPU-only install and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to OpenTranscribe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **CPU-only install flag (`--cpu`)**: `setup-opentranscribe.sh`, `opentranscribe.sh`, and `opentr.sh` now accept a `--cpu` flag (and honor `OPENTRANSCRIBE_FORCE_CPU=1` for unattended installs) to explicitly opt out of the GPU compose overlay. Required on hosts where the NVIDIA Container Toolkit is detected by Docker but GPU passthrough is non-functional — e.g. WSL2 without a WSL-capable Windows NVIDIA driver, where auto-detection would otherwise enable the GPU overlay and cause celery-worker / celery-cpu-worker to fail at container start with `nvidia-container-cli: initialization error: WSL environment detected but no adapters were found`. The choice is persisted to `.env` as `FORCE_CPU_MODE=true`, so `./opentranscribe.sh start/restart/stop` continues to skip the GPU overlay without re-passing the flag. Default behaviour for GPU users is unchanged.
+
 ## [0.4.1] - 2026-04-14
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -257,6 +257,18 @@ Then follow the on-screen instructions. The setup script will:
 - **Automatically download and cache AI models (~2.9GB)** if token is provided
 - Set up the management script (`opentranscribe.sh`)
 
+**💻 CPU-only install:** If you don't have an NVIDIA GPU, or you're on WSL2 with the NVIDIA Container Toolkit installed but GPU passthrough disabled, pass `--cpu` to skip GPU detection and avoid the `nvidia-container-cli` adapter error at container start:
+
+```bash
+# Piped install
+curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/setup-opentranscribe.sh | bash -s -- --cpu
+
+# Unattended / CI equivalent
+OPENTRANSCRIBE_FORCE_CPU=1 curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/setup-opentranscribe.sh | bash
+```
+
+The CPU-only choice is persisted to `.env` as `FORCE_CPU_MODE=true` so subsequent `./opentranscribe.sh start`/`restart` calls continue to skip the GPU overlay automatically.
+
 **⚠️ IMPORTANT - HuggingFace Setup:**
 The script will prompt you for your HuggingFace token during setup. **BEFORE running the installer:**
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,6 +43,37 @@ curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/s
 curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/setup-opentranscribe.sh | bash
 ```
 
+## 🧮 CPU-Only Installation (Opt-Out of GPU)
+
+Auto-detection enables GPU acceleration whenever it finds a working NVIDIA
+setup. If you **know** you want to run on CPU only — either because you have
+no NVIDIA GPU, or because the NVIDIA Container Toolkit is installed but GPU
+passthrough is not functional (a common situation on WSL2 without a
+WSL-capable Windows driver) — pass `--cpu` to skip GPU detection entirely:
+
+```bash
+# Piped install: forward --cpu with `bash -s --`
+curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/setup-opentranscribe.sh | bash -s -- --cpu
+
+# Or via env var (useful in CI / unattended installs)
+OPENTRANSCRIBE_FORCE_CPU=1 curl -fsSL https://raw.githubusercontent.com/davidamacey/OpenTranscribe/master/setup-opentranscribe.sh | bash
+
+# Or after downloading the script
+./setup-opentranscribe.sh --cpu
+```
+
+When `--cpu` is active the installer:
+
+- Skips `nvidia-smi` and NVIDIA Container Toolkit probing.
+- Writes `FORCE_CPU_MODE=true`, `DETECTED_DEVICE=cpu`, and CPU-optimized
+  precision (`int8`) / batch-size defaults into `.env`.
+- Causes `opentranscribe.sh start` (and subsequent `restart`/`stop` calls) to
+  skip the `docker-compose.gpu.yml` / `docker-compose.blackwell.yml`
+  overlays. You do **not** need to re-pass `--cpu` on every run.
+
+To switch a CPU-only install back to GPU later, re-run the installer without
+`--cpu` (or set `FORCE_CPU_MODE=false` in `.env` and restart).
+
 ## 📋 Prerequisites
 
 **Required (automatically checked):**

--- a/opentr.sh
+++ b/opentr.sh
@@ -43,6 +43,7 @@ show_help() {
   echo "  --gpu-scale          - Enable multi-GPU worker scaling"
   echo "  --nas                - Use custom storage paths (NAS for media, NVMe for DB/search)"
   echo "  --lite               - Cloud-only ASR mode (no GPU required)"
+  echo "  --cpu                - CPU-only mode (local transcription, no GPU overlay)"
   echo "  --with-pki           - Enable PKI certificate authentication (PROD MODE ONLY - requires nginx)"
   echo "  --with-ldap-test     - Start LDAP test container (dev or prod)"
   echo "  --with-keycloak-test - Start Keycloak test container (dev or prod)"
@@ -92,6 +93,7 @@ show_help() {
   echo "  ./opentr.sh start dev --gpu-scale            # Dev with multi-GPU scaling"
   echo "  ./opentr.sh start dev --gpu-scale --nas      # Multi-GPU + NAS/NVMe storage"
   echo "  ./opentr.sh start dev --lite                 # Cloud-only ASR mode (no GPU)"
+  echo "  ./opentr.sh start dev --cpu                  # Local CPU-only (skip GPU overlay)"
   echo "  ./opentr.sh start dev --with-ldap-test       # Dev with LDAP test container"
   echo "  ./opentr.sh start dev --with-keycloak-test   # Dev with Keycloak test container"
   echo "  ./opentr.sh start prod                       # Production (pulls from Docker Hub)"
@@ -266,6 +268,7 @@ start_app() {
   WITH_LDAP_TEST_FLAG=""
   WITH_KEYCLOAK_TEST_FLAG=""
   LITE_FLAG=""
+  CPU_FLAG=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -287,6 +290,10 @@ start_app() {
         ;;
       --lite)
         LITE_FLAG="--lite"
+        shift
+        ;;
+      --cpu)
+        CPU_FLAG="--cpu"
         shift
         ;;
       --with-pki)
@@ -334,18 +341,26 @@ start_app() {
     echo "☁️  Lite mode enabled (cloud-only ASR, no GPU required)"
   fi
 
+  if [ -n "$CPU_FLAG" ]; then
+    echo "🧮 CPU-only mode enabled (local CPU transcription, no GPU overlay)"
+  fi
+
   # Ensure Docker is running
   check_docker
 
-  # Detect and configure hardware (skipped in lite mode — no GPU needed)
-  if [ -z "$LITE_FLAG" ]; then
-    detect_and_configure_hardware
-  else
-    echo "ℹ️  Skipping GPU detection (lite mode uses cloud ASR providers)"
+  # Detect and configure hardware (skipped in lite/cpu modes — no GPU needed)
+  if [ -n "$CPU_FLAG" ] || [ -n "$LITE_FLAG" ]; then
+    if [ -n "$CPU_FLAG" ]; then
+      echo "ℹ️  Skipping GPU detection (--cpu mode: local CPU transcription only)"
+    else
+      echo "ℹ️  Skipping GPU detection (lite mode uses cloud ASR providers)"
+    fi
     export DOCKER_RUNTIME=""
     export TORCH_DEVICE="cpu"
     export COMPUTE_TYPE="int8"
     export USE_GPU="false"
+  else
+    detect_and_configure_hardware
   fi
 
   # Set build environment
@@ -584,6 +599,7 @@ reset_and_init() {
   WITH_LDAP_TEST_FLAG=""
   WITH_KEYCLOAK_TEST_FLAG=""
   LITE_FLAG=""
+  CPU_FLAG=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -605,6 +621,10 @@ reset_and_init() {
         ;;
       --lite)
         LITE_FLAG="--lite"
+        shift
+        ;;
+      --cpu)
+        CPU_FLAG="--cpu"
         shift
         ;;
       --with-pki)
@@ -652,18 +672,26 @@ reset_and_init() {
     echo "☁️  Lite mode enabled (cloud-only ASR, no GPU required)"
   fi
 
+  if [ -n "$CPU_FLAG" ]; then
+    echo "🧮 CPU-only mode enabled (local CPU transcription, no GPU overlay)"
+  fi
+
   # Ensure Docker is running
   check_docker
 
-  # Detect and configure hardware (skipped in lite mode — no GPU needed)
-  if [ -z "$LITE_FLAG" ]; then
-    detect_and_configure_hardware
-  else
-    echo "ℹ️  Skipping GPU detection (lite mode uses cloud ASR providers)"
+  # Detect and configure hardware (skipped in lite/cpu modes — no GPU needed)
+  if [ -n "$CPU_FLAG" ] || [ -n "$LITE_FLAG" ]; then
+    if [ -n "$CPU_FLAG" ]; then
+      echo "ℹ️  Skipping GPU detection (--cpu mode: local CPU transcription only)"
+    else
+      echo "ℹ️  Skipping GPU detection (lite mode uses cloud ASR providers)"
+    fi
     export DOCKER_RUNTIME=""
     export TORCH_DEVICE="cpu"
     export COMPUTE_TYPE="int8"
     export USE_GPU="false"
+  else
+    detect_and_configure_hardware
   fi
 
   # Set build environment

--- a/opentranscribe.sh
+++ b/opentranscribe.sh
@@ -115,6 +115,29 @@ is_blackwell_gpu() {
     [[ "$compute_cap" == 12.* ]]
 }
 
+# force_cpu_mode_requested: returns success (0) when the user opted out of
+# GPU acceleration at install time (setup-opentranscribe.sh --cpu, or the
+# OPENTRANSCRIBE_FORCE_CPU env var), which persisted FORCE_CPU_MODE=true to
+# .env. When true, get_compose_files skips the GPU overlay(s) regardless of
+# whether Docker reports an nvidia runtime. This is the authoritative signal
+# because Docker's runtime presence is a necessary but not sufficient
+# condition for a working GPU (e.g. WSL2 with toolkit installed but no
+# adapter passthrough still advertises the runtime). Also honors
+# OPENTRANSCRIBE_FORCE_CPU set in the current shell for one-off overrides.
+force_cpu_mode_requested() {
+    if [ -n "${OPENTRANSCRIBE_FORCE_CPU:-}" ]; then
+        return 0
+    fi
+    if [ -f .env ]; then
+        local value
+        value=$(grep '^FORCE_CPU_MODE=' .env 2>/dev/null \
+            | cut -d'=' -f2 | tr -d ' "' | head -1)
+        [ "$value" = "true" ]
+        return
+    fi
+    return 1
+}
+
 get_compose_files() {
     local compose_files="-f docker-compose.yml"
 
@@ -123,10 +146,15 @@ get_compose_files() {
         compose_files="$compose_files -f docker-compose.prod.yml"
     fi
 
-    # Add GPU overlay if NVIDIA runtime is available and overlay exists
+    # Add GPU overlay if NVIDIA runtime is available and overlay exists,
+    # unless the user explicitly chose CPU-only mode at install time.
     local docker_runtime
     docker_runtime=$(detect_nvidia_runtime)
-    if [ "$docker_runtime" = "nvidia" ]; then
+    if force_cpu_mode_requested; then
+        if [ "$docker_runtime" = "nvidia" ]; then
+            echo -e "${BLUE}🧮 CPU-only mode (FORCE_CPU_MODE=true in .env) — skipping GPU overlay despite nvidia runtime being available${NC}" >&2
+        fi
+    elif [ "$docker_runtime" = "nvidia" ]; then
         if is_blackwell_gpu && [ -f docker-compose.blackwell.yml ]; then
             compose_files="$compose_files -f docker-compose.blackwell.yml"
             echo -e "${BLUE}Blackwell GPU overlay enabled (SM_12x detected)${NC}" >&2

--- a/setup-opentranscribe.sh
+++ b/setup-opentranscribe.sh
@@ -6,6 +6,15 @@
 #   OPENTRANSCRIBE_UNATTENDED  When non-empty, skip all interactive prompts and
 #                              use safe defaults or pre-set environment variables
 #                              (used by CI and release-test harnesses)
+#   OPENTRANSCRIBE_FORCE_CPU   When non-empty, skip NVIDIA/GPU detection entirely
+#                              and install in CPU-only mode. Equivalent to passing
+#                              --cpu on the command line. Useful on hosts with the
+#                              NVIDIA Container Toolkit installed but no working
+#                              GPU passthrough (e.g. WSL2 without a supported
+#                              Windows NVIDIA driver), where auto-detection would
+#                              otherwise enable a GPU overlay that fails at
+#                              container start with an nvidia-container-cli
+#                              adapter error.
 #
 # Env vars honored in unattended mode (all optional; any can be pre-set):
 #   PROJECT_DIR                Where to install (default: ./opentranscribe)
@@ -79,6 +88,16 @@ COMPUTE_TYPE=""
 BATCH_SIZE=""
 DOCKER_RUNTIME=""
 USE_GPU_RUNTIME="false"
+# FORCE_CPU: when "true", skip NVIDIA/GPU detection entirely and install in
+# CPU-only mode. Set via --cpu flag or OPENTRANSCRIBE_FORCE_CPU=1 env var.
+# This is a supported manual opt-out for hosts where GPU auto-detection
+# produces a false positive (e.g. WSL2 with toolkit installed but no working
+# adapter passthrough), or where the user simply wants to exclude GPU
+# workloads. Default (unset) preserves the original auto-detect behaviour.
+FORCE_CPU="false"
+if [[ -n "${OPENTRANSCRIBE_FORCE_CPU:-}" ]]; then
+    FORCE_CPU="true"
+fi
 
 #######################
 # HARDWARE DETECTION
@@ -114,6 +133,30 @@ detect_platform() {
 
 detect_hardware_acceleration() {
     DETECTED_DEVICE="cpu"  # Default fallback
+
+    # CPU-only mode requested explicitly (--cpu flag or OPENTRANSCRIBE_FORCE_CPU):
+    # skip all GPU probing so we don't touch nvidia-smi or docker's NVIDIA
+    # runtime. This also prevents a later false-positive overlay being layered
+    # in at runtime by opentranscribe.sh, because we write USE_GPU=false into
+    # .env below.
+    if [[ "$FORCE_CPU" == "true" ]]; then
+        echo "ℹ️  CPU-only mode requested (--cpu / OPENTRANSCRIBE_FORCE_CPU set)"
+        echo "    Skipping NVIDIA GPU detection."
+        DETECTED_DEVICE="cpu"
+        COMPUTE_TYPE="int8"
+        BATCH_SIZE="4"
+        USE_GPU_RUNTIME="false"
+
+        if command -v nproc &> /dev/null; then
+            CPU_CORES=$(nproc)
+        elif command -v sysctl &> /dev/null; then
+            CPU_CORES=$(sysctl -n hw.ncpu)
+        else
+            CPU_CORES=4
+        fi
+        echo "✓ Detected $CPU_CORES CPU cores"
+        return
+    fi
 
     # Check for NVIDIA GPU (CUDA)
     if command -v nvidia-smi &> /dev/null; then
@@ -1472,6 +1515,13 @@ create_env_file() {
     echo "# Hardware Configuration (Auto-detected)" >> .env
     echo "DETECTED_DEVICE=${DETECTED_DEVICE}" >> .env
     echo "USE_NVIDIA_RUNTIME=${USE_GPU_RUNTIME}" >> .env
+    # FORCE_CPU_MODE: persisted opt-out signal read by opentranscribe.sh at
+    # start/restart time. When "true", the management script skips the
+    # docker-compose.gpu.yml / docker-compose.blackwell.yml overlays even if
+    # Docker reports an nvidia runtime — ensuring the CPU-only choice made at
+    # install time survives subsequent start/stop/restart cycles without
+    # requiring the user to re-pass --cpu.
+    echo "FORCE_CPU_MODE=${FORCE_CPU}" >> .env
 
     # Note: Database schema is managed by Alembic migrations on backend startup
 
@@ -1944,7 +1994,11 @@ display_summary() {
     echo -e "${BLUE}📋 Configuration Summary${NC}"
     echo "┌─ Hardware:"
     echo "│  • Platform: $DETECTED_PLATFORM ($ARCH)"
-    echo "│  • Device: $DETECTED_DEVICE ($COMPUTE_TYPE precision)"
+    if [[ "$FORCE_CPU" == "true" ]]; then
+        echo "│  • Device: cpu ($COMPUTE_TYPE precision) — forced via --cpu / OPENTRANSCRIBE_FORCE_CPU"
+    else
+        echo "│  • Device: $DETECTED_DEVICE ($COMPUTE_TYPE precision)"
+    fi
     if [[ "$DETECTED_DEVICE" == "cuda" ]]; then
         if command -v nvidia-smi &> /dev/null; then
             GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits -i "${GPU_DEVICE_ID:-0}" 2>/dev/null || echo "Unknown")
@@ -2118,6 +2172,48 @@ prompt_start() {
 }
 
 main() {
+    # Parse command-line arguments. Currently the only supported flag is
+    # --cpu, which forces CPU-only mode and skips NVIDIA/GPU detection.
+    # Equivalent to setting OPENTRANSCRIBE_FORCE_CPU=1 in the environment.
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cpu)
+                FORCE_CPU="true"
+                shift
+                ;;
+            -h|--help)
+                echo "OpenTranscribe installer"
+                echo ""
+                echo "Usage: setup-opentranscribe.sh [--cpu]"
+                echo ""
+                echo "Options:"
+                echo "  --cpu       Install in CPU-only mode. Skips NVIDIA GPU"
+                echo "              detection and configures the stack to run"
+                echo "              without the GPU compose overlay. Use this on"
+                echo "              hosts that have the NVIDIA Container Toolkit"
+                echo "              installed but no working GPU passthrough"
+                echo "              (e.g. WSL2 without a WSL-capable driver), or"
+                echo "              on any machine where you simply do not want"
+                echo "              GPU acceleration."
+                echo "  -h, --help  Show this help message."
+                echo ""
+                echo "Environment variables (see script header for the full list):"
+                echo "  OPENTRANSCRIBE_FORCE_CPU  Non-empty = same as --cpu"
+                echo "  OPENTRANSCRIBE_UNATTENDED Non-empty = skip all prompts"
+                echo "  OPENTRANSCRIBE_BRANCH     Git branch for downloaded files"
+                exit 0
+                ;;
+            *)
+                echo -e "${YELLOW}⚠️  Unknown argument: $1 (ignored)${NC}"
+                shift
+                ;;
+        esac
+    done
+
+    if [[ "$FORCE_CPU" == "true" ]]; then
+        echo -e "${BLUE}ℹ️  CPU-only install mode selected${NC}"
+    fi
+
     # Auto-enable unattended mode when /dev/tty is unavailable (CI, Docker without -it, etc.)
     # The interactive read prompts all use </dev/tty; without it they would produce an
     # obscure error rather than a helpful message.
@@ -2146,4 +2242,4 @@ main() {
 }
 
 # Execute main function
-main
+main "$@"


### PR DESCRIPTION
## Description

On WSL2 systems with the NVIDIA Container Toolkit installed but no actual GPU (or no WSL-capable Windows driver), containers fail at startup with:

`
nvidia-container-cli: initialization error: WSL environment detected but no adapters were found
`

This adds an explicit `--cpu` opt-out flag that persists across start/stop/restart, while preserving auto-detection as the default for GPU users.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes made
- **setup-opentranscribe.sh**: New `--cpu` flag (and `OPENTRANSCRIBE_FORCE_CPU=1` env var for CI). Skips nvidia-smi/Container Toolkit probing and writes `FORCE_CPU_MODE=true` to `.env`.
- **opentranscribe.sh**: `get_compose_files()` now checks `FORCE_CPU_MODE` in `.env` before layering `docker-compose.gpu.yml` or `docker-compose.blackwell.yml`.
- **opentr.sh**: New `--cpu` flag parallel to `--lite` for dev workflows.
- **CHANGELOG.md, README.md, docs/INSTALLATION.md**: CPU-Only Installation section with examples.

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests for my changes
- [x] All existing tests pass
- [ ] I have tested with different audio/video formats (if applicable)

## Backend changes (if applicable)
- [ ] API endpoints are properly documented
- [ ] Database migrations are included (if needed)
- [x] Error handling is implemented
- [x] Logging is appropriate

## Documentation
- [x] I have updated the README if needed
- [x] I have updated relevant documentation
- [x] Code is properly commented

## Additional notes
GPU users see zero behavioral change - auto-detection remains the default. The `--cpu` flag is only needed when the NVIDIA Container Toolkit is installed but no usable GPU is present (common on WSL2 without proper driver passthrough).

Verified with `bash -n` and `shellcheck --severity=warning` (v0.9.0) on all three modified scripts; both clean.