### PR TITLE
chore(dependabot): reduce noise — monthly, grouped, ignore broken versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
 version: 2
-# Dependency updates are intentionally low-noise: monthly schedule, grouped into
-# a single PR per ecosystem (not one-per-package), with known-bad versions ignored.
-# To pause entirely, comment out the `updates:` entries below; to run on demand,
-# use the "Check for updates" button on the repo's Dependabot (Insights) tab.
+# Low-clutter dependency updates: weekly, but GROUPED so each ecosystem produces a
+# single batched PR (not one-per-package) — i.e. one frontend (npm) PR and one
+# backend (pip) PR per week, plus a grouped GitHub Actions PR. Known-bad versions
+# are ignored. To pause entirely, comment out the `updates:` entries below; to run
+# on demand, use the "Check for updates" button on the repo's Dependabot tab.
 updates:
+  # Frontend — one grouped PR
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      npm:
+      frontend:
         patterns:
           - "*"
     ignore:
@@ -23,31 +25,42 @@ updates:
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
 
+  # Backend — one grouped PR
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      pip:
+      backend:
         patterns:
           - "*"
 
+  # CI workflow actions — one grouped PR
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Dockerfile base images — infrequent, grouped per service
   - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
       interval: "monthly"
+    groups:
+      backend-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:
       interval: "monthly"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
     groups:
-      github-actions:
+      frontend-docker:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,37 @@
 version: 2
+# Dependency updates are intentionally low-noise: monthly schedule, grouped into
+# a single PR per ecosystem (not one-per-package), with known-bad versions ignored.
+# To pause entirely, comment out the `updates:` entries below; to run on demand,
+# use the "Check for updates" button on the repo's Dependabot (Insights) tab.
 updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns:
+          - "*"
+    ignore:
+      # svelte 5.56.x has a parser regression (declaration_tag_invalid_type on a
+      # plain ternary expression). Pinned to ~5.55.5 until upstream patches it.
+      - dependency-name: "svelte"
+        versions: ["5.56.x"]
+      # vite 8 requires @sveltejs/vite-plugin-svelte >=6; the current plugin (v5)
+      # peer-pins vite ^6. Hold the major until the Svelte plugin supports vite 8.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
+    groups:
+      pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/backend"
@@ -25,5 +46,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Switches Dependabot to **monthly + grouped** (one batched PR per ecosystem instead of one-per-package) and ignores known-bad versions:
- svelte 5.56.x (parser regression — pinned ~5.55.5)
- vite major bumps (vite 8 needs @sveltejs/vite-plugin-svelte >=6; current plugin peer-pins vite ^6)

Dependabot reads its config from the **default branch (master)**, so this must be merged to master to take effect. Config-only change.

This is the lever that stops the weekly per-package flood.