### PR TITLE
feat: open-core cloud seams — pluggable auth, org/usage schema (v367), capabilities/entitlements, pipeline hooks

### DIFF
--- a/backend/alembic/versions/v367_add_cloud_seams.py
+++ b/backend/alembic/versions/v367_add_cloud_seams.py
@@ -1,0 +1,158 @@
+"""Add cloud-edition seams: organizations, usage events, Clerk identity columns.
+
+Open-core seams for the commercial cloud edition (external auth + billing).
+Community/self-hosted deployments are unaffected: every column is nullable,
+every new table starts empty, and core only READS the billing columns — the
+private cloud layer writes them via its own webhooks. All DDL is idempotent
+(IF NOT EXISTS) so it is safe to re-run on partially-migrated DBs.
+
+Creates:
+  - organization            : tenant mirror (external org id) + billing/quota columns
+  - organization_membership : org membership mirror for fast joins
+  - usage_event             : billing + product-analytics event spine
+
+Alters:
+  - "user"      : clerk_id (unique partial index), clerk_org_id (last-seen org)
+  - media_file / collection / speaker / speaker_profile / speaker_collection /
+    summary_prompt / custom_vocabulary / user_setting : nullable organization_id
+
+Revision ID: v367_add_cloud_seams
+Revises: v366_add_watch_sources
+"""
+
+from alembic import op
+
+revision = "v367_add_cloud_seams"
+down_revision = "v366_add_watch_sources"
+branch_labels = None
+depends_on = None
+
+# Tables that gain a nullable organization_id scoping column. Pattern: every
+# user_id-scoped resource that should be shareable within a company/tenant.
+ORG_SCOPED_TABLES = (
+    "media_file",
+    "collection",
+    "speaker",
+    "speaker_profile",
+    "speaker_collection",
+    "summary_prompt",
+    "custom_vocabulary",
+    "user_setting",
+)
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS organization (
+            id SERIAL PRIMARY KEY,
+            uuid UUID NOT NULL,
+            clerk_org_id VARCHAR(255) NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            slug VARCHAR(255),
+            subscription_tier VARCHAR(20) NOT NULL DEFAULT 'community',
+            subscription_status VARCHAR(20) NOT NULL DEFAULT 'active',
+            stripe_customer_id VARCHAR(64),
+            stripe_subscription_id VARCHAR(64),
+            seats_limit INTEGER,
+            hours_limit_per_month NUMERIC(10,3),
+            hours_used_this_month NUMERIC(10,3) NOT NULL DEFAULT 0,
+            billing_cycle_anchor_day SMALLINT,
+            current_period_end TIMESTAMPTZ,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_organization_clerk_org_id "
+        "ON organization (clerk_org_id)"
+    )
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_organization_uuid ON organization (uuid)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_organization_stripe_customer_id "
+        "ON organization (stripe_customer_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS organization_membership (
+            id SERIAL PRIMARY KEY,
+            organization_id INTEGER NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+            role VARCHAR(20) NOT NULL DEFAULT 'org:member',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_org_membership UNIQUE (organization_id, user_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_org_membership_user_id ON organization_membership (user_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS usage_event (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id INTEGER REFERENCES "user"(id) ON DELETE SET NULL,
+            organization_id INTEGER REFERENCES organization(id) ON DELETE SET NULL,
+            event_type VARCHAR(50) NOT NULL,
+            quantity NUMERIC(12,3) NOT NULL DEFAULT 1,
+            unit VARCHAR(16),
+            file_id INTEGER REFERENCES media_file(id) ON DELETE SET NULL,
+            idempotency_key VARCHAR(128),
+            event_metadata JSONB,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    # Partial unique index: idempotency is enforced only when a key is supplied
+    # (Celery retries / webhook replays), free-form events can omit it.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_usage_event_idempotency_key "
+        "ON usage_event (idempotency_key) WHERE idempotency_key IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_usage_event_org_type_time "
+        "ON usage_event (organization_id, event_type, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_usage_event_user_time ON usage_event (user_id, created_at)"
+    )
+
+    # Allow the new external auth type in the user.auth_type CHECK constraint.
+    op.execute('ALTER TABLE "user" DROP CONSTRAINT IF EXISTS users_auth_type_check')
+    op.execute(
+        'ALTER TABLE "user" ADD CONSTRAINT users_auth_type_check '
+        "CHECK (auth_type IN ('local', 'ldap', 'keycloak', 'pki', 'clerk'))"
+    )
+
+    # External-IdP identity columns on user (mirrors keycloak_id pattern).
+    op.execute('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS clerk_id VARCHAR(255)')
+    op.execute('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS clerk_org_id VARCHAR(255)')
+    op.execute(
+        'CREATE UNIQUE INDEX IF NOT EXISTS uq_user_clerk_id ON "user" (clerk_id) '
+        "WHERE clerk_id IS NOT NULL"
+    )
+
+    # Nullable org-scoping column on every shareable resource (NULL = personal).
+    for table in ORG_SCOPED_TABLES:
+        op.execute(
+            f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS "
+            f"organization_id INTEGER REFERENCES organization(id)"
+        )
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_organization_id ON {table} (organization_id)"
+        )
+
+
+def downgrade():
+    for table in ORG_SCOPED_TABLES:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS organization_id")
+    op.execute("DROP INDEX IF EXISTS uq_user_clerk_id")
+    op.execute('ALTER TABLE "user" DROP COLUMN IF EXISTS clerk_org_id')
+    op.execute('ALTER TABLE "user" DROP COLUMN IF EXISTS clerk_id')
+    op.execute("DROP TABLE IF EXISTS usage_event")
+    op.execute("DROP TABLE IF EXISTS organization_membership")
+    op.execute("DROP TABLE IF EXISTS organization")

--- a/backend/app/api/deps_context.py
+++ b/backend/app/api/deps_context.py
@@ -1,0 +1,105 @@
+"""Request context with tenant (organization) scope — cloud-edition seam.
+
+``get_current_context`` wraps ``get_current_user`` and resolves the active
+organization for this request:
+  - community / personal: no org -> personal scope (user_id filtering)
+  - cloud: the external verifier stashed the verified identity (with the
+    provider org id) on ``request.state``; we map it to our Organization row
+    and authorize against the **membership mirror**, never the token alone,
+    so a removed member loses access before their token expires.
+
+``scope_to_context`` is the default-deny query helper every org-aware
+endpoint uses: org context -> filter by organization_id, else by user_id.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+from typing import Optional
+
+from fastapi import Depends
+from fastapi import Request
+from sqlalchemy.orm import Query
+from sqlalchemy.orm import Session
+
+from app.api.endpoints.auth import get_current_user
+from app.db.base import get_db
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Authenticated user + active tenant scope for this request."""
+
+    user: User
+    org_id: Optional[int] = None  # our organization.id (NOT the provider's string id)
+    org_role: Optional[str] = None  # "org:admin" | "org:member" | None
+
+    @property
+    def is_org_context(self) -> bool:
+        return self.org_id is not None
+
+    @property
+    def is_org_admin(self) -> bool:
+        return self.org_role == "org:admin"
+
+
+def get_current_context(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RequestContext:
+    """Resolve the request's tenant context (personal when no org applies)."""
+    identity = getattr(request.state, "external_identity", None)
+    if identity is None or not getattr(identity, "org_id", None):
+        return RequestContext(user=current_user)
+
+    from app.models.organization import Organization
+    from app.models.organization import OrganizationMembership
+
+    org = (
+        db.query(Organization)
+        .filter(Organization.clerk_org_id == identity.org_id, Organization.is_active.is_(True))
+        .first()
+    )
+    if org is None:
+        # Org not mirrored (webhook lag) — fall back to personal scope rather
+        # than failing the request; the next webhook/login sync repairs it.
+        logger.warning(f"Unknown org in token: {identity.org_id} (falling back to personal)")
+        return RequestContext(user=current_user)
+
+    membership = (
+        db.query(OrganizationMembership)
+        .filter(
+            OrganizationMembership.organization_id == org.id,
+            OrganizationMembership.user_id == current_user.id,
+        )
+        .first()
+    )
+    if membership is None:
+        # Token claims an org the mirror doesn't confirm (e.g. member just
+        # removed). Authorization follows the mirror: personal scope only.
+        logger.warning(
+            f"User {current_user.id} carries org {identity.org_id} in token "
+            "but has no membership row — personal scope applied"
+        )
+        return RequestContext(user=current_user)
+
+    return RequestContext(user=current_user, org_id=org.id, org_role=membership.role)
+
+
+def scope_to_context(query: Query, model: Any, ctx: RequestContext) -> Query:
+    """Default-deny tenancy filter: org scope when active, else personal.
+
+    Personal scope = the user's PERSONAL rows (``organization_id IS NULL``):
+    a file uploaded into an org belongs to the org space, not the uploader's
+    personal space. In the community edition ``organization_id`` is always
+    NULL, so this is behavior-identical to plain user_id filtering there.
+
+    ``model`` must expose ``organization_id`` and ``user_id`` columns.
+    """
+    if ctx.is_org_context:
+        return query.filter(model.organization_id == ctx.org_id)
+    return query.filter(model.user_id == ctx.user.id, model.organization_id.is_(None))

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -123,6 +123,24 @@ def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # Cloud-edition seam: offer the token to registered external verifiers
+    # (e.g. Clerk) before the local-JWT path. The community edition registers
+    # none, so this branch is a no-op there.
+    from app.auth.provider_registry import has_verifiers
+
+    if has_verifiers():
+        from app.auth.external_sync import sync_external_user_to_db
+        from app.auth.provider_registry import verify_external_token
+
+        external_identity = verify_external_token(token, request)
+        if external_identity is not None:
+            external_user = sync_external_user_to_db(db, external_identity)
+            if not external_user.is_active:
+                raise HTTPException(status_code=400, detail="Inactive user")
+            # Stash for get_current_context() so org scoping doesn't re-verify.
+            request.state.external_identity = external_identity
+            return external_user
+
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -1521,11 +1539,20 @@ async def get_auth_methods(db: Session = Depends(get_db)):
     if pki_enabled:
         methods.append("pki")
 
+    # Registry-based external providers (cloud edition registers e.g. "clerk";
+    # community registers none). Presence in the registry == enabled.
+    from app.auth.provider_registry import get_registered_providers
+
+    external_providers = get_registered_providers()
+    methods.extend(p for p in external_providers if p not in methods)
+
     return {
         "methods": methods,
         "keycloak_enabled": keycloak_enabled,
         "pki_enabled": pki_enabled,
         "ldap_enabled": ldap_enabled,
+        "external_providers": external_providers,
+        "clerk_enabled": "clerk" in external_providers,
         "mfa_enabled": mfa_enabled,
         "mfa_required": mfa_required,
         "login_banner_enabled": login_banner_enabled,

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -38,10 +38,17 @@ async def get_system_capabilities(request: Request) -> dict[str, Any]:
     edition returns everything-on defaults; the cloud edition's resolver
     computes edition ∩ subscription tier.
     """
+    from app.core.capabilities import CAPABILITY_AUDIENCE
     from app.core.capabilities import edition
     from app.core.capabilities import get_capabilities
 
-    return {"edition": edition(), "capabilities": get_capabilities(request)}
+    return {
+        "edition": edition(),
+        "capabilities": get_capabilities(request),
+        # WHO each surface is for (user|team|org_admin|platform) — drives
+        # which UI area renders it; roles below the audience see nothing.
+        "audience": CAPABILITY_AUDIENCE,
+    }
 
 
 def _device_mode_info(gpu_stats: list[dict[str, Any]]) -> dict[str, Any]:

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi import status
 from sqlalchemy.orm import Session
 
@@ -25,6 +26,22 @@ from app.services.protected_media_providers import get_protected_media_auth_conf
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/capabilities")
+async def get_system_capabilities(request: Request) -> dict[str, Any]:
+    """Edition + capability map driving server-side feature gating.
+
+    The frontend calls this once at bootstrap and renders only the surfaces
+    listed as enabled; gated endpoints independently 404 when off (the
+    backend gate is the authority — see app.core.capabilities). Community
+    edition returns everything-on defaults; the cloud edition's resolver
+    computes edition ∩ subscription tier.
+    """
+    from app.core.capabilities import edition
+    from app.core.capabilities import get_capabilities
+
+    return {"edition": edition(), "capabilities": get_capabilities(request)}
 
 
 def _device_mode_info(gpu_stats: list[dict[str, Any]]) -> dict[str, Any]:

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -43,7 +43,7 @@ api_router = APIRouter()
 
 
 # Function to include routers with proper route handling for consistent frontend-backend communication
-def include_router_with_consistency(router, prefix, tags=None):
+def include_router_with_consistency(router, prefix, tags=None, capability=None):
     """Include a router with consistent route handling that works both with and without trailing slashes
 
     This ensures consistent API behavior regardless of whether the frontend sends requests
@@ -53,6 +53,10 @@ def include_router_with_consistency(router, prefix, tags=None):
         router: The router to include
         prefix: The prefix for the router (e.g., '/users')
         tags: Tags for the router for API documentation
+        capability: Optional capability key gating the whole router — routes
+            return 404 when the deployment's capability resolver disables it
+            (community default: everything enabled, so no behavior change;
+            platform staff bypass applies). See app.core.capabilities.
     """
     if tags is None:
         tags = [prefix.strip("/")]  # Default tag based on prefix
@@ -60,8 +64,18 @@ def include_router_with_consistency(router, prefix, tags=None):
     # Ensure prefix starts with / but doesn't end with one
     normalized_prefix = "/" + prefix.strip("/")
 
+    dependencies = None
+    if capability is not None:
+        from fastapi import Depends
+
+        from app.core.capabilities import require_capability
+
+        dependencies = [Depends(require_capability(capability))]
+
     # Include the router with the normalized prefix
-    api_router.include_router(router, prefix=normalized_prefix, tags=tags)
+    api_router.include_router(
+        router, prefix=normalized_prefix, tags=tags, dependencies=dependencies
+    )
 
 
 # Include routers from different endpoints with consistent path handling
@@ -80,13 +94,19 @@ include_router_with_consistency(comments.router, prefix="/comments", tags=["comm
 include_router_with_consistency(tags.router, prefix="/tags", tags=["tags"])
 include_router_with_consistency(users.router, prefix="/users", tags=["users"])
 include_router_with_consistency(
-    watch_sources.router, prefix="/watch-sources", tags=["watch-sources"]
+    watch_sources.router,
+    prefix="/watch-sources",
+    tags=["watch-sources"],
+    capability="watch_sources",
 )
 include_router_with_consistency(tasks.router, prefix="/tasks", tags=["tasks"])
 include_router_with_consistency(admin.router, prefix="/admin", tags=["admin"])
 include_router_with_consistency(admin_timing.router, prefix="/admin", tags=["admin-timing"])
 include_router_with_consistency(
-    auth_config.router, prefix="/admin/auth-config", tags=["auth-config"]
+    auth_config.router,
+    prefix="/admin/auth-config",
+    tags=["auth-config"],
+    capability="auth.config_ui",
 )
 include_router_with_consistency(system.router, prefix="/system", tags=["system"])
 include_router_with_consistency(
@@ -96,11 +116,24 @@ include_router_with_consistency(groups.router, prefix="/groups", tags=["groups"]
 include_router_with_consistency(user_files.router, prefix="/my-files", tags=["user-files"])
 include_router_with_consistency(summarization.router, prefix="/files", tags=["summarization"])
 include_router_with_consistency(prompts.router, prefix="/prompts", tags=["prompts"])
-include_router_with_consistency(llm_settings.router, prefix="/llm-settings", tags=["llm-settings"])
-include_router_with_consistency(llm_status.router, prefix="/llm", tags=["llm-status"])
-include_router_with_consistency(asr_settings.router, prefix="/asr-settings", tags=["asr-settings"])
 include_router_with_consistency(
-    engine_settings.router, prefix="/admin/engine-settings", tags=["admin"]
+    llm_settings.router,
+    prefix="/llm-settings",
+    tags=["llm-settings"],
+    capability="llm.user_settings",
+)
+include_router_with_consistency(llm_status.router, prefix="/llm", tags=["llm-status"])
+include_router_with_consistency(
+    asr_settings.router,
+    prefix="/asr-settings",
+    tags=["asr-settings"],
+    capability="asr.user_providers",
+)
+include_router_with_consistency(
+    engine_settings.router,
+    prefix="/admin/engine-settings",
+    tags=["admin"],
+    capability="engine.settings",
 )
 include_router_with_consistency(
     custom_vocabulary.router, prefix="/custom-vocabulary", tags=["custom-vocabulary"]

--- a/backend/app/auth/constants.py
+++ b/backend/app/auth/constants.py
@@ -10,9 +10,24 @@ AUTH_TYPE_LOCAL = "local"
 AUTH_TYPE_LDAP = "ldap"
 AUTH_TYPE_KEYCLOAK = "keycloak"
 AUTH_TYPE_PKI = "pki"
+# External managed-IdP provider used by the commercial cloud edition. Core only
+# defines the constant + seams; the verifier implementation lives in the
+# private cloud layer and registers itself via app.auth.provider_registry.
+AUTH_TYPE_CLERK = "clerk"
 
 # All valid auth types
-VALID_AUTH_TYPES = [AUTH_TYPE_LOCAL, AUTH_TYPE_LDAP, AUTH_TYPE_KEYCLOAK, AUTH_TYPE_PKI]
+VALID_AUTH_TYPES = [
+    AUTH_TYPE_LOCAL,
+    AUTH_TYPE_LDAP,
+    AUTH_TYPE_KEYCLOAK,
+    AUTH_TYPE_PKI,
+    AUTH_TYPE_CLERK,
+]
+
+# Version of the cloud-extension seam surface (verifier registry, pipeline
+# hooks, capability resolver, ExternalIdentity shape). Bump on ANY signature
+# change so the private cloud repo fails loudly instead of drifting silently.
+CLOUD_SEAM_VERSION = 1
 
 # Auth types that support local password fallback (have local password capability)
 AUTH_TYPES_SUPPORT_LOCAL_FALLBACK = [AUTH_TYPE_PKI, AUTH_TYPE_KEYCLOAK]

--- a/backend/app/auth/external_sync.py
+++ b/backend/app/auth/external_sync.py
@@ -1,0 +1,122 @@
+"""Generic JIT user provisioning for registry-based external providers.
+
+Mirrors the battle-tested ``sync_keycloak_user_to_db`` pattern (lookup by
+external id -> email -> create, with IntegrityError race recovery) but is
+provider-agnostic so new managed IdPs (Clerk today) need no core changes
+beyond a column mapping entry.
+
+LDAP/Keycloak/PKI keep their existing dedicated sync paths — this module only
+serves providers registered through ``app.auth.provider_registry``.
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.auth.constants import EXTERNAL_AUTH_NO_PASSWORD
+from app.auth.provider_registry import ExternalIdentity
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+# provider -> (User column holding the external subject id,
+#              optional User column holding the last-seen org id)
+PROVIDER_ID_COLUMNS: dict[str, tuple[str, Optional[str]]] = {
+    "clerk": ("clerk_id", "clerk_org_id"),
+}
+
+
+def _apply_identity(user: User, identity: ExternalIdentity, id_col: str, org_col: Optional[str]):
+    """Stamp provider identity + profile fields onto a user row."""
+    setattr(user, id_col, identity.external_id)
+    if org_col is not None and identity.org_id is not None:
+        # Convenience/last-seen only — authorization always re-derives org
+        # context from the verified token + membership mirror, never this.
+        setattr(user, org_col, identity.org_id)
+    if identity.full_name:
+        user.full_name = identity.full_name
+    user.auth_type = identity.provider
+    # PLATFORM admin only — customer org roles (org:admin) intentionally do
+    # NOT map here; org-admin is a tenant capability, not a platform role.
+    if identity.is_admin and user.role != "admin":
+        logger.info(f"Promoting external user {identity.external_id} to platform admin")
+        user.role = "admin"
+        user.is_superuser = True
+
+
+def sync_external_user_to_db(db: Session, identity: ExternalIdentity) -> User:
+    """Create or update a user from a verified external identity (JIT).
+
+    Lookup order: external id -> email -> create. Concurrent first-requests
+    are race-safe via IntegrityError recovery on the unique external-id
+    column. Existing local users matched by email are converted one-way to
+    the external provider (local password cleared), mirroring the Keycloak
+    conversion semantics.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    try:
+        id_col, org_col = PROVIDER_ID_COLUMNS[identity.provider]
+    except KeyError:
+        raise ValueError(
+            f"No User column mapping for external provider '{identity.provider}'"
+        ) from None
+
+    email = identity.email or f"{identity.external_id}@{identity.provider}.local"
+
+    user = db.query(User).filter(getattr(User, id_col) == identity.external_id).first()
+    if not user and identity.email:
+        user = db.query(User).filter(User.email == identity.email).first()
+
+    if user:
+        if user.auth_type == "local":
+            logger.warning(
+                f"SECURITY: Converting local user {user.email} to {identity.provider} auth. "
+                "Local password will be cleared."
+            )
+            user.hashed_password = EXTERNAL_AUTH_NO_PASSWORD
+        if identity.email and identity.email != user.email:
+            logger.warning(
+                f"SECURITY: User email changed during {identity.provider} login. "
+                f"external_id={identity.external_id}, "
+                f"old_email={user.email}, new_email={identity.email}"
+            )
+            user.email = identity.email
+        _apply_identity(user, identity, id_col, org_col)
+        db.commit()
+        db.refresh(user)
+        return user  # type: ignore[no-any-return]
+
+    logger.info(f"Creating new user from {identity.provider}: {identity.external_id} ({email})")
+    user = User(
+        email=email,
+        full_name=identity.full_name or email.split("@")[0],
+        hashed_password=EXTERNAL_AUTH_NO_PASSWORD,
+        auth_type=identity.provider,
+        role="admin" if identity.is_admin else "user",
+        is_superuser=identity.is_admin,
+        is_active=True,
+    )
+    setattr(user, id_col, identity.external_id)
+    if org_col is not None and identity.org_id is not None:
+        setattr(user, org_col, identity.org_id)
+    db.add(user)
+    try:
+        db.commit()
+        db.refresh(user)
+        return user
+    except IntegrityError:
+        # Concurrent first-request created the row — fetch and reuse it.
+        db.rollback()
+        logger.info(
+            f"User {identity.external_id} was created by a concurrent request, fetching existing"
+        )
+        user = db.query(User).filter(getattr(User, id_col) == identity.external_id).first()
+        if not user:
+            user = db.query(User).filter(User.email == email).first()
+        if not user:
+            raise ValueError(
+                f"Failed to create or find {identity.provider} user: {identity.external_id}"
+            ) from None
+        return user  # type: ignore[no-any-return]

--- a/backend/app/auth/provider_registry.py
+++ b/backend/app/auth/provider_registry.py
@@ -1,0 +1,99 @@
+"""Pluggable external token-verifier registry (cloud-edition seam).
+
+The community edition registers nothing here: the registry stays empty and
+``get_current_user`` takes its normal local-JWT path with zero overhead. The
+commercial cloud edition registers a verifier (e.g. Clerk) at startup;
+``get_current_user`` then offers each bearer token to the registered verifiers
+before falling back to local JWT validation.
+
+Contract (covered by ``CLOUD_SEAM_VERSION`` in app.auth.constants):
+  - Verifiers MUST be fast and networkless on the hot path (local signature
+    verification against a cached key) — they run on every request.
+  - ``verify`` returns ``None`` for "not my token / invalid" so the next
+    verifier (or the local path) gets a chance. It must not raise for
+    ordinary non-matching tokens.
+  - A crashing verifier is contained: errors are logged and treated as None,
+    so a broken cloud layer can never take down local authentication.
+"""
+
+import logging
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Optional
+from typing import Protocol
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExternalIdentity:
+    """Verified identity extracted from an external provider's token.
+
+    ``org_id``/``org_role`` carry tenant context (e.g. Clerk's nested ``o``
+    claim). ``is_admin`` means PLATFORM admin and should stay False for
+    customer org roles — org-admin is a per-tenant capability, not a platform
+    role (privilege separation).
+    """
+
+    provider: str
+    external_id: str
+    email: str
+    full_name: Optional[str] = None
+    org_id: Optional[str] = None
+    org_role: Optional[str] = None
+    is_admin: bool = False
+    raw_claims: dict[str, Any] = field(default_factory=dict)
+
+
+class TokenVerifier(Protocol):
+    """Protocol for external token verifiers (implemented by the cloud layer)."""
+
+    def verify(self, token: str, request: Request) -> Optional[ExternalIdentity]:
+        """Return the verified identity, or None if this token isn't ours/valid."""
+        ...
+
+
+_verifiers: dict[str, TokenVerifier] = {}
+
+
+def register_verifier(auth_type: str, verifier: TokenVerifier) -> None:
+    """Register an external token verifier for an auth type (idempotent)."""
+    if auth_type in _verifiers:
+        logger.warning(f"Replacing already-registered token verifier for '{auth_type}'")
+    _verifiers[auth_type] = verifier
+    logger.info(f"Registered external token verifier: {auth_type}")
+
+
+def unregister_verifier(auth_type: str) -> None:
+    """Remove a registered verifier (primarily for tests)."""
+    _verifiers.pop(auth_type, None)
+
+
+def has_verifiers() -> bool:
+    """True when any external verifier is registered (cloud edition)."""
+    return bool(_verifiers)
+
+
+def get_registered_providers() -> list[str]:
+    """Auth types with a registered external verifier (for /auth/methods)."""
+    return sorted(_verifiers)
+
+
+def verify_external_token(token: str, request: Request) -> Optional[ExternalIdentity]:
+    """Offer a bearer token to every registered verifier, first match wins.
+
+    Exceptions are contained per-verifier so external-auth problems can never
+    break local authentication.
+    """
+    for auth_type, verifier in _verifiers.items():
+        try:
+            identity = verifier.verify(token, request)
+        except Exception:
+            logger.exception(f"External token verifier '{auth_type}' raised; treating as no-match")
+            continue
+        if identity is not None:
+            return identity
+    return None

--- a/backend/app/core/capabilities.py
+++ b/backend/app/core/capabilities.py
@@ -28,25 +28,87 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+# ---- Audience taxonomy -------------------------------------------------------
+# WHO a surface is for when it is enabled. Orthogonal to enabled-ness: the
+# capability map says whether the surface EXISTS in this deployment; the
+# audience says which role's UI/permissions it belongs to. End users are
+# never admins; org admins manage their tenant only (billing, members,
+# policies) and are NEVER platform admins; "platform" = Attevon staff in
+# cloud / the operator in self-host.
+AUDIENCE_USER = "user"  # individual end users (their own content/prefs)
+AUDIENCE_TEAM = "team"  # inner-team collaboration among org/group members
+AUDIENCE_ORG_ADMIN = "org_admin"  # tenant administrators (billing, seats, policies)
+AUDIENCE_PLATFORM = "platform"  # platform staff / self-host operator (config & ops)
+
 # Known capability keys with their COMMUNITY defaults (everything on except
 # the cloud-only surfaces, which don't exist without the cloud layer).
 COMMUNITY_CAPABILITIES: dict[str, bool] = {
-    # Feature surfaces that exist today
-    "watch_sources": True,  # local/S3/SMB auto-import (Settings → Watch Sources)
-    "asr.user_providers": True,  # per-user cloud-ASR provider configs + keys
-    "asr.model_selection": True,  # admin local-model pinning UI
-    "engine.settings": True,  # diarization/boundary tuning admin panel
-    "llm.user_settings": True,  # per-user LLM provider/endpoint/keys
-    "auth.config_ui": True,  # LDAP/Keycloak/PKI admin configuration UI
-    "users.local_admin": True,  # local user CRUD admin UI
-    "system.hardware_stats": True,  # GPU/CPU stats, benchmarks
-    "url_ingest": True,  # yt-dlp URL ingestion
+    # -- user-facing ------------------------------------------------------------
+    "upload": True,  # file upload + presigned flow
     "recording": True,  # in-browser recording
-    # Cloud-only surfaces (no implementation in core — the cloud layer
-    # flips these on and mounts the corresponding routers/UI)
+    "url_ingest": True,  # yt-dlp URL ingestion
+    "search": True,  # hybrid/semantic search
+    "exports": True,  # SRT/VTT/TXT/bulk exports
+    "comments": True,  # per-transcript comments
+    "transcription.prefs": True,  # language/translate/speaker prefs
+    "vocab.user": True,  # custom vocabulary (own terms)
+    "prompts.user": True,  # own summary prompts
+    "redaction.user": True,  # personal redaction preferences
+    "asr.user_providers": True,  # per-user cloud-ASR provider configs + keys
+    "llm.user_settings": True,  # per-user LLM provider/endpoint/keys
+    "watch_sources": True,  # local/S3/SMB auto-import (Settings → Watch Sources)
+    # -- team-facing (inner-team collaboration) ----------------------------------
+    "sharing.teams": True,  # groups + collection shares
+    "collections.shared": True,  # shared/org-visible collections
+    "speakers.shared": True,  # shared speaker profiles
+    "prompts.shared": True,  # shared prompt library
+    # -- org-admin (tenant administration; cloud-only surfaces) ------------------
     "billing": False,
     "usage_dashboard": False,
-    "organizations": False,
+    "organizations": False,  # member/seat management surface
+    "org.defaults": False,  # org-level default settings/policies
+    "redaction.policy": True,  # enforcement floor (org admin in cloud; operator here)
+    # -- platform (staff / self-host operator config & ops) ----------------------
+    "auth.config_ui": True,  # LDAP/Keycloak/PKI admin configuration UI
+    "users.local_admin": True,  # local user CRUD admin UI
+    "asr.model_selection": True,  # admin local-model pinning UI
+    "engine.settings": True,  # diarization/boundary tuning admin panel
+    "system.hardware_stats": True,  # GPU/CPU stats, benchmarks
+}
+
+# Every capability key MUST be classified (tested). The frontend uses this to
+# place surfaces in the right area (user settings / team / org admin /
+# platform admin) — and to render nothing at all for roles below the audience.
+CAPABILITY_AUDIENCE: dict[str, str] = {
+    "upload": AUDIENCE_USER,
+    "recording": AUDIENCE_USER,
+    "url_ingest": AUDIENCE_USER,
+    "search": AUDIENCE_USER,
+    "exports": AUDIENCE_USER,
+    "comments": AUDIENCE_USER,
+    "transcription.prefs": AUDIENCE_USER,
+    "vocab.user": AUDIENCE_USER,
+    "prompts.user": AUDIENCE_USER,
+    "redaction.user": AUDIENCE_USER,
+    "asr.user_providers": AUDIENCE_USER,
+    "llm.user_settings": AUDIENCE_USER,
+    "watch_sources": AUDIENCE_USER,
+    "sharing.teams": AUDIENCE_TEAM,
+    "collections.shared": AUDIENCE_TEAM,
+    "speakers.shared": AUDIENCE_TEAM,
+    "prompts.shared": AUDIENCE_TEAM,
+    "billing": AUDIENCE_ORG_ADMIN,
+    "usage_dashboard": AUDIENCE_ORG_ADMIN,
+    "organizations": AUDIENCE_ORG_ADMIN,
+    "org.defaults": AUDIENCE_ORG_ADMIN,
+    "redaction.policy": AUDIENCE_ORG_ADMIN,
+    "auth.config_ui": AUDIENCE_PLATFORM,
+    "users.local_admin": AUDIENCE_PLATFORM,
+    "asr.model_selection": AUDIENCE_PLATFORM,
+    "engine.settings": AUDIENCE_PLATFORM,
+    "system.hardware_stats": AUDIENCE_PLATFORM,
+    # Cloud-only tier-gated extras (resolver-added)
+    "llm.byok": AUDIENCE_ORG_ADMIN,
 }
 
 # Resolver signature: (request | None) -> capability dict. The request is
@@ -93,16 +155,38 @@ def capability_enabled(key: str, request: Optional[Request] = None) -> bool:
     return bool(get_capabilities(request).get(key, False))
 
 
-def require_capability(key: str) -> Callable:
+def require_capability(key: str, *, platform_admin_bypass: bool = True) -> Callable:
     """FastAPI dependency factory: 404 when the capability is off.
 
     404 (not 403) on purpose — a disabled feature surface should not exist
     at all for this deployment, exactly like an unknown route.
+
+    ``platform_admin_bypass`` (default on) lets platform staff
+    (``is_superuser``) through even when the capability is hidden from
+    tenants — cloud tenants can never become superusers (external_sync never
+    grants it), so this exactly implements the capabilities matrix's
+    "invisible to org users / available to platform staff" column.
     """
 
     def _dependency(request: Request) -> None:
-        if not capability_enabled(key, request):
-            raise HTTPException(status_code=404, detail="Not Found")
+        if capability_enabled(key, request):
+            return
+        if platform_admin_bypass:
+            try:
+                from app.api.endpoints.auth import get_optional_current_user
+                from app.db.base import SessionLocal
+
+                db = SessionLocal()
+                try:
+                    user = get_optional_current_user(request, db)
+                    if user is not None and bool(user.is_superuser):
+                        return
+                finally:
+                    db.close()
+            except Exception:
+                # Bypass is best-effort; any failure falls through to 404.
+                logger.debug("platform-admin bypass check failed", exc_info=True)
+        raise HTTPException(status_code=404, detail="Not Found")
 
     return _dependency
 

--- a/backend/app/core/capabilities.py
+++ b/backend/app/core/capabilities.py
@@ -1,0 +1,112 @@
+"""Edition capabilities / entitlements (cloud-edition seam).
+
+Server-driven feature gating: the backend decides which feature surfaces
+exist; the frontend renders only what `GET /system/capabilities` returns, and
+gated endpoints 404 when a capability is off — UI hiding is cosmetic, the
+backend gate is the authority.
+
+Community/self-hosted default: **everything ON** (zero behavior change).
+The commercial cloud edition replaces the resolver via
+``set_capability_resolver`` to compute ``edition ∩ subscription tier``
+(e.g. hide engine tuning and watch folders from tenants, gate BYOK-LLM to a
+paid tier). Capability KEYS are generic core vocabulary; the cloud
+*resolution policy* is proprietary and lives in the private layer.
+
+Rule: every gate — backend dependency, beat schedule, frontend tab — reads
+the same capability key. Never sprinkle ``if edition == "cloud"`` in feature
+code.
+"""
+
+import logging
+from typing import Callable
+from typing import Optional
+
+from fastapi import HTTPException
+from fastapi import Request
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Known capability keys with their COMMUNITY defaults (everything on except
+# the cloud-only surfaces, which don't exist without the cloud layer).
+COMMUNITY_CAPABILITIES: dict[str, bool] = {
+    # Feature surfaces that exist today
+    "watch_sources": True,  # local/S3/SMB auto-import (Settings → Watch Sources)
+    "asr.user_providers": True,  # per-user cloud-ASR provider configs + keys
+    "asr.model_selection": True,  # admin local-model pinning UI
+    "engine.settings": True,  # diarization/boundary tuning admin panel
+    "llm.user_settings": True,  # per-user LLM provider/endpoint/keys
+    "auth.config_ui": True,  # LDAP/Keycloak/PKI admin configuration UI
+    "users.local_admin": True,  # local user CRUD admin UI
+    "system.hardware_stats": True,  # GPU/CPU stats, benchmarks
+    "url_ingest": True,  # yt-dlp URL ingestion
+    "recording": True,  # in-browser recording
+    # Cloud-only surfaces (no implementation in core — the cloud layer
+    # flips these on and mounts the corresponding routers/UI)
+    "billing": False,
+    "usage_dashboard": False,
+    "organizations": False,
+}
+
+# Resolver signature: (request | None) -> capability dict. The request is
+# offered so a cloud resolver can derive tenant/tier from the verified
+# identity stashed by get_current_user (request.state.external_identity).
+CapabilityResolver = Callable[[Optional[Request]], dict[str, bool]]
+
+
+def _community_resolver(_request: Optional[Request]) -> dict[str, bool]:
+    return dict(COMMUNITY_CAPABILITIES)
+
+
+_resolver: CapabilityResolver = _community_resolver
+
+
+def set_capability_resolver(resolver: CapabilityResolver) -> None:
+    """Replace the capability resolver (registered by the cloud layer)."""
+    global _resolver
+    logger.info("Capability resolver overridden (cloud edition)")
+    _resolver = resolver
+
+
+def reset_capability_resolver() -> None:
+    """Restore the community resolver (primarily for tests)."""
+    global _resolver
+    _resolver = _community_resolver
+
+
+def get_capabilities(request: Optional[Request] = None) -> dict[str, bool]:
+    """Effective capability map for this deployment/request.
+
+    Unknown keys from a custom resolver are passed through; missing known
+    keys fall back to the community defaults so a partial resolver cannot
+    accidentally disable surfaces it never considered.
+    """
+    resolved = _resolver(request)
+    caps = dict(COMMUNITY_CAPABILITIES)
+    caps.update(resolved)
+    return caps
+
+
+def capability_enabled(key: str, request: Optional[Request] = None) -> bool:
+    """Check a single capability (False for unknown keys)."""
+    return bool(get_capabilities(request).get(key, False))
+
+
+def require_capability(key: str) -> Callable:
+    """FastAPI dependency factory: 404 when the capability is off.
+
+    404 (not 403) on purpose — a disabled feature surface should not exist
+    at all for this deployment, exactly like an unknown route.
+    """
+
+    def _dependency(request: Request) -> None:
+        if not capability_enabled(key, request):
+            raise HTTPException(status_code=404, detail="Not Found")
+
+    return _dependency
+
+
+def edition() -> str:
+    """Deployment edition string ("community" | "cloud")."""
+    return settings.DEPLOYMENT_EDITION

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -113,6 +113,11 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")
     DEBUG: bool = ENVIRONMENT == "development"
 
+    # Edition: "community" (self-hosted, default — everything enabled) or
+    # "cloud" (commercial managed edition; the private cloud layer overrides
+    # the capability resolver to hide platform-managed features from tenants).
+    DEPLOYMENT_EDITION: str = os.getenv("DEPLOYMENT_EDITION", "community")
+
     # JWT Token settings (NIST SP 800-63B compliant)
     JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "this_should_be_changed_in_production")
     JWT_ALGORITHM: str = "HS256"

--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -214,8 +214,14 @@ def _detect_schema_version(conn, tables: list[str]) -> str | None:  # noqa: C901
     has_watch_sources = _check_exists(
         "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'watch_source')"
     )
+    has_cloud_seams = _check_exists(
+        "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'organization')"
+    )
 
     # Return the highest version stamp that matches (newest first)
+    # v367: cloud-edition seams (organization/usage_event tables, clerk columns)
+    if has_cloud_seams:
+        return "v367_add_cloud_seams"
     # v366: watch-source auto-import tables
     if has_watch_sources:
         return "v366_add_watch_sources"

--- a/backend/app/middleware/csrf.py
+++ b/backend/app/middleware/csrf.py
@@ -34,6 +34,10 @@ _EXEMPT_PREFIXES = (
     "/api/redoc",
     "/api/openapi.json",
     "/health",
+    # Server-to-server webhooks (cloud edition: Clerk/Stripe). They carry no
+    # cookies and authenticate by cryptographic signature on the raw body —
+    # CSRF does not apply and would silently 403 every delivery.
+    "/api/webhooks/",
 )
 
 # WebSocket paths are upgraded before middleware runs but check just in case

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,8 @@ from .media import SpeakerProfile
 from .media import Tag
 from .media import Task
 from .media import TranscriptSegment
+from .organization import Organization
+from .organization import OrganizationMembership
 from .password_history import PasswordHistory
 from .password_reset import PasswordResetToken
 from .pipeline_timing import FilePipelineTiming
@@ -37,6 +39,7 @@ from .refresh_token import RefreshToken
 from .sharing import CollectionShare
 from .topic import TopicSuggestion
 from .upload_batch import UploadBatch
+from .usage_event import UsageEvent
 from .user import User
 from .user_asr_settings import UserASRSettings
 from .user_diarization_settings import UserDiarizationSettings
@@ -88,4 +91,7 @@ __all__ = [
     "WatchSourceFile",
     "EmailNotificationConfig",
     "WatchSourceEmail",
+    "Organization",
+    "OrganizationMembership",
+    "UsageEvent",
 ]

--- a/backend/app/models/custom_vocabulary.py
+++ b/backend/app/models/custom_vocabulary.py
@@ -31,6 +31,8 @@ class CustomVocabulary(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=True, index=True)
+    # Cloud-edition seam: tenant scope (NULL = personal). Written by the cloud layer.
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     term = Column(String(200), nullable=False)
     domain = Column(String(50), nullable=False, default="general")
     category = Column(String(100), nullable=True)  # Sub-category within domain

--- a/backend/app/models/media.py
+++ b/backend/app/models/media.py
@@ -27,6 +27,8 @@ class MediaFile(Base):
         UUID(as_uuid=True), unique=True, nullable=False, default=uuid_pkg.uuid4, index=True
     )
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    # Cloud-edition seam: tenant scope (NULL = personal). Written by the cloud layer.
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     filename = Column(String, index=True)
     storage_path = Column(String, nullable=False)  # Path in MinIO/S3
     upload_time = Column(DateTime(timezone=True), server_default=func.now())
@@ -208,6 +210,7 @@ class SpeakerProfile(Base):
         UUID(as_uuid=True), unique=True, nullable=False, default=uuid_pkg.uuid4, index=True
     )
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     name = Column(String, nullable=False)  # User-assigned name (e.g., "John Doe")
     description = Column(Text, nullable=True)  # Optional description or notes
 
@@ -259,6 +262,7 @@ class Speaker(Base):
         UUID(as_uuid=True), unique=True, nullable=False, default=uuid_pkg.uuid4, index=True
     )
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     media_file_id = Column(Integer, ForeignKey("media_file.id", ondelete="CASCADE"), nullable=False)
     profile_id = Column(
         Integer, ForeignKey("speaker_profile.id", ondelete="SET NULL"), nullable=True
@@ -398,6 +402,7 @@ class Collection(Base):
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     is_public = Column(Boolean, default=False)
     default_summary_prompt_id = Column(
         Integer,
@@ -459,6 +464,7 @@ class SpeakerCollection(Base):
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     is_public = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -1,0 +1,83 @@
+"""Organization (tenant) models — cloud-edition seam.
+
+Mirrors the external IdP's organization + membership state so resources can be
+org-scoped and quotas enforced per tenant. In the community/self-hosted edition
+these tables simply stay empty (everything is personal, ``organization_id`` is
+NULL everywhere).
+
+Billing columns (``subscription_*``, ``stripe_*``, ``hours_*``, ``seats_limit``)
+are READ-ONLY to core: the private cloud layer writes them from its billing
+webhooks; core only displays them.
+"""
+
+import uuid as uuid_pkg
+
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import Numeric
+from sqlalchemy import SmallInteger
+from sqlalchemy import String
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class Organization(Base):
+    __tablename__ = "organization"
+
+    id = Column(Integer, primary_key=True, index=True)
+    uuid = Column(
+        UUID(as_uuid=True), unique=True, nullable=False, default=uuid_pkg.uuid4, index=True
+    )
+    clerk_org_id = Column(String(255), unique=True, nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    slug = Column(String(255), nullable=True)
+
+    # Billing state — written by the private cloud layer, read-only to core.
+    subscription_tier = Column(String(20), nullable=False, default="community")
+    subscription_status = Column(String(20), nullable=False, default="active")
+    stripe_customer_id = Column(String(64), nullable=True, index=True)
+    stripe_subscription_id = Column(String(64), nullable=True)
+    seats_limit = Column(Integer, nullable=True)
+    hours_limit_per_month = Column(Numeric(10, 3), nullable=True)  # NULL = unlimited
+    hours_used_this_month = Column(Numeric(10, 3), nullable=False, default=0)
+    billing_cycle_anchor_day = Column(SmallInteger, nullable=True)
+    current_period_end = Column(DateTime(timezone=True), nullable=True)
+
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    memberships = relationship(
+        "OrganizationMembership", back_populates="organization", cascade="all, delete-orphan"
+    )
+
+
+class OrganizationMembership(Base):
+    """Mirror of external-IdP org membership (refreshed by webhooks + on login).
+
+    Authorization checks run against THIS table, not just the token, so a
+    removed member loses access even before their short-lived token expires.
+    """
+
+    __tablename__ = "organization_membership"
+    __table_args__ = (UniqueConstraint("organization_id", "user_id", name="uq_org_membership"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    organization_id = Column(
+        Integer, ForeignKey("organization.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True)
+    role = Column(String(20), nullable=False, default="org:member")  # org:admin | org:member
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    organization = relationship("Organization", back_populates="memberships")
+    user = relationship("User", back_populates="org_memberships")

--- a/backend/app/models/prompt.py
+++ b/backend/app/models/prompt.py
@@ -38,6 +38,8 @@ class SummaryPrompt(Base):
     prompt_text = Column(Text, nullable=False)
     is_system_default = Column(Boolean, nullable=False, default=False)
     user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=True, index=True)
+    # Cloud-edition seam: tenant scope (NULL = personal). Written by the cloud layer.
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     is_active = Column(Boolean, nullable=False, default=True)
     content_type = Column(
         String(50), nullable=True, index=True
@@ -74,6 +76,7 @@ class UserSetting(Base):
         UUID(as_uuid=True), unique=True, nullable=False, default=uuid_pkg.uuid4, index=True
     )
     user_id = Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True)
+    organization_id = Column(Integer, ForeignKey("organization.id"), nullable=True, index=True)
     setting_key = Column(String(100), nullable=False, index=True)
     setting_value = Column(Text, nullable=True)  # Can store JSON or simple values
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/usage_event.py
+++ b/backend/app/models/usage_event.py
@@ -1,0 +1,45 @@
+"""Usage event spine — cloud-edition seam, also useful for self-host analytics.
+
+One row per countable thing that happened (transcription hours, uploads,
+summaries, searches, exports, ...). Serves BOTH billing/quota (cloud) and
+product analytics. Events never contain transcript content — IDs/counts only.
+
+``idempotency_key`` (unique when present) makes writers safe against Celery
+retries and webhook replays.
+"""
+
+import uuid as uuid_pkg
+
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Index
+from sqlalchemy import Integer
+from sqlalchemy import Numeric
+from sqlalchemy import String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class UsageEvent(Base):
+    __tablename__ = "usage_event"
+    __table_args__ = (
+        Index("idx_usage_event_org_type_time", "organization_id", "event_type", "created_at"),
+        Index("idx_usage_event_user_time", "user_id", "created_at"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid_pkg.uuid4)
+    user_id = Column(Integer, ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
+    organization_id = Column(
+        Integer, ForeignKey("organization.id", ondelete="SET NULL"), nullable=True
+    )
+    event_type = Column(String(50), nullable=False)  # e.g. "transcription.hours"
+    quantity = Column(Numeric(12, 3), nullable=False, default=1)
+    unit = Column(String(16), nullable=True)  # e.g. "hours", "count", "tokens"
+    file_id = Column(Integer, ForeignKey("media_file.id", ondelete="SET NULL"), nullable=True)
+    idempotency_key = Column(String(128), nullable=True, unique=True)
+    event_metadata = Column(JSONB, nullable=True)  # IDs/counts only — never content
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -36,6 +36,10 @@ class User(Base):
     )  # When True: user can authenticate via password even if auth_type != 'local'
     ldap_uid = Column(String, nullable=True, unique=True, index=True)  # sAMAccountName from AD
     keycloak_id = Column(String(255), unique=True, nullable=True, index=True)  # Keycloak subject ID
+    clerk_id = Column(String(255), unique=True, nullable=True, index=True)  # Clerk subject (sub)
+    clerk_org_id = Column(
+        String(255), nullable=True
+    )  # Last-seen Clerk org — convenience only, never authorization authority
     keycloak_refresh_token = Column(
         Text, nullable=True
     )  # Encrypted KC refresh token for federated logout
@@ -112,6 +116,10 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
         order_by="desc(PasswordHistory.created_at)",
+    )
+    # Organization (tenant) memberships — cloud-edition seam, empty for self-host
+    org_memberships = relationship(
+        "OrganizationMembership", back_populates="user", cascade="all, delete-orphan"
     )
     # Groups and sharing relationships
     owned_groups = relationship("UserGroup", back_populates="owner", cascade="all, delete-orphan")

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -1,0 +1,65 @@
+"""Usage event recording (billing + product analytics spine).
+
+``record_event`` is safe to call from anywhere (API handlers, Celery tasks,
+hooks): failures are contained and never break the calling feature, and an
+``idempotency_key`` makes writers replay/retry-safe (duplicate keys are
+silently ignored). Events must contain IDs/counts only — never transcript
+content (PII hygiene).
+"""
+
+import logging
+from decimal import Decimal
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def record_event(
+    db: Session,
+    *,
+    event_type: str,
+    quantity: Union[Decimal, float, int] = 1,
+    unit: Optional[str] = None,
+    user_id: Optional[int] = None,
+    organization_id: Optional[int] = None,
+    file_id: Optional[int] = None,
+    idempotency_key: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> bool:
+    """Insert a usage event row. Returns True if recorded, False if skipped.
+
+    Duplicate ``idempotency_key`` -> skipped (already recorded by a previous
+    attempt). Any other failure is logged and swallowed — usage accounting
+    must never break the feature that emitted the event.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.usage_event import UsageEvent
+
+    try:
+        db.add(
+            UsageEvent(
+                event_type=event_type,
+                quantity=Decimal(str(quantity)),
+                unit=unit,
+                user_id=user_id,
+                organization_id=organization_id,
+                file_id=file_id,
+                idempotency_key=idempotency_key,
+                event_metadata=metadata,
+            )
+        )
+        db.commit()
+        return True
+    except IntegrityError:
+        db.rollback()
+        logger.info(f"Usage event already recorded (idempotency_key={idempotency_key})")
+        return False
+    except Exception:
+        db.rollback()
+        logger.exception(f"Failed to record usage event '{event_type}' (contained)")
+        return False

--- a/backend/app/tasks/transcription/core.py
+++ b/backend/app/tasks/transcription/core.py
@@ -1254,6 +1254,31 @@ def _run_post_gpu_background(
             # Note: media_file.status is already set to COMPLETED by
             # update_media_file_transcription_status in the critical path
 
+            # Cloud-edition seam: metering/analytics hook (no-op in community,
+            # failures contained — metering can never fail a transcription).
+            from app.models.media import MediaFile as _MediaFile
+            from app.models.pipeline_timing import FilePipelineTiming as _Timing
+
+            from .hooks import CompletionContext
+            from .hooks import fire_transcription_complete
+
+            _mf = db.query(_MediaFile).filter(_MediaFile.id == ctx.file_id).first()
+            _timing = db.query(_Timing.asr_provider).filter(_Timing.file_id == ctx.file_id).first()
+            fire_transcription_complete(
+                CompletionContext(
+                    file_id=ctx.file_id,
+                    file_uuid=str(ctx.file_uuid),
+                    user_id=ctx.user_id,
+                    organization_id=_mf.organization_id if _mf else None,
+                    audio_duration_s=float(_mf.duration) if _mf and _mf.duration else 0.0,
+                    run_id=ctx.task_id,
+                    provider=(
+                        _timing.asr_provider if _timing and _timing.asr_provider else "local"
+                    ),
+                    success=True,
+                )
+            )
+
         send_completion_notification(ctx.user_id, ctx.file_id)
 
         logger.info(

--- a/backend/app/tasks/transcription/dispatch.py
+++ b/backend/app/tasks/transcription/dispatch.py
@@ -110,6 +110,26 @@ def dispatch_transcription_pipeline(
         file_id = int(media_file.id)
         user_id = int(media_file.user_id)
 
+        # Cloud-edition seam: quota reservation hook (no-op in community).
+        # QuotaExceededError (HTTP 402) propagates BEFORE the task record is
+        # created, so a blocked job leaves no trace and nothing dispatches.
+        from decimal import Decimal
+
+        from .hooks import DispatchContext
+        from .hooks import fire_before_dispatch
+
+        duration_s = media_file.duration
+        fire_before_dispatch(
+            DispatchContext(
+                file_id=file_id,
+                file_uuid=file_uuid,
+                user_id=user_id,
+                organization_id=media_file.organization_id,
+                est_audio_hours=(Decimal(str(duration_s)) / Decimal(3600) if duration_s else None),
+                task_id=task_id,
+            )
+        )
+
         # Auto-resolve queue from user's ASR provider if not specified
         if not use_cpu and gpu_queue is None:
             gpu_queue = _resolve_gpu_queue(user_id, db)

--- a/backend/app/tasks/transcription/hooks.py
+++ b/backend/app/tasks/transcription/hooks.py
@@ -1,0 +1,108 @@
+"""Transcription pipeline hooks (cloud-edition seam).
+
+Two extension points fired by the core pipeline; community defaults are
+no-ops with zero overhead. The commercial cloud layer registers:
+  - a before-dispatch hook for quota reservation (raising
+    ``QuotaExceededError`` -> HTTP 402 with an upgrade prompt), and
+  - a transcription-complete hook for usage metering + analytics events
+    (idempotent on ``file_id:run_id`` against retries/replays).
+
+Contract covered by ``CLOUD_SEAM_VERSION`` (app.auth.constants).
+"""
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Callable
+from typing import Optional
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+class QuotaExceededError(HTTPException):
+    """Raised by a before-dispatch hook when the tenant is over quota.
+
+    Subclasses HTTPException so API-triggered dispatches surface as a clean
+    402 Payment Required without extra translation layers; Celery-triggered
+    dispatches (watch sources) catch it like any pipeline error.
+    """
+
+    def __init__(self, detail: str = "Transcription quota exceeded", hours_over: float = 0.0):
+        super().__init__(status_code=402, detail=detail)
+        self.hours_over = hours_over
+
+
+@dataclass(frozen=True)
+class DispatchContext:
+    """What a quota hook needs to decide whether a job may run."""
+
+    file_id: int
+    file_uuid: str
+    user_id: int
+    organization_id: Optional[int]
+    est_audio_hours: Optional[Decimal]  # None when duration not yet known
+    task_id: str
+
+
+@dataclass(frozen=True)
+class CompletionContext:
+    """What a metering hook needs to charge/record a finished run."""
+
+    file_id: int
+    file_uuid: str
+    user_id: int
+    organization_id: Optional[int]
+    audio_duration_s: float
+    run_id: str  # task_id of this pipeline run — idempotency scope
+    provider: str  # "local" | cloud-ASR provider name
+    success: bool
+
+
+BeforeDispatchHook = Callable[[DispatchContext], None]
+TranscriptionCompleteHook = Callable[[CompletionContext], None]
+
+_before_dispatch_hooks: list[BeforeDispatchHook] = []
+_transcription_complete_hooks: list[TranscriptionCompleteHook] = []
+
+
+def register_before_dispatch(hook: BeforeDispatchHook) -> None:
+    """Register a pre-dispatch hook (cloud: quota reservation)."""
+    _before_dispatch_hooks.append(hook)
+    logger.info("Registered before-dispatch pipeline hook")
+
+
+def register_transcription_complete(hook: TranscriptionCompleteHook) -> None:
+    """Register a completion hook (cloud: metering + usage events)."""
+    _transcription_complete_hooks.append(hook)
+    logger.info("Registered transcription-complete pipeline hook")
+
+
+def clear_hooks() -> None:
+    """Remove all registered hooks (primarily for tests)."""
+    _before_dispatch_hooks.clear()
+    _transcription_complete_hooks.clear()
+
+
+def fire_before_dispatch(ctx: DispatchContext) -> None:
+    """Run pre-dispatch hooks. QuotaExceededError propagates (blocks the job);
+    any other hook failure is contained so a broken cloud layer can never
+    stop community transcription."""
+    for hook in _before_dispatch_hooks:
+        try:
+            hook(ctx)
+        except QuotaExceededError:
+            raise
+        except Exception:
+            logger.exception("before-dispatch hook failed; allowing dispatch")
+
+
+def fire_transcription_complete(ctx: CompletionContext) -> None:
+    """Run completion hooks. Failures are contained — metering problems must
+    never mark a successful transcription as failed."""
+    for hook in _transcription_complete_hooks:
+        try:
+            hook(ctx)
+        except Exception:
+            logger.exception("transcription-complete hook failed (contained)")

--- a/backend/tests/test_cloud_seams.py
+++ b/backend/tests/test_cloud_seams.py
@@ -1,0 +1,262 @@
+"""Tests for the cloud-edition seams (open-core extension points).
+
+Covers the auth provider registry, generic external JIT user sync, the
+get_current_user external-verifier branch, /auth/methods discovery, and the
+new organization / usage_event models. The community edition registers no
+verifiers, so every test restores the empty-registry state on exit.
+"""
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from typing import Optional
+
+import pytest
+from fastapi import HTTPException
+from fastapi import Request
+
+from app.auth.constants import AUTH_TYPE_CLERK
+from app.auth.constants import CLOUD_SEAM_VERSION
+from app.auth.constants import EXTERNAL_AUTH_NO_PASSWORD
+from app.auth.constants import VALID_AUTH_TYPES
+from app.auth.external_sync import sync_external_user_to_db
+from app.auth.provider_registry import ExternalIdentity
+from app.auth.provider_registry import get_registered_providers
+from app.auth.provider_registry import has_verifiers
+from app.auth.provider_registry import register_verifier
+from app.auth.provider_registry import unregister_verifier
+from app.auth.provider_registry import verify_external_token
+from app.models.organization import Organization
+from app.models.organization import OrganizationMembership
+from app.models.usage_event import UsageEvent
+from app.models.user import User
+
+
+class FakeVerifier:
+    """Test double matching the TokenVerifier protocol."""
+
+    def __init__(self, accept_token: str, identity: Optional[ExternalIdentity]):
+        self.accept_token = accept_token
+        self.identity = identity
+        self.calls = 0
+
+    def verify(self, token: str, request: Request) -> Optional[ExternalIdentity]:
+        self.calls += 1
+        return self.identity if token == self.accept_token else None
+
+
+class CrashingVerifier:
+    def verify(self, token: str, request: Request):
+        raise RuntimeError("boom")
+
+
+def _identity(**overrides: Any) -> ExternalIdentity:
+    defaults: dict[str, Any] = {
+        "provider": "clerk",
+        "external_id": f"user_{uuid.uuid4().hex[:12]}",
+        "email": f"seam-test-{uuid.uuid4().hex[:8]}@example.com",
+        "full_name": "Seam Tester",
+        "org_id": "org_abc123",
+        "org_role": "org:member",
+    }
+    defaults.update(overrides)
+    return ExternalIdentity(**defaults)
+
+
+def _fake_request() -> Request:
+    # get_current_user only touches request.state on the external path; a
+    # lightweight stand-in keeps these tests free of ASGI plumbing.
+    return SimpleNamespace(state=SimpleNamespace())  # type: ignore[return-value]
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Every test starts and ends with an empty verifier registry."""
+    unregister_verifier(AUTH_TYPE_CLERK)
+    unregister_verifier("other")
+    yield
+    unregister_verifier(AUTH_TYPE_CLERK)
+    unregister_verifier("other")
+
+
+class TestConstants:
+    def test_clerk_is_valid_auth_type(self):
+        assert AUTH_TYPE_CLERK == "clerk"
+        assert AUTH_TYPE_CLERK in VALID_AUTH_TYPES
+
+    def test_seam_version_present(self):
+        assert isinstance(CLOUD_SEAM_VERSION, int)
+        assert CLOUD_SEAM_VERSION >= 1
+
+
+class TestProviderRegistry:
+    def test_empty_by_default(self):
+        assert not has_verifiers()
+        assert get_registered_providers() == []
+        assert verify_external_token("anything", _fake_request()) is None
+
+    def test_register_and_match(self):
+        ident = _identity()
+        verifier = FakeVerifier("good-token", ident)
+        register_verifier(AUTH_TYPE_CLERK, verifier)
+
+        assert has_verifiers()
+        assert get_registered_providers() == ["clerk"]
+        assert verify_external_token("good-token", _fake_request()) is ident
+        assert verify_external_token("bad-token", _fake_request()) is None
+
+    def test_unregister(self):
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("t", _identity()))
+        unregister_verifier(AUTH_TYPE_CLERK)
+        assert not has_verifiers()
+
+    def test_crashing_verifier_is_contained(self):
+        """A broken cloud layer must never take down authentication."""
+        ident = _identity()
+        register_verifier("other", CrashingVerifier())
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("tok", ident))
+        assert verify_external_token("tok", _fake_request()) is ident
+
+
+class TestExternalSync:
+    def test_creates_new_user(self, db_session):
+        ident = _identity()
+        user = sync_external_user_to_db(db_session, ident)
+
+        assert user.clerk_id == ident.external_id
+        assert user.email == ident.email
+        assert user.auth_type == "clerk"
+        assert user.hashed_password == EXTERNAL_AUTH_NO_PASSWORD
+        assert user.clerk_org_id == "org_abc123"
+        # org:member / org:admin are tenant capabilities, never platform roles
+        assert user.role == "user"
+        assert user.is_superuser is False
+
+    def test_resync_updates_profile(self, db_session):
+        ident = _identity()
+        sync_external_user_to_db(db_session, ident)
+        updated = ExternalIdentity(
+            provider=ident.provider,
+            external_id=ident.external_id,
+            email=ident.email,
+            full_name="Renamed Person",
+            org_id="org_new",
+            org_role="org:admin",
+        )
+        user = sync_external_user_to_db(db_session, updated)
+        assert user.full_name == "Renamed Person"
+        assert user.clerk_org_id == "org_new"
+        # Still not a platform admin even as org:admin
+        assert user.role == "user"
+
+    def test_converts_local_user_by_email(self, db_session):
+        email = f"seam-local-{uuid.uuid4().hex[:8]}@example.com"
+        local = User(
+            email=email,
+            full_name="Local Person",
+            hashed_password="$2b$12$fakehashfakehashfakehash",
+            auth_type="local",
+            is_active=True,
+        )
+        db_session.add(local)
+        db_session.commit()
+
+        ident = _identity(email=email)
+        user = sync_external_user_to_db(db_session, ident)
+
+        assert user.id == local.id
+        assert user.clerk_id == ident.external_id
+        assert user.auth_type == "clerk"
+        assert user.hashed_password == EXTERNAL_AUTH_NO_PASSWORD  # one-way conversion
+
+    def test_platform_admin_only_when_flagged(self, db_session):
+        user = sync_external_user_to_db(db_session, _identity(is_admin=True))
+        assert user.role == "admin"
+        assert user.is_superuser is True
+
+    def test_unknown_provider_rejected(self, db_session):
+        with pytest.raises(ValueError, match="No User column mapping"):
+            sync_external_user_to_db(db_session, _identity(provider="nonsense"))
+
+
+class TestGetCurrentUserExternalBranch:
+    def test_external_token_returns_jit_user(self, db_session):
+        from app.api.endpoints.auth import get_current_user
+
+        ident = _identity()
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("ext-token", ident))
+        request = _fake_request()
+
+        user = get_current_user(request=request, token="ext-token", db=db_session)
+
+        assert user.clerk_id == ident.external_id
+        assert request.state.external_identity is ident
+
+    def test_non_matching_token_falls_through_to_local(self, db_session):
+        from app.api.endpoints.auth import get_current_user
+
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("only-this", _identity()))
+
+        with pytest.raises(HTTPException) as exc:
+            get_current_user(request=_fake_request(), token="not-a-valid-jwt", db=db_session)
+        assert exc.value.status_code == 401
+
+    def test_inactive_external_user_rejected(self, db_session):
+        from app.api.endpoints.auth import get_current_user
+
+        ident = _identity()
+        user = sync_external_user_to_db(db_session, ident)
+        user.is_active = False
+        db_session.commit()
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("tok", ident))
+
+        with pytest.raises(HTTPException) as exc:
+            get_current_user(request=_fake_request(), token="tok", db=db_session)
+        assert exc.value.status_code == 400
+
+
+class TestAuthMethodsDiscovery:
+    def test_clerk_disabled_by_default(self, client):
+        body = client.get("/api/auth/methods").json()
+        assert body["clerk_enabled"] is False
+        assert body["external_providers"] == []
+        assert "clerk" not in body["methods"]
+
+    def test_clerk_enabled_when_registered(self, client):
+        register_verifier(AUTH_TYPE_CLERK, FakeVerifier("t", _identity()))
+        body = client.get("/api/auth/methods").json()
+        assert body["clerk_enabled"] is True
+        assert body["external_providers"] == ["clerk"]
+        assert "clerk" in body["methods"]
+
+
+class TestOrganizationModels:
+    def test_org_membership_and_usage_event_roundtrip(self, db_session):
+        org = Organization(clerk_org_id=f"org_{uuid.uuid4().hex[:10]}", name="Acme Inc")
+        db_session.add(org)
+        db_session.commit()
+        assert org.subscription_tier == "community"
+        assert float(org.hours_used_this_month) == 0.0
+
+        user = sync_external_user_to_db(db_session, _identity())
+        member = OrganizationMembership(organization_id=org.id, user_id=user.id, role="org:admin")
+        db_session.add(member)
+        db_session.commit()
+        assert org.memberships[0].user.id == user.id
+        assert user.org_memberships[0].role == "org:admin"
+
+    def test_usage_event_idempotency_key_unique(self, db_session):
+        from sqlalchemy.exc import IntegrityError
+
+        key = f"file:{uuid.uuid4().hex[:8]}:run1"
+        db_session.add(
+            UsageEvent(event_type="transcription.hours", quantity=1.5, idempotency_key=key)
+        )
+        db_session.commit()
+
+        db_session.add(
+            UsageEvent(event_type="transcription.hours", quantity=1.5, idempotency_key=key)
+        )
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()

--- a/backend/tests/test_cloud_seams_capabilities.py
+++ b/backend/tests/test_cloud_seams_capabilities.py
@@ -1,0 +1,258 @@
+"""Tests for capabilities/entitlements, pipeline hooks, request context, and
+usage-event recording (cloud-edition seams, parts 3+4).
+
+Community-default behavior is the contract: everything on except cloud-only
+surfaces, hooks are no-ops, and a broken cloud layer can never break core.
+"""
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from typing import Optional
+
+import pytest
+from fastapi import HTTPException
+from fastapi import Request
+
+from app.api.deps_context import RequestContext
+from app.api.deps_context import get_current_context
+from app.api.deps_context import scope_to_context
+from app.auth.external_sync import sync_external_user_to_db
+from app.auth.provider_registry import ExternalIdentity
+from app.core.capabilities import COMMUNITY_CAPABILITIES
+from app.core.capabilities import capability_enabled
+from app.core.capabilities import get_capabilities
+from app.core.capabilities import require_capability
+from app.core.capabilities import reset_capability_resolver
+from app.core.capabilities import set_capability_resolver
+from app.models.media import MediaFile
+from app.models.organization import Organization
+from app.models.organization import OrganizationMembership
+from app.services.usage_service import record_event
+from app.tasks.transcription.hooks import CompletionContext
+from app.tasks.transcription.hooks import DispatchContext
+from app.tasks.transcription.hooks import QuotaExceededError
+from app.tasks.transcription.hooks import clear_hooks
+from app.tasks.transcription.hooks import fire_before_dispatch
+from app.tasks.transcription.hooks import fire_transcription_complete
+from app.tasks.transcription.hooks import register_before_dispatch
+from app.tasks.transcription.hooks import register_transcription_complete
+
+
+def _fake_request(**state: Any) -> Request:
+    return SimpleNamespace(state=SimpleNamespace(**state))  # type: ignore[return-value]
+
+
+def _identity(**overrides: Any) -> ExternalIdentity:
+    defaults: dict[str, Any] = {
+        "provider": "clerk",
+        "external_id": f"user_{uuid.uuid4().hex[:12]}",
+        "email": f"cap-test-{uuid.uuid4().hex[:8]}@example.com",
+        "full_name": "Cap Tester",
+        "org_id": f"org_{uuid.uuid4().hex[:10]}",
+        "org_role": "org:member",
+    }
+    defaults.update(overrides)
+    return ExternalIdentity(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def clean_seams():
+    reset_capability_resolver()
+    clear_hooks()
+    yield
+    reset_capability_resolver()
+    clear_hooks()
+
+
+class TestCapabilities:
+    def test_community_defaults_everything_on_except_cloud_surfaces(self):
+        caps = get_capabilities()
+        assert caps["watch_sources"] is True
+        assert caps["engine.settings"] is True
+        assert caps["auth.config_ui"] is True
+        # Cloud-only surfaces don't exist without the cloud layer
+        assert caps["billing"] is False
+        assert caps["usage_dashboard"] is False
+        assert caps["organizations"] is False
+
+    def test_resolver_override_and_reset(self):
+        set_capability_resolver(lambda _req: {"watch_sources": False, "billing": True})
+        caps = get_capabilities()
+        assert caps["watch_sources"] is False
+        assert caps["billing"] is True
+        # Partial resolvers can't accidentally disable unconsidered surfaces
+        assert caps["engine.settings"] is True
+
+        reset_capability_resolver()
+        assert get_capabilities() == COMMUNITY_CAPABILITIES
+
+    def test_capability_enabled_unknown_key_false(self):
+        assert capability_enabled("does.not.exist") is False
+
+    def test_require_capability_404_when_off(self):
+        dep = require_capability("billing")  # off in community
+        with pytest.raises(HTTPException) as exc:
+            dep(_fake_request())
+        assert exc.value.status_code == 404
+
+        dep_on = require_capability("watch_sources")
+        assert dep_on(_fake_request()) is None  # no raise
+
+    def test_endpoint_shape(self, client):
+        body = client.get("/api/system/capabilities").json()
+        assert body["edition"] == "community"
+        assert body["capabilities"]["watch_sources"] is True
+        assert body["capabilities"]["billing"] is False
+
+
+class TestPipelineHooks:
+    def _dispatch_ctx(self, **overrides: Any) -> DispatchContext:
+        defaults: dict[str, Any] = {
+            "file_id": 1,
+            "file_uuid": str(uuid.uuid4()),
+            "user_id": 1,
+            "organization_id": None,
+            "est_audio_hours": None,
+            "task_id": str(uuid.uuid4()),
+        }
+        defaults.update(overrides)
+        return DispatchContext(**defaults)
+
+    def test_no_hooks_is_noop(self):
+        fire_before_dispatch(self._dispatch_ctx())  # no raise
+
+    def test_quota_exceeded_propagates_as_402(self):
+        def quota_hook(ctx: DispatchContext) -> None:
+            raise QuotaExceededError(hours_over=1.5)
+
+        register_before_dispatch(quota_hook)
+        with pytest.raises(QuotaExceededError) as exc:
+            fire_before_dispatch(self._dispatch_ctx())
+        assert exc.value.status_code == 402
+        assert exc.value.hours_over == 1.5
+
+    def test_other_dispatch_hook_errors_contained(self):
+        register_before_dispatch(lambda ctx: (_ for _ in ()).throw(RuntimeError("boom")))
+        fire_before_dispatch(self._dispatch_ctx())  # contained, no raise
+
+    def test_completion_hook_receives_context_and_errors_contained(self):
+        seen: list[CompletionContext] = []
+        register_transcription_complete(seen.append)
+        register_transcription_complete(
+            lambda ctx: (_ for _ in ()).throw(RuntimeError("metering down"))
+        )
+
+        ctx = CompletionContext(
+            file_id=7,
+            file_uuid=str(uuid.uuid4()),
+            user_id=3,
+            organization_id=None,
+            audio_duration_s=123.4,
+            run_id="run-1",
+            provider="local",
+            success=True,
+        )
+        fire_transcription_complete(ctx)  # second hook crashing is contained
+        assert seen == [ctx]
+
+
+class TestRecordEvent:
+    def test_records_and_dedupes(self, db_session):
+        key = f"test:{uuid.uuid4().hex[:8]}"
+        assert (
+            record_event(
+                db_session,
+                event_type="transcription.hours",
+                quantity=1.25,
+                unit="hours",
+                idempotency_key=key,
+                metadata={"provider": "local"},
+            )
+            is True
+        )
+        # Replay with the same key is skipped, not an error
+        assert (
+            record_event(
+                db_session,
+                event_type="transcription.hours",
+                quantity=1.25,
+                unit="hours",
+                idempotency_key=key,
+            )
+            is False
+        )
+
+
+class TestRequestContext:
+    def _user(self, db_session, ident: Optional[ExternalIdentity] = None):
+        return sync_external_user_to_db(db_session, ident or _identity())
+
+    def test_personal_context_without_identity(self, db_session):
+        user = self._user(db_session)
+        ctx = get_current_context(_fake_request(), db=db_session, current_user=user)
+        assert ctx.org_id is None
+        assert not ctx.is_org_context
+
+    def test_org_context_requires_membership_mirror(self, db_session):
+        ident = _identity()
+        user = self._user(db_session, ident)
+        org = Organization(clerk_org_id=ident.org_id, name="Acme")
+        db_session.add(org)
+        db_session.commit()
+
+        request = _fake_request(external_identity=ident)
+
+        # Token claims the org but no membership row yet -> personal scope
+        ctx = get_current_context(request, db=db_session, current_user=user)
+        assert not ctx.is_org_context
+
+        # Mirror confirms membership -> org scope + role
+        db_session.add(
+            OrganizationMembership(organization_id=org.id, user_id=user.id, role="org:admin")
+        )
+        db_session.commit()
+        ctx = get_current_context(request, db=db_session, current_user=user)
+        assert ctx.org_id == org.id
+        assert ctx.is_org_admin
+
+    def test_scope_to_context_filters(self, db_session):
+        ident = _identity()
+        user = self._user(db_session, ident)
+        org = Organization(clerk_org_id=ident.org_id, name="Acme")
+        db_session.add(org)
+        db_session.commit()
+
+        mine_personal = MediaFile(
+            user_id=user.id,
+            filename="personal.mp3",
+            storage_path=f"t/{uuid.uuid4().hex}.mp3",
+            file_size=10,
+            content_type="audio/mpeg",
+        )
+        org_file = MediaFile(
+            user_id=user.id,
+            organization_id=org.id,
+            filename="org.mp3",
+            storage_path=f"t/{uuid.uuid4().hex}.mp3",
+            file_size=10,
+            content_type="audio/mpeg",
+        )
+        db_session.add_all([mine_personal, org_file])
+        db_session.commit()
+
+        personal_ctx = RequestContext(user=user)
+        org_ctx = RequestContext(user=user, org_id=org.id, org_role="org:member")
+
+        personal_q = scope_to_context(db_session.query(MediaFile), MediaFile, personal_ctx)
+        org_q = scope_to_context(db_session.query(MediaFile), MediaFile, org_ctx)
+
+        personal_ids = {f.id for f in personal_q.all()}
+        org_ids = {f.id for f in org_q.all()}
+
+        assert mine_personal.id in personal_ids
+        assert org_file.id in org_ids
+        # A file uploaded into an org lives in the org space, NOT the
+        # uploader's personal space — and vice versa (no cross-leak).
+        assert org_file.id not in personal_ids
+        assert mine_personal.id not in org_ids

--- a/backend/tests/test_cloud_seams_capabilities.py
+++ b/backend/tests/test_cloud_seams_capabilities.py
@@ -104,6 +104,56 @@ class TestCapabilities:
         assert body["edition"] == "community"
         assert body["capabilities"]["watch_sources"] is True
         assert body["capabilities"]["billing"] is False
+        assert body["audience"]["billing"] == "org_admin"
+        assert body["audience"]["engine.settings"] == "platform"
+
+    def test_every_capability_has_an_audience(self):
+        from app.core.capabilities import CAPABILITY_AUDIENCE
+
+        unclassified = set(COMMUNITY_CAPABILITIES) - set(CAPABILITY_AUDIENCE)
+        assert not unclassified, f"capabilities missing audience: {unclassified}"
+        valid = {"user", "team", "org_admin", "platform"}
+        assert set(CAPABILITY_AUDIENCE.values()) <= valid
+
+    def test_audience_separation_invariants(self):
+        """Org admins manage their tenant, never the platform: no org_admin
+        surface may be a platform config surface and vice versa."""
+        from app.core.capabilities import CAPABILITY_AUDIENCE
+
+        platform_keys = {k for k, a in CAPABILITY_AUDIENCE.items() if a == "platform"}
+        org_keys = {k for k, a in CAPABILITY_AUDIENCE.items() if a == "org_admin"}
+        assert not platform_keys & org_keys
+        # The dangerous platform surfaces are classified as platform
+        for key in ("auth.config_ui", "users.local_admin", "engine.settings"):
+            assert CAPABILITY_AUDIENCE[key] == "platform"
+
+
+class TestRouterGating:
+    """Capability-gated routers: visible in community, 404 when a cloud-style
+    resolver disables the surface, capabilities endpoint never gated."""
+
+    def test_community_router_reachable(self, client):
+        # Unauthenticated -> 401/403 (auth gate), NOT 404 (capability gate)
+        assert client.get("/api/watch-sources").status_code != 404
+        assert client.get("/api/llm-settings").status_code != 404
+
+    def test_cloud_resolver_hides_gated_routers(self, client):
+        set_capability_resolver(
+            lambda _req: {
+                "watch_sources": False,
+                "asr.user_providers": False,
+                "engine.settings": False,
+                "llm.user_settings": False,
+                "auth.config_ui": False,
+            }
+        )
+        assert client.get("/api/watch-sources").status_code == 404
+        assert client.get("/api/llm-settings").status_code == 404
+        assert client.get("/api/asr-settings/providers").status_code == 404
+        assert client.get("/api/admin/engine-settings").status_code == 404
+        assert client.get("/api/admin/auth-config").status_code == 404
+        # The capabilities endpoint itself must NEVER be gated
+        assert client.get("/api/system/capabilities").status_code == 200
 
 
 class TestPipelineHooks:

--- a/frontend/src/components/SettingsModal.svelte
+++ b/frontend/src/components/SettingsModal.svelte
@@ -3,6 +3,7 @@
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
   import { page } from '$app/stores';
   import { user as userStore } from '$stores/auth';
+  import { capabilities, isCapabilityEnabled } from '$stores/capabilities';
   import { settingsModalStore, type SettingsSection } from '$stores/settingsModalStore';
   import { toastStore } from '$stores/toast';
   import axiosInstance from '$lib/axios';
@@ -125,12 +126,21 @@
   let confirmModalMessage = '';
   let confirmCallback: (() => void) | null = null;
 
-  // Define sidebar sections
+  // Edition capability gating (server-driven entitlements): a section item
+  // tagged with `cap` renders only when the backend lists that capability as
+  // enabled for this deployment. Community = everything on (no change);
+  // cloud hides platform/self-host surfaces so the product "just works".
+  // The backend independently 404s gated endpoints — this is cosmetic only.
+  $: capState = $capabilities;
+  const capOn = (state: typeof $capabilities, key?: string) =>
+    !key || isCapabilityEnabled(state, key);
+
+  // Define sidebar sections (filtered by capability; empty sections drop out)
   $: sidebarSections = [
     {
       title: $t('settings.sections.system'),
       items: [
-        { id: 'system-statistics' as SettingsSection, label: $t('settings.statistics.title'), icon: 'chart' }
+        { id: 'system-statistics' as SettingsSection, label: $t('settings.statistics.title'), icon: 'chart', cap: 'system.hardware_stats' }
       ]
     },
     ...(isAdmin ? [
@@ -139,9 +149,9 @@
         items: [
           ...(isSuperAdmin ? [
             { id: 'audit-logs' as SettingsSection, label: $t('settings.auditLog.navLabel'), icon: 'list' },
-            { id: 'authentication' as SettingsSection, label: $t('settings.authentication.title'), icon: 'key' }
+            { id: 'authentication' as SettingsSection, label: $t('settings.authentication.title'), icon: 'key', cap: 'auth.config_ui' }
           ] : []),
-          { id: 'admin-users' as SettingsSection, label: $t('settings.users.title'), icon: 'users' }
+          { id: 'admin-users' as SettingsSection, label: $t('settings.users.title'), icon: 'users', cap: 'users.local_admin' }
         ]
       },
       {
@@ -158,24 +168,24 @@
     {
       title: $t('settings.sections.account'),
       items: [
-        { id: 'groups' as SettingsSection, label: $t('groups.title'), icon: 'group' },
+        { id: 'groups' as SettingsSection, label: $t('groups.title'), icon: 'group', cap: 'sharing.teams' },
         { id: 'profile' as SettingsSection, label: $t('settings.profile.title'), icon: 'user' }
       ]
     },
     {
       title: $t('settings.sections.transcriptionAi'),
       items: [
-        { id: 'ai-prompts' as SettingsSection, label: $t('settings.aiPrompts.title'), icon: 'message' },
-        { id: 'asr-provider' as SettingsSection, label: $t('settings.asrProvider.title'), icon: 'mic' },
-        ...(isAdmin ? [{ id: 'engine-settings' as SettingsSection, label: $t('settings.engineSettings.title'), icon: 'cpu' }] : []),
-        ...(isAdmin ? [{ id: 'redaction-policy' as SettingsSection, label: $t('settings.redactionPolicy.title'), icon: 'shield' }] : []),
+        { id: 'ai-prompts' as SettingsSection, label: $t('settings.aiPrompts.title'), icon: 'message', cap: 'prompts.user' },
+        { id: 'asr-provider' as SettingsSection, label: $t('settings.asrProvider.title'), icon: 'mic', cap: 'asr.user_providers' },
+        ...(isAdmin ? [{ id: 'engine-settings' as SettingsSection, label: $t('settings.engineSettings.title'), icon: 'cpu', cap: 'engine.settings' }] : []),
+        ...(isAdmin ? [{ id: 'redaction-policy' as SettingsSection, label: $t('settings.redactionPolicy.title'), icon: 'shield', cap: 'redaction.policy' }] : []),
         { id: 'auto-labeling' as SettingsSection, label: $t('autoLabel.title'), icon: 'tag' },
-        { id: 'custom-vocabulary' as SettingsSection, label: $t('settings.customVocabulary.title'), icon: 'list' },
-        { id: 'content-redaction' as SettingsSection, label: $t('settings.contentRedaction.title'), icon: 'eye-off' },
-        { id: 'llm-provider' as SettingsSection, label: $t('settings.llmProvider.title'), icon: 'brain' },
+        { id: 'custom-vocabulary' as SettingsSection, label: $t('settings.customVocabulary.title'), icon: 'list', cap: 'vocab.user' },
+        { id: 'content-redaction' as SettingsSection, label: $t('settings.contentRedaction.title'), icon: 'eye-off', cap: 'redaction.user' },
+        { id: 'llm-provider' as SettingsSection, label: $t('settings.llmProvider.title'), icon: 'brain', cap: 'llm.user_settings' },
         { id: 'organization-context' as SettingsSection, label: $t('settings.orgContext.title'), icon: 'briefcase' },
         { id: 'speaker-attributes' as SettingsSection, label: $t('settings.speakerAttributes.navTitle'), icon: 'user' },
-        { id: 'transcription' as SettingsSection, label: $t('settings.transcription.title'), icon: 'waveform' }
+        { id: 'transcription' as SettingsSection, label: $t('settings.transcription.title'), icon: 'waveform', cap: 'transcription.prefs' }
       ]
     },
     {
@@ -183,12 +193,17 @@
       items: [
         { id: 'audio-extraction' as SettingsSection, label: $t('settings.audioExtraction.title'), icon: 'file-audio' },
         { id: 'media-sources' as SettingsSection, label: $t('settings.mediaSources.title'), icon: 'link' },
-        { id: 'watch-sources' as SettingsSection, label: $t('settings.watchSources.title'), icon: 'eye' },
-        { id: 'recording' as SettingsSection, label: $t('settings.recording.title'), icon: 'mic' },
-        { id: 'download' as SettingsSection, label: $t('settings.download.title'), icon: 'download' }
+        { id: 'watch-sources' as SettingsSection, label: $t('settings.watchSources.title'), icon: 'eye', cap: 'watch_sources' },
+        { id: 'recording' as SettingsSection, label: $t('settings.recording.title'), icon: 'mic', cap: 'recording' },
+        { id: 'download' as SettingsSection, label: $t('settings.download.title'), icon: 'download', cap: 'exports' }
       ]
     }
-  ];
+  ]
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => capOn(capState, (item as { cap?: string }).cap))
+    }))
+    .filter((section) => section.items.length > 0);
 
   // Reactive recording settings change detection
   $: {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 
   // Import auth store
   import { authStore, isAuthenticated, initAuth, authReady, getAuthMethods } from "$stores/auth";
+  import { loadCapabilities } from "$stores/capabilities";
   import { theme } from "../stores/theme";
   import { locale } from "../stores/locale";
   import { llmStatusStore } from "../stores/llmStatus";
@@ -76,6 +77,10 @@
 
       // Initialize network connectivity monitoring
       networkStore.initialize();
+
+      // Edition capabilities (cloud hides platform/self-host surfaces).
+      // Fail-open: errors leave community defaults (everything visible).
+      void loadCapabilities();
 
       // Fetch auth methods to get banner settings
       try {

--- a/frontend/src/stores/capabilities.test.ts
+++ b/frontend/src/stores/capabilities.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('$lib/axios', () => ({
+  default: { get: vi.fn() },
+}));
+
+import axiosInstance from '$lib/axios';
+import { capabilities, isCapabilityEnabled, loadCapabilities } from './capabilities';
+
+const mockedGet = vi.mocked(axiosInstance.get);
+
+describe('capabilities store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capabilities.set({ edition: 'community', loaded: false, capabilities: {}, audience: {} });
+  });
+
+  it('defaults fail-open: unknown keys are enabled', () => {
+    const state = get(capabilities);
+    expect(isCapabilityEnabled(state, 'watch_sources')).toBe(true);
+    expect(isCapabilityEnabled(state, 'anything.unknown')).toBe(true);
+  });
+
+  it('loads the cloud edition map and disables hidden surfaces', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        edition: 'cloud',
+        capabilities: { watch_sources: false, billing: true },
+        audience: { billing: 'org_admin' },
+      },
+    });
+
+    await loadCapabilities();
+    const state = get(capabilities);
+
+    expect(state.edition).toBe('cloud');
+    expect(state.loaded).toBe(true);
+    expect(isCapabilityEnabled(state, 'watch_sources')).toBe(false);
+    expect(isCapabilityEnabled(state, 'billing')).toBe(true);
+    // Keys the resolver didn't mention stay enabled (fail-open)
+    expect(isCapabilityEnabled(state, 'recording')).toBe(true);
+    expect(state.audience['billing']).toBe('org_admin');
+  });
+
+  it('falls back to community defaults when the endpoint fails', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('network down'));
+
+    await loadCapabilities();
+    const state = get(capabilities);
+
+    expect(state.edition).toBe('community');
+    expect(state.loaded).toBe(true);
+    expect(isCapabilityEnabled(state, 'watch_sources')).toBe(true);
+  });
+});

--- a/frontend/src/stores/capabilities.ts
+++ b/frontend/src/stores/capabilities.ts
@@ -1,0 +1,59 @@
+/**
+ * Edition capabilities / entitlements store.
+ *
+ * Mirrors GET /api/system/capabilities — the backend decides which feature
+ * surfaces exist for this deployment (community: everything; cloud: the
+ * managed subset, tier-aware). The UI renders only enabled surfaces; the
+ * backend independently 404s disabled endpoints, so this is purely cosmetic
+ * gating on top of a real server-side gate.
+ *
+ * Fail-open by design: until the endpoint responds (or if it ever fails),
+ * the store holds community defaults so a self-hosted instance — or a blip
+ * during startup — never hides features.
+ */
+
+import { writable } from 'svelte/store';
+import axiosInstance from '$lib/axios';
+
+export type CapabilityAudience = 'user' | 'team' | 'org_admin' | 'platform';
+
+export interface CapabilitiesState {
+  edition: 'community' | 'cloud';
+  loaded: boolean;
+  capabilities: Record<string, boolean>;
+  audience: Record<string, CapabilityAudience>;
+}
+
+const COMMUNITY_DEFAULTS: CapabilitiesState = {
+  edition: 'community',
+  loaded: false,
+  capabilities: {},
+  audience: {},
+};
+
+export const capabilities = writable<CapabilitiesState>(COMMUNITY_DEFAULTS);
+
+/**
+ * True unless the backend explicitly disabled the key. Unknown keys default
+ * to enabled (fail-open) — the cloud resolver explicitly sets false for
+ * every surface it hides.
+ */
+export function isCapabilityEnabled(state: CapabilitiesState, key: string): boolean {
+  return state.capabilities[key] !== false;
+}
+
+/** Fetch once at app bootstrap; safe to call again (e.g. after login). */
+export async function loadCapabilities(): Promise<void> {
+  try {
+    const response = await axiosInstance.get('/system/capabilities');
+    capabilities.set({
+      edition: response.data?.edition === 'cloud' ? 'cloud' : 'community',
+      loaded: true,
+      capabilities: response.data?.capabilities ?? {},
+      audience: response.data?.audience ?? {},
+    });
+  } catch {
+    // Fail-open: keep community defaults (everything visible).
+    capabilities.set({ ...COMMUNITY_DEFAULTS, loaded: true });
+  }
+}


### PR DESCRIPTION
## What

Open-core extension seams enabling the commercial cloud edition (Clerk auth + Stripe billing live in the private `opentranscribe-cloud` repo and register into these seams at startup). **Community/self-hosted behavior is unchanged**: the verifier registry is empty (zero-overhead no-op), all new columns are nullable, all new tables start empty, capabilities default to everything-on, and hooks are no-ops.

- **Auth seam**: pluggable external token-verifier registry + `AUTH_TYPE_CLERK` + generic JIT user sync (race-safe, mirrors the Keycloak pattern; customer org roles never map to platform admin). `get_current_user` offers bearer tokens to registered verifiers before the local-JWT path.
- **Schema (migration v367, idempotent)**: `organization` (read-only billing/quota columns), `organization_membership` (authz mirror), `usage_event` (billing + analytics spine, idempotency-key unique), `user.clerk_id/clerk_org_id`, nullable `organization_id` on 8 resource tables; extends `users_auth_type_check` with 'clerk'.
- **Capabilities/entitlements**: server-driven feature gating with a four-audience taxonomy (user / team / org_admin / platform), `GET /system/capabilities`, `require_capability` 404 gates wired onto watch-sources / auth-config / llm-settings / asr-settings / engine-settings routers (platform-admin bypass).
- **Pipeline hooks**: before-dispatch (quota → HTTP 402 before any task record) + transcription-complete (metering) registries, fired in dispatch + the finalize chokepoint; failures contained.
- **Tenant context**: `get_current_context()` (membership mirror is the authority) + default-deny `scope_to_context()`.
- **Frontend**: $stores/capabilities (fail-open) + SettingsModal sidebar gating.
- CSRF exemption for signature-authenticated `/api/webhooks/*`.

## Testing
- 35 backend seam tests + 3 vitest store tests (new); adjacent auth + dispatch suites green
- svelte-check 899 files / 0 errors; vite build clean; settings e2e 6/6 vs live stack
- v367 verified on the live dev DB (additive) AND on a fresh DB via the full chain
- Cloud-edition e2e: isolated otcloud stack — 10/10 smoke checks (gated routers 404, capabilities map, webhook signature rejection)
- Security audit recorded in the private repo (`docs/SECURITY-AUDIT.md`); bandit clean

Plan reference: SaaS plan Tracks A–D (seam portion); reconciled with `docs/deployment/aws/SAAS-PLAN-RECONCILIATION.md`.