### PR TITLE
Embedded SQLite search (FTS5 + sqlite-vec) — local, daemon-free, OpenSearch-removable

### DIFF
--- a/backend/app/api/endpoints/search.py
+++ b/backend/app/api/endpoints/search.py
@@ -162,9 +162,14 @@ def search_transcripts(
     if search_mode not in ("hybrid", "keyword"):
         raise HTTPException(status_code=400, detail="search_mode must be: hybrid or keyword")
 
-    from app.services.search.hybrid_search_service import HybridSearchService
+    if settings.SEARCH_BACKEND.lower() == "sqlite":
+        from app.services.search.sqlite_hybrid_search_service import SQLiteHybridSearchService
 
-    search_service = HybridSearchService()
+        search_service = SQLiteHybridSearchService()
+    else:
+        from app.services.search.hybrid_search_service import HybridSearchService
+
+        search_service = HybridSearchService()
     response = search_service.search(
         query=q,
         user_id=current_user.id,
@@ -253,6 +258,30 @@ def trigger_reindex(
     Returns:
         Dict with task_id and status.
     """
+    if settings.SEARCH_BACKEND.lower() == "sqlite":
+        from app.db.session_utils import session_scope
+        from app.services.sqlite_search.api import sqlite_pending_file_uuids
+        from app.tasks.sqlite_search_indexing_task import sqlite_search_reindex_task
+
+        if pending_only and file_uuids is None:
+            with session_scope() as db:
+                file_uuids = sqlite_pending_file_uuids(db, current_user.id)
+            if not file_uuids:
+                return {
+                    "task_id": None,
+                    "status": "no_pending",
+                    "message": "All files are already indexed.",
+                    "backend": "sqlite",
+                }
+
+        task = sqlite_search_reindex_task.delay(user_id=current_user.id, file_uuids=file_uuids)
+        return {
+            "task_id": task.id,
+            "status": "started",
+            "message": "SQLite search re-indexing started.",
+            "backend": "sqlite",
+        }
+
     if pending_only and file_uuids is None:
         # Find file UUIDs that are NOT yet indexed in OpenSearch
         from sqlalchemy import exists
@@ -423,6 +452,17 @@ def reindex_status(
     Returns:
         Dict with total_files, indexed_files, pending info, current model.
     """
+    if settings.SEARCH_BACKEND.lower() == "sqlite":
+        from app.db.session_utils import session_scope
+        from app.services.sqlite_search.api import sqlite_reindex_status
+
+        with session_scope() as db:
+            return sqlite_reindex_status(
+                db,
+                current_user.id,
+                in_progress=_check_reindex_task_active(current_user.id),
+            )
+
     from sqlalchemy import exists
     from sqlalchemy import select
 

--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -77,6 +77,7 @@ celery_app = Celery(
         "app.tasks.search_maintenance_task",
         "app.tasks.opensearch_integrity_task",
         "app.tasks.search_indexing_task",
+        "app.tasks.sqlite_search_indexing_task",
         "app.tasks.redaction_task",
         "app.tasks.thumbnail",
         "app.tasks.thumbnail_migration",
@@ -164,6 +165,7 @@ celery_app.conf.update(
         "generate_thumbnail": {"queue": CeleryQueues.CPU},
         "migrate_thumbnails_to_webp": {"queue": CeleryQueues.CPU},
         "reindex_transcripts": {"queue": CeleryQueues.CPU},
+        "sqlite_search_reindex": {"queue": CeleryQueues.CPU},
         "reindex_batch": {"queue": CeleryQueues.CPU},
         "search_index_maintenance": {"queue": CeleryQueues.CPU},
         "opensearch_orphan_cleanup": {"queue": CeleryQueues.CPU},
@@ -279,6 +281,18 @@ celery_app.conf.update(
         },
     },
 )
+
+
+# When SQLite is the search backend, drop the OpenSearch-only maintenance beats so
+# the OpenSearch JVM can be turned off without periodic non-fatal warnings. Manual
+# dispatch still works; only the automatic schedule is removed.
+if settings.SEARCH_BACKEND.lower() == "sqlite":
+    for _opensearch_beat in (
+        "search-index-maintenance",
+        "opensearch-orphan-cleanup",
+        "embedding-consistency-check",
+    ):
+        celery_app.conf.beat_schedule.pop(_opensearch_beat, None)
 
 
 # Apply our logging config (text/JSON per settings.LOG_FORMAT) to Celery.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,6 +118,13 @@ async def _setup_minio():
     through presigned URLs, so public read is unnecessary and a security risk.
     """
     try:
+        from app.services.storage.routing import filesystem_enabled, local_storage
+
+        if filesystem_enabled():
+            local_storage().ensure_ready()
+            logger.info("Filesystem storage ready")
+            return
+
         import json
 
         from minio import Minio
@@ -411,6 +418,9 @@ async def _initialize_neural_search():
     For offline/air-gapped deployments, models are loaded from
     pre-downloaded local files (mounted at /ml-models in OpenSearch container).
     """
+    if settings.SEARCH_BACKEND.lower() == "sqlite":
+        logger.info("SQLite search backend active, skipping OpenSearch neural init")
+        return
     if not settings.OPENSEARCH_NEURAL_SEARCH_ENABLED:
         logger.info("Neural search disabled, skipping initialization")
         return
@@ -527,32 +537,35 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Initial data seeding failed (non-fatal): {e}")
 
-    # Check OpenSearch index health (auto-repair corrupted shards from unclean shutdowns)
-    try:
-        from app.services.opensearch_service import check_and_repair_indices
-        from app.services.opensearch_service import ensure_indices_exist
-        from app.services.opensearch_service import ensure_v4_index_exists
-
-        ensure_indices_exist()
-        ensure_v4_index_exists()
-        check_and_repair_indices()
-    except Exception as e:
-        logger.warning(f"OpenSearch startup health check failed (non-fatal): {e}")
-
-    # Sync speaker profile data from PostgreSQL to OpenSearch
-    try:
-        from app.db.base import SessionLocal
-        from app.services.opensearch_service import sync_speaker_profiles_to_opensearch
-
-        _db = SessionLocal()
+    # OpenSearch boot init (index health + speaker sync) is skipped entirely when
+    # SQLite is the search backend, so the JVM can be turned off; best-effort otherwise.
+    if settings.SEARCH_BACKEND.lower() != "sqlite":
+        # Check OpenSearch index health (auto-repair corrupted shards from unclean shutdowns)
         try:
-            sync_result = sync_speaker_profiles_to_opensearch(_db)
-            if sync_result["updated"] > 0:
-                logger.info(f"Speaker profile sync: {sync_result}")
-        finally:
-            _db.close()
-    except Exception as e:
-        logger.warning(f"Speaker profile sync failed (non-fatal): {e}")
+            from app.services.opensearch_service import check_and_repair_indices
+            from app.services.opensearch_service import ensure_indices_exist
+            from app.services.opensearch_service import ensure_v4_index_exists
+
+            ensure_indices_exist()
+            ensure_v4_index_exists()
+            check_and_repair_indices()
+        except Exception as e:
+            logger.warning(f"OpenSearch startup health check failed (non-fatal): {e}")
+
+        # Sync speaker profile data from PostgreSQL to OpenSearch
+        try:
+            from app.db.base import SessionLocal
+            from app.services.opensearch_service import sync_speaker_profiles_to_opensearch
+
+            _db = SessionLocal()
+            try:
+                sync_result = sync_speaker_profiles_to_opensearch(_db)
+                if sync_result["updated"] > 0:
+                    logger.info(f"Speaker profile sync: {sync_result}")
+            finally:
+                _db.close()
+        except Exception as e:
+            logger.warning(f"Speaker profile sync failed (non-fatal): {e}")
 
     # Apply the admin-configured derived-cache retention (DB over env) so the MinIO
     # lifecycle rule reflects UI changes after a restart — no redeploy needed. Also
@@ -589,7 +602,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Migration state cleanup failed (non-fatal): {e}")
 
-    logger.info("Setting up MinIO and task recovery...")
+    logger.info("Setting up object storage and task recovery...")
     minio_task = asyncio.create_task(_setup_minio())
     recovery_task = asyncio.create_task(_run_startup_recovery())
     search_maintenance = asyncio.create_task(_run_search_maintenance())
@@ -758,12 +771,18 @@ def readiness_check():
     except Exception as exc:  # noqa: BLE001
         checks["opensearch"] = f"error: {type(exc).__name__}"
 
-    # MinIO (degraded-but-ready) — reuse the existing client singleton.
+    # Object storage (degraded-but-ready) — use the selected backend.
     try:
-        from app.services.minio_service import minio_client
+        from app.services.storage.routing import filesystem_enabled, local_storage
 
-        minio_client.bucket_exists(settings.MEDIA_BUCKET_NAME)
-        checks["minio"] = "ok"
+        if filesystem_enabled():
+            local_storage().ensure_ready()
+            checks["minio"] = "skipped: filesystem storage"
+        else:
+            from app.services.minio_service import minio_client
+
+            minio_client.bucket_exists(settings.MEDIA_BUCKET_NAME)
+            checks["minio"] = "ok"
     except Exception as exc:  # noqa: BLE001
         checks["minio"] = f"error: {type(exc).__name__}"
 

--- a/backend/app/services/sqlite_search/__init__.py
+++ b/backend/app/services/sqlite_search/__init__.py
@@ -1,0 +1,5 @@
+"""Embedded SQLite search backend."""
+
+from .store import SQLiteSearchStore
+
+__all__ = ["SQLiteSearchStore"]

--- a/backend/app/services/sqlite_search/api.py
+++ b/backend/app/services/sqlite_search/api.py
@@ -1,0 +1,63 @@
+"""API helpers for the embedded SQLite search index."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+
+def _indexable_file_uuids(db, user_id: int) -> set[str]:
+    """Return completed transcript-bearing file UUIDs for one user."""
+    from sqlalchemy import exists
+    from sqlalchemy import select
+
+    from app.models.media import FileStatus, MediaFile, TranscriptSegment
+
+    has_segments = exists(
+        select(TranscriptSegment.id).where(TranscriptSegment.media_file_id == MediaFile.id)
+    )
+    rows = (
+        db.query(MediaFile.uuid)
+        .filter(MediaFile.user_id == user_id, MediaFile.status == FileStatus.COMPLETED, has_segments)
+        .all()
+    )
+    return {str(row[0]) for row in rows}
+
+
+def _indexed_file_uuids(user_id: int) -> set[str]:
+    """Return file UUIDs currently present in the SQLite text index."""
+    store = SQLiteSearchStore(settings.SQLITE_SEARCH_PATH)
+    with store.connect() as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT file_uuid FROM transcript_chunk WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def sqlite_reindex_status(db, user_id: int, in_progress: bool = False) -> dict[str, Any]:
+    """Return API-compatible status for the embedded SQLite search index."""
+    from app.services.sqlite_search.orchestrator import SQLiteSearchOrchestrator
+
+    all_uuids = _indexable_file_uuids(db, user_id)
+    indexed_uuids = _indexed_file_uuids(user_id)
+    state = SQLiteSearchOrchestrator(SQLiteSearchStore(settings.SQLITE_SEARCH_PATH)).status()
+    return {
+        "total_files": len(all_uuids),
+        "indexed_files": len(indexed_uuids & all_uuids),
+        "pending_files": len(all_uuids - indexed_uuids),
+        "in_progress": in_progress or state.get("status") == "running",
+        "stop_requested": False,
+        "current_model": "sqlite-fts5-sqlite-vec",
+        "current_dimension": 512,
+        "last_indexed_at": state.get("finished_at"),
+        "backend": "sqlite",
+        "counts": state.get("counts", {}),
+        "job": {k: v for k, v in state.items() if k != "counts"},
+    }
+
+
+def sqlite_pending_file_uuids(db, user_id: int) -> list[str]:
+    """Return completed file UUIDs missing from the SQLite text index."""
+    return sorted(_indexable_file_uuids(db, user_id) - _indexed_file_uuids(user_id))

--- a/backend/app/services/sqlite_search/context_import.py
+++ b/backend/app/services/sqlite_search/context_import.py
@@ -1,0 +1,101 @@
+"""Import external context records into SQLite FTS search."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+SEARCHABLE_KINDS = {"ocr_text", "screen_context_report", "screen_activity_insights"}
+
+
+def _stable_negative_id(*parts: object) -> int:
+    """Return a deterministic negative SQLite row id."""
+    digest = hashlib.sha256("|".join(str(p) for p in parts).encode()).hexdigest()
+    return -(int(digest[:15], 16) % 9_000_000_000_000_000 + 1)
+
+
+def _record_text(record: dict[str, Any]) -> str:
+    """Build searchable text for one supported context record."""
+    kind = record.get("kind")
+    if kind == "ocr_text":
+        return "\n".join(
+            str(record.get(k) or "").strip()
+            for k in ("window_title", "text")
+            if str(record.get(k) or "").strip()
+        )
+    if kind == "screen_context_report":
+        return "\n".join(
+            str(record.get(k) or "").strip()
+            for k in ("activity_label", "app_or_window", "summary")
+            if str(record.get(k) or "").strip()
+        )
+    if kind == "screen_activity_insights":
+        return json.dumps({
+            "activity_mix": record.get("activity_mix", {}),
+            "active_hours": record.get("active_hours", {}),
+            "active_days": record.get("active_days", {}),
+            "top_apps": record.get("top_apps", []),
+        }, sort_keys=True)
+    return ""
+
+
+def _record_time(record: dict[str, Any]) -> str:
+    """Return the best timestamp for sorting/filtering."""
+    return str(record.get("captured_at") or record.get("window_start") or "")
+
+
+def context_row(record: dict[str, Any], user_id: int | None = None) -> dict[str, Any] | None:
+    """Convert a Rewind/HiNotes context record into a search row."""
+    kind = str(record.get("kind") or "")
+    text = _record_text(record)
+    if kind not in SEARCHABLE_KINDS or not text.strip():
+        return None
+    source_id = str(record.get("source_id") or record.get("content_hash") or kind)
+    recording = str(record.get("recording_id") or source_id)
+    title = str(record.get("app_or_window") or record.get("window_title") or f"{kind} {recording}")
+    return {
+        "id": _stable_negative_id(record.get("source", "context"), kind, source_id),
+        "file_id": _stable_negative_id(record.get("source", "context"), recording),
+        "file_uuid": f"{record.get('source', 'context')}:{recording}",
+        "user_id": user_id,
+        "source": kind,
+        "title": title,
+        "speaker": None,
+        "start_time": None,
+        "end_time": None,
+        "upload_time": _record_time(record),
+        "content_type": "text/plain",
+        "duration": None,
+        "file_size": len(text.encode()),
+        "language": "",
+        "content": text,
+    }
+
+
+def records_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract records from a payload or a single insights object."""
+    if isinstance(payload.get("records"), list):
+        return list(payload["records"])
+    return [payload] if payload.get("kind") in SEARCHABLE_KINDS else []
+
+
+def import_context_payloads(
+    sqlite_path: str,
+    payload_paths: list[Path],
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    """Import context JSON payloads into the SQLite FTS table."""
+    store = SQLiteSearchStore(sqlite_path)
+    rows: list[dict[str, Any]] = []
+    for path in payload_paths:
+        payload = json.loads(path.expanduser().read_text())
+        rows.extend(row for record in records_from_payload(payload) if (row := context_row(record, user_id)))
+    with store.connect() as conn:
+        for row in rows:
+            store.upsert_transcript_chunk(conn, row)
+        conn.commit()
+        summary = store.log_summary(conn)
+    return {**summary, "context_rows_seen": len(rows)}

--- a/backend/app/services/sqlite_search/gallery_import.py
+++ b/backend/app/services/sqlite_search/gallery_import.py
@@ -1,0 +1,43 @@
+"""Import Auris clean speaker centroids into sqlite-vec."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore, VECTOR_DIM
+
+MODEL = "sherpa-3dspeaker"
+
+
+def load_centroids(path: str | Path) -> list[dict[str, Any]]:
+    """Load name -> 512-d centroid JSON as deterministic rows."""
+    data = json.loads(Path(path).read_text())
+    rows: list[dict[str, Any]] = []
+    for rowid, name in enumerate(sorted(data), start=1):
+        vector = data[name]
+        if len(vector) != VECTOR_DIM:
+            raise ValueError(f"{name}: expected {VECTOR_DIM}-d vector, got {len(vector)}")
+        rows.append({
+            "rowid": rowid,
+            "speaker_id": None,
+            "profile_id": None,
+            "name": name,
+            "model": MODEL,
+            "embedding": vector,
+        })
+    return rows
+
+
+def import_gallery(sqlite_path: str | Path, centroids_path: str | Path) -> dict[str, Any]:
+    """Import all Auris clean centroids into SQLite speaker vectors."""
+    rows = load_centroids(centroids_path)
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        conn.execute("DELETE FROM speaker_vec")
+        conn.execute("DELETE FROM speaker_vec_meta")
+        for row in rows:
+            store.upsert_speaker_vector(conn, row)
+        conn.commit()
+        summary = store.log_summary(conn)
+    return {**summary, "rows_seen": len(rows), "source": str(centroids_path)}

--- a/backend/app/services/sqlite_search/gallery_parity.py
+++ b/backend/app/services/sqlite_search/gallery_parity.py
@@ -1,0 +1,54 @@
+"""Compare canonical Auris gallery decisions with sqlite-vec decisions."""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+
+def _l2(a: list[float], b: list[float]) -> float:
+    """Return Euclidean distance between two vectors."""
+    return math.sqrt(sum((x - y) * (x - y) for x, y in zip(a, b)))
+
+
+def _top_from_gallery(centroids: dict[str, list[float]], vector: list[float]) -> dict[str, Any]:
+    """Return nearest gallery row by L2 distance."""
+    name, distance = min(((name, _l2(vec, vector)) for name, vec in centroids.items()), key=lambda x: x[1])
+    return {"name": name, "distance": distance}
+
+
+def compare_gallery_decision(sqlite_path: str, centroids_path: str | Path, query_name: str) -> dict[str, Any]:
+    """Compare canonical JSON-gallery and sqlite-vec top match for one speaker."""
+    centroids = json.loads(Path(centroids_path).read_text())
+    if query_name not in centroids:
+        raise KeyError(f"speaker not in gallery: {query_name}")
+    vector = [float(item) for item in centroids[query_name]]
+    gallery_top = _top_from_gallery(centroids, vector)
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        sqlite_rows = store.search_speaker_vectors(conn, vector, limit=1)
+    sqlite_top = sqlite_rows[0] if sqlite_rows else None
+    sqlite_name = sqlite_top.get("name") if sqlite_top else None
+    return {
+        "query_name": query_name,
+        "gallery_top": gallery_top["name"],
+        "sqlite_top": sqlite_name,
+        "match": gallery_top["name"] == sqlite_name,
+        "gallery_distance": gallery_top["distance"],
+        "sqlite_distance": sqlite_top.get("distance") if sqlite_top else None,
+    }
+
+
+def compare_gallery_sample(sqlite_path: str, centroids_path: str | Path, limit: int = 10) -> dict[str, Any]:
+    """Compare deterministic first-N gallery names against sqlite-vec."""
+    centroids = json.loads(Path(centroids_path).read_text())
+    results = [compare_gallery_decision(sqlite_path, centroids_path, name) for name in sorted(centroids)[:limit]]
+    return {
+        "sample_size": len(results),
+        "matches": sum(1 for item in results if item["match"]),
+        "mismatches": [item for item in results if not item["match"]],
+        "results": results,
+    }

--- a/backend/app/services/sqlite_search/hybrid.py
+++ b/backend/app/services/sqlite_search/hybrid.py
@@ -1,0 +1,41 @@
+"""Hybrid ranking helpers for embedded SQLite search."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _ranked_file_ids(rows: list[dict[str, Any]]) -> list[int]:
+    """Return unique file ids preserving row order."""
+    seen: set[int] = set()
+    out: list[int] = []
+    for row in rows:
+        file_id = row.get("file_id")
+        if file_id is None or int(file_id) in seen:
+            continue
+        seen.add(int(file_id))
+        out.append(int(file_id))
+    return out
+
+
+def rrf_fuse(
+    text_rows: list[dict[str, Any]],
+    vector_rows: list[dict[str, Any]],
+    *,
+    rank_constant: int = 30,
+) -> list[dict[str, Any]]:
+    """Fuse ranked text/vector rows with Reciprocal Rank Fusion."""
+    scores: dict[int, float] = {}
+    ranks: dict[int, dict[str, int]] = {}
+    for source, ids in (("text", _ranked_file_ids(text_rows)), ("vector", _ranked_file_ids(vector_rows))):
+        for rank, file_id in enumerate(ids, start=1):
+            scores[file_id] = scores.get(file_id, 0.0) + 1.0 / (rank_constant + rank)
+            ranks.setdefault(file_id, {})[source] = rank
+    return [
+        {"file_id": file_id, "score": score, "ranks": ranks.get(file_id, {})}
+        for file_id, score in sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def hybrid_text_only(text_rows: list[dict[str, Any]], *, rank_constant: int = 30) -> list[dict[str, Any]]:
+    """Return hybrid-shaped ranking when only FTS rows are available."""
+    return rrf_fuse(text_rows, [], rank_constant=rank_constant)

--- a/backend/app/services/sqlite_search/orchestrator.py
+++ b/backend/app/services/sqlite_search/orchestrator.py
@@ -1,0 +1,98 @@
+"""Local orchestration for embedded SQLite search indexing."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from app.services.sqlite_search.reindexer import SQLiteTranscriptReindexer
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+STATUS_KEY = "sqlite_search_reindex_status"
+
+
+def _now() -> str:
+    """Return an ISO timestamp for persisted job status."""
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class ReindexSlice:
+    """Bounded search indexing request."""
+    user_id: int
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+    limit: int | None = None
+    file_uuids: list[str] | None = None
+
+
+@dataclass(frozen=True)
+class JobStatus:
+    """Persisted status for the latest local search indexing job."""
+    status: str
+    attempts: int
+    started_at: str
+    finished_at: str | None = None
+    error: str | None = None
+    summary: dict[str, Any] = field(default_factory=dict)
+
+
+class SQLiteSearchOrchestrator:
+    """Coordinates bounded SQLite search indexing with status and retries."""
+
+    def __init__(
+        self,
+        store: SQLiteSearchStore,
+        reindexer: SQLiteTranscriptReindexer | None = None,
+        max_attempts: int = 2,
+    ):
+        self.store = store
+        self.reindexer = reindexer or SQLiteTranscriptReindexer(store)
+        self.max_attempts = max(1, max_attempts)
+
+    def status(self) -> dict[str, Any]:
+        """Return the latest persisted status plus current index counts."""
+        with self.store.connect() as conn:
+            row = conn.execute("SELECT value FROM search_meta WHERE key = ?", (STATUS_KEY,)).fetchone()
+            counts = self.store.count_summary(conn)
+        state = json.loads(row[0]) if row else {"status": "idle", "attempts": 0}
+        return {**state, "counts": counts}
+
+    def run_reindex(self, db, index_slice: ReindexSlice) -> dict[str, Any]:
+        """Run a bounded reindex with retry-visible status."""
+        started = _now()
+        last_error = None
+        for attempt in range(1, self.max_attempts + 1):
+            self._write(JobStatus("running", attempt, started, error=last_error))
+            try:
+                rows = self.reindexer.rows_for_slice(db, **asdict(index_slice))
+                summary = self.reindexer.reindex_rows(rows)
+                status = JobStatus("completed", attempt, started, _now(), summary=summary)
+                self._write(status)
+                return {**asdict(status), "elapsed_ms": self._elapsed_ms(started)}
+            except Exception as exc:  # pragma: no cover - message preserved in tests
+                last_error = str(exc)
+                if attempt >= self.max_attempts:
+                    failed = JobStatus("failed", attempt, started, _now(), error=last_error)
+                    self._write(failed)
+                    return {**asdict(failed), "elapsed_ms": self._elapsed_ms(started)}
+                time.sleep(0.05 * attempt)
+        return self.status()
+
+    def _write(self, status: JobStatus) -> None:
+        """Persist a job status snapshot."""
+        with self.store.connect() as conn:
+            conn.execute(
+                "INSERT INTO search_meta(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (STATUS_KEY, json.dumps(asdict(status), sort_keys=True)),
+            )
+            conn.commit()
+
+    @staticmethod
+    def _elapsed_ms(started_at: str) -> int:
+        """Return elapsed milliseconds from a persisted timestamp."""
+        started = datetime.fromisoformat(started_at)
+        return int((datetime.now(UTC) - started).total_seconds() * 1000)

--- a/backend/app/services/sqlite_search/parity.py
+++ b/backend/app/services/sqlite_search/parity.py
@@ -1,0 +1,56 @@
+"""Parity checks between SQLite FTS and OpenSearch chunk search."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+
+def _ids(rows: list[dict[str, Any]]) -> list[int]:
+    """Return unique file IDs preserving rank order."""
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for row in rows:
+        file_id = int(row["file_id"])
+        if file_id not in seen:
+            seen.add(file_id)
+            ordered.append(file_id)
+    return ordered
+
+
+def _opensearch_rows(query: str, limit: int) -> list[dict[str, Any]]:
+    """Fetch OpenSearch chunk hits for a keyword query."""
+    from app.core.config import settings
+    from app.services.opensearch_service import get_opensearch_client
+
+    client = get_opensearch_client()
+    if client is None:
+        return []
+    body = {
+        "size": limit,
+        "query": {"multi_match": {"query": query, "fields": ["content", "title"]}},
+        "_source": ["file_id", "file_uuid", "title", "content", "start_time"],
+    }
+    response = client.search(index=settings.OPENSEARCH_CHUNKS_INDEX, body=body)
+    return [dict(hit.get("_source", {}), score=hit.get("_score")) for hit in response["hits"]["hits"]]
+
+
+def compare_fts(query: str, sqlite_path: str, limit: int = 10) -> dict[str, Any]:
+    """Compare SQLite FTS and OpenSearch chunk results for one query."""
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        sqlite_rows = store.search_text(conn, query, limit=limit)
+    os_rows = _opensearch_rows(query, limit)
+    sqlite_ids = _ids(sqlite_rows)
+    os_ids = _ids(os_rows)
+    overlap = sorted(set(sqlite_ids).intersection(os_ids))
+    return {
+        "query": query,
+        "sqlite_count": len(sqlite_rows),
+        "opensearch_count": len(os_rows),
+        "sqlite_file_ids": sqlite_ids,
+        "opensearch_file_ids": os_ids,
+        "overlap_file_ids": overlap,
+        "missing_from_sqlite": sorted(set(os_ids) - set(sqlite_ids)),
+        "missing_from_opensearch": sorted(set(sqlite_ids) - set(os_ids)),
+    }

--- a/backend/app/services/sqlite_search/reindexer.py
+++ b/backend/app/services/sqlite_search/reindexer.py
@@ -19,8 +19,25 @@ def _date_filter(query, media_model, date_from: datetime | None, date_to: dateti
 class SQLiteTranscriptReindexer:
     """Indexes bounded completed transcript segments into SQLite FTS."""
 
-    def __init__(self, store: SQLiteSearchStore):
+    MODEL_NAME = "all-MiniLM-L6-v2"
+
+    def __init__(self, store: SQLiteSearchStore, embedder: Any = None):
         self.store = store
+        self._embedder = embedder
+        self._embedder_ready = embedder is not None
+
+    def _encode(self, rows: list[dict[str, Any]]) -> list[list[float]]:
+        """Locally embed row contents; [] if the local model is unavailable (text stays indexed)."""
+        if not rows:
+            return []
+        try:
+            if not self._embedder_ready:
+                from app.services.sqlite_search.transcript_embedder import LocalMiniLMEmbedder
+                self._embedder = LocalMiniLMEmbedder()
+                self._embedder_ready = True
+            return self._embedder.encode([row["content"] for row in rows])
+        except Exception:
+            return []
 
     def rows_for_slice(
         self,
@@ -69,10 +86,17 @@ class SQLiteTranscriptReindexer:
         return rows
 
     def reindex_rows(self, rows: list[dict[str, Any]]) -> dict[str, int | bool]:
-        """Write rows into SQLite and return orchestrator count summary."""
+        """Write rows into SQLite (FTS text + local semantic vectors) and return counts."""
+        vectors = self._encode(rows)
         with self.store.connect() as conn:
             for row in rows:
                 self.store.upsert_transcript_chunk(conn, row)
+            for row, embedding in zip(rows, vectors):
+                self.store.upsert_transcript_vector(conn, {
+                    "rowid": int(row["id"]), "chunk_id": int(row["id"]),
+                    "file_id": row["file_id"], "file_uuid": row["file_uuid"],
+                    "model": self.MODEL_NAME, "embedding": embedding,
+                })
             conn.commit()
             summary = self.store.log_summary(conn)
-        return {**summary, "rows_seen": len(rows)}
+        return {**summary, "rows_seen": len(rows), "vectors_indexed": len(vectors)}

--- a/backend/app/services/sqlite_search/reindexer.py
+++ b/backend/app/services/sqlite_search/reindexer.py
@@ -1,0 +1,78 @@
+"""Bounded transcript reindexing into embedded SQLite search."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+
+def _date_filter(query, media_model, date_from: datetime | None, date_to: datetime | None):
+    """Apply optional upload_time bounds."""
+    if date_from is not None:
+        query = query.filter(media_model.upload_time >= date_from)
+    if date_to is not None:
+        query = query.filter(media_model.upload_time < date_to)
+    return query
+
+
+class SQLiteTranscriptReindexer:
+    """Indexes bounded completed transcript segments into SQLite FTS."""
+
+    def __init__(self, store: SQLiteSearchStore):
+        self.store = store
+
+    def rows_for_slice(
+        self,
+        db,
+        *,
+        user_id: int,
+        date_from=None,
+        date_to=None,
+        limit: int | None = None,
+        file_uuids: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch completed transcript rows for one bounded user slice."""
+        from app.models.media import FileStatus, MediaFile, Speaker, TranscriptSegment
+
+        query = (
+            db.query(TranscriptSegment, MediaFile, Speaker)
+            .join(MediaFile, MediaFile.id == TranscriptSegment.media_file_id)
+            .outerjoin(Speaker, Speaker.id == TranscriptSegment.speaker_id)
+            .filter(MediaFile.user_id == user_id, MediaFile.status == FileStatus.COMPLETED)
+            .order_by(MediaFile.upload_time, TranscriptSegment.start_time)
+        )
+        query = _date_filter(query, MediaFile, date_from, date_to)
+        if file_uuids:
+            query = query.filter(MediaFile.uuid.in_(file_uuids))
+        if limit is not None:
+            query = query.limit(limit)
+        rows = []
+        for segment, media, speaker in query.all():
+            rows.append({
+                "id": int(segment.id),
+                "file_id": int(media.id),
+                "file_uuid": str(media.uuid),
+                "user_id": int(media.user_id),
+                "source": "transcript",
+                "title": str(media.title or media.filename),
+                "speaker": str(speaker.display_name or speaker.name) if speaker else None,
+                "start_time": float(segment.start_time),
+                "end_time": float(segment.end_time),
+                "upload_time": media.upload_time.isoformat() if media.upload_time else "",
+                "content_type": str(media.content_type or ""),
+                "duration": float(media.duration or 0.0),
+                "file_size": int(media.file_size or 0),
+                "language": str(media.language or ""),
+                "content": str(segment.text),
+            })
+        return rows
+
+    def reindex_rows(self, rows: list[dict[str, Any]]) -> dict[str, int | bool]:
+        """Write rows into SQLite and return orchestrator count summary."""
+        with self.store.connect() as conn:
+            for row in rows:
+                self.store.upsert_transcript_chunk(conn, row)
+            conn.commit()
+            summary = self.store.log_summary(conn)
+        return {**summary, "rows_seen": len(rows)}

--- a/backend/app/services/sqlite_search/speaker_parity.py
+++ b/backend/app/services/sqlite_search/speaker_parity.py
@@ -1,0 +1,64 @@
+"""Speaker-vector import and parity helpers for SQLite search."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore
+
+
+def _speaker_doc_rows(limit: int = 500) -> list[dict[str, Any]]:
+    """Read current OpenSearch speaker docs with embeddings."""
+    from app.core.constants import get_speaker_index
+    from app.services.opensearch_service import get_opensearch_client
+
+    client = get_opensearch_client()
+    if client is None:
+        return []
+    body = {
+        "size": limit,
+        "query": {"exists": {"field": "embedding"}},
+        "_source": ["speaker_id", "profile_id", "name", "embedding", "embedding_model"],
+    }
+    hits = client.search(index=get_speaker_index(), body=body)["hits"]["hits"]
+    rows = []
+    for idx, hit in enumerate(hits, start=1):
+        src = hit.get("_source", {})
+        if len(src.get("embedding") or []) != 512:
+            continue
+        rows.append({
+            "rowid": idx,
+            "speaker_id": src.get("speaker_id"),
+            "profile_id": src.get("profile_id"),
+            "name": src.get("name"),
+            "model": src.get("embedding_model") or "sherpa-3dspeaker",
+            "embedding": src["embedding"],
+        })
+    return rows
+
+
+def import_speaker_vectors(sqlite_path: str, limit: int = 500) -> dict[str, Any]:
+    """Copy current OpenSearch speaker vectors into SQLite for parity."""
+    rows = _speaker_doc_rows(limit=limit)
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        for row in rows:
+            store.upsert_speaker_vector(conn, row)
+        conn.commit()
+        summary = store.log_summary(conn)
+    return {**summary, "rows_seen": len(rows)}
+
+
+def compare_speaker_vector(vector, sqlite_path: str, limit: int = 5) -> dict[str, Any]:
+    """Compare top speaker IDs from SQLite and current OpenSearch."""
+    from app.services.opensearch_service import find_matching_speaker
+
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        sqlite_rows = store.search_speaker_vectors(conn, vector, limit=limit)
+    os_match = find_matching_speaker(list(vector), user_id=0, threshold=-1.0)
+    return {
+        "sqlite_count": len(sqlite_rows),
+        "sqlite_top_speaker_id": sqlite_rows[0].get("speaker_id") if sqlite_rows else None,
+        "opensearch_top_speaker_id": os_match.get("speaker_id") if os_match else None,
+        "has_sample": bool(sqlite_rows or os_match),
+    }

--- a/backend/app/services/sqlite_search/store.py
+++ b/backend/app/services/sqlite_search/store.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import sqlite3
 import contextlib
+import math
 import struct
 from pathlib import Path
 from typing import Iterable
@@ -9,6 +10,15 @@ import sqlite_vec
 VECTOR_DIM = 512
 TRANSCRIPT_VECTOR_DIM = 384
 VECTOR_WARN_THRESHOLD = 100_000
+
+
+def _pack_unit(values: Iterable[float], dim: int) -> bytes:
+    """Validate + L2-normalize + pack: unit vectors make sqlite-vec's L2 distance rank like cosine."""
+    vector = tuple(float(item) for item in values)
+    if len(vector) != dim:
+        raise ValueError(f"expected {dim}-d vector, got {len(vector)}")
+    norm = math.sqrt(sum(component * component for component in vector)) or 1.0
+    return struct.pack(f"{dim}f", *(component / norm for component in vector))
 SCHEMA = (
     "CREATE TABLE IF NOT EXISTS search_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
     "CREATE TABLE IF NOT EXISTS transcript_chunk ("
@@ -54,11 +64,8 @@ class SQLiteSearchStore:
 
     @staticmethod
     def vector_blob(values: Iterable[float]) -> bytes:
-        """Pack exactly one 512-d float vector for sqlite-vec."""
-        vector = tuple(float(item) for item in values)
-        if len(vector) != VECTOR_DIM:
-            raise ValueError(f"expected {VECTOR_DIM}-d vector, got {len(vector)}")
-        return struct.pack(f"{VECTOR_DIM}f", *vector)
+        """Pack one 512-d speaker vector as a unit vector (L2 rank == cosine rank)."""
+        return _pack_unit(values, VECTOR_DIM)
 
     @staticmethod
     def count_summary(conn: sqlite3.Connection) -> dict[str, int | bool]:
@@ -129,11 +136,8 @@ class SQLiteSearchStore:
 
     @staticmethod
     def transcript_vector_blob(values: Iterable[float]) -> bytes:
-        """Pack exactly one 384-d transcript vector."""
-        vector = tuple(float(item) for item in values)
-        if len(vector) != TRANSCRIPT_VECTOR_DIM:
-            raise ValueError(f"expected {TRANSCRIPT_VECTOR_DIM}-d vector, got {len(vector)}")
-        return struct.pack(f"{TRANSCRIPT_VECTOR_DIM}f", *vector)
+        """Pack one 384-d transcript vector as a unit vector (L2 rank == cosine rank)."""
+        return _pack_unit(values, TRANSCRIPT_VECTOR_DIM)
 
     def upsert_transcript_vector(self, conn: sqlite3.Connection, row: dict) -> None:
         """Upsert one transcript semantic vector."""

--- a/backend/app/services/sqlite_search/store.py
+++ b/backend/app/services/sqlite_search/store.py
@@ -1,0 +1,197 @@
+"""SQLite FTS5 + sqlite-vec store foundation."""
+from __future__ import annotations
+import sqlite3
+import contextlib
+import struct
+from pathlib import Path
+from typing import Iterable
+import sqlite_vec
+VECTOR_DIM = 512
+TRANSCRIPT_VECTOR_DIM = 384
+VECTOR_WARN_THRESHOLD = 100_000
+SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS search_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS transcript_chunk ("
+    "id INTEGER PRIMARY KEY, file_id INTEGER NOT NULL, file_uuid TEXT NOT NULL, "
+    "user_id INTEGER, source TEXT NOT NULL, title TEXT, speaker TEXT, "
+    "start_time REAL, end_time REAL, upload_time TEXT, content_type TEXT, "
+    "duration REAL, file_size INTEGER, language TEXT, content TEXT NOT NULL)",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS transcript_chunk_fts USING fts5(content, title, speaker)",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS speaker_vec USING vec0(embedding float[512])",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS transcript_vec USING vec0(embedding float[384])",
+    "CREATE TABLE IF NOT EXISTS transcript_vec_meta ("
+    "rowid INTEGER PRIMARY KEY, chunk_id INTEGER NOT NULL, file_id INTEGER NOT NULL, file_uuid TEXT NOT NULL, model TEXT)",
+    "CREATE TABLE IF NOT EXISTS speaker_vec_meta ("
+    "rowid INTEGER PRIMARY KEY, speaker_id INTEGER, profile_id INTEGER, name TEXT, model TEXT NOT NULL)",
+)
+class SQLiteSearchStore:
+    """Owns the embedded SQLite search database."""
+    def __init__(self, path: str | Path):
+        self.path = Path(path).expanduser()
+    def connect(self) -> sqlite3.Connection:
+        """Open SQLite, enable WAL, load sqlite-vec, and ensure schema."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        self.ensure_schema(conn)
+        return conn
+
+    @staticmethod
+    def ensure_schema(conn: sqlite3.Connection) -> None:
+        """Create the foundation FTS/vector schema."""
+        for statement in SCHEMA:
+            conn.execute(statement)
+        for name, kind in (
+            ("user_id", "INTEGER"), ("upload_time", "TEXT"), ("content_type", "TEXT"),
+            ("duration", "REAL"), ("file_size", "INTEGER"), ("language", "TEXT"),
+        ):
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(f"ALTER TABLE transcript_chunk ADD COLUMN {name} {kind}")
+        conn.commit()
+
+    @staticmethod
+    def vector_blob(values: Iterable[float]) -> bytes:
+        """Pack exactly one 512-d float vector for sqlite-vec."""
+        vector = tuple(float(item) for item in values)
+        if len(vector) != VECTOR_DIM:
+            raise ValueError(f"expected {VECTOR_DIM}-d vector, got {len(vector)}")
+        return struct.pack(f"{VECTOR_DIM}f", *vector)
+
+    @staticmethod
+    def count_summary(conn: sqlite3.Connection) -> dict[str, int | bool]:
+        """Return index counts and whether brute-force warning threshold is crossed."""
+        chunks = int(conn.execute("SELECT count(*) FROM transcript_chunk").fetchone()[0])
+        vectors = int(conn.execute("SELECT count(*) FROM speaker_vec_meta").fetchone()[0])
+        transcript_vectors = int(conn.execute("SELECT count(*) FROM transcript_vec_meta").fetchone()[0])
+        return {
+            "text_chunks": chunks,
+            "speaker_vectors": vectors,
+            "transcript_vectors": transcript_vectors,
+            "vector_warning": vectors > VECTOR_WARN_THRESHOLD,
+        }
+
+    @staticmethod
+    def upsert_transcript_chunk(conn: sqlite3.Connection, row: dict) -> None:
+        """Upsert one transcript/screen text row into content + FTS tables."""
+        values = (
+            row["id"], row["file_id"], row["file_uuid"], row.get("user_id"),
+            row["source"], row.get("title"), row.get("speaker"), row.get("start_time"),
+            row.get("end_time"), row.get("upload_time"), row.get("content_type"),
+            row.get("duration"), row.get("file_size"), row.get("language"), row["content"],
+        )
+        conn.execute(
+            "INSERT INTO transcript_chunk(id, file_id, file_uuid, user_id, source, title, speaker, "
+            "start_time, end_time, upload_time, content_type, duration, file_size, language, content) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET file_id=excluded.file_id, "
+            "file_uuid=excluded.file_uuid, user_id=excluded.user_id, source=excluded.source, title=excluded.title, "
+            "speaker=excluded.speaker, start_time=excluded.start_time, end_time=excluded.end_time, "
+            "upload_time=excluded.upload_time, content_type=excluded.content_type, "
+            "duration=excluded.duration, file_size=excluded.file_size, "
+            "language=excluded.language, content=excluded.content",
+            values,
+        )
+        conn.execute("DELETE FROM transcript_chunk_fts WHERE rowid = ?", (row["id"],))
+        conn.execute(
+            "INSERT INTO transcript_chunk_fts(rowid, content, title, speaker) VALUES (?, ?, ?, ?)",
+            (row["id"], row["content"], row.get("title"), row.get("speaker")),
+        )
+
+    def upsert_speaker_vector(self, conn: sqlite3.Connection, row: dict) -> None:
+        """Upsert one 512-d speaker/profile vector."""
+        rowid = int(row["rowid"])
+        conn.execute("DELETE FROM speaker_vec WHERE rowid = ?", (rowid,))
+        conn.execute(
+            "INSERT INTO speaker_vec(rowid, embedding) VALUES (?, ?)",
+            (rowid, self.vector_blob(row["embedding"])),
+        )
+        conn.execute(
+            "INSERT INTO speaker_vec_meta(rowid, speaker_id, profile_id, name, model) "
+            "VALUES (?, ?, ?, ?, ?) ON CONFLICT(rowid) DO UPDATE SET "
+            "speaker_id=excluded.speaker_id, profile_id=excluded.profile_id, "
+            "name=excluded.name, model=excluded.model",
+            (rowid, row.get("speaker_id"), row.get("profile_id"), row.get("name"), row["model"]),
+        )
+
+    def search_speaker_vectors(self, conn: sqlite3.Connection, vector, limit: int = 5) -> list[dict]:
+        """Return nearest speaker vectors from sqlite-vec."""
+        rows = conn.execute(
+            "SELECT m.rowid, m.speaker_id, m.profile_id, m.name, m.model, v.distance "
+            "FROM speaker_vec v JOIN speaker_vec_meta m ON m.rowid = v.rowid "
+            "WHERE v.embedding MATCH ? AND k = ? ORDER BY v.distance",
+            (self.vector_blob(vector), limit),
+        ).fetchall()
+        keys = ("rowid", "speaker_id", "profile_id", "name", "model", "distance")
+        return [dict(zip(keys, row)) for row in rows]
+
+    @staticmethod
+    def transcript_vector_blob(values: Iterable[float]) -> bytes:
+        """Pack exactly one 384-d transcript vector."""
+        vector = tuple(float(item) for item in values)
+        if len(vector) != TRANSCRIPT_VECTOR_DIM:
+            raise ValueError(f"expected {TRANSCRIPT_VECTOR_DIM}-d vector, got {len(vector)}")
+        return struct.pack(f"{TRANSCRIPT_VECTOR_DIM}f", *vector)
+
+    def upsert_transcript_vector(self, conn: sqlite3.Connection, row: dict) -> None:
+        """Upsert one transcript semantic vector."""
+        rowid = int(row["rowid"])
+        conn.execute("DELETE FROM transcript_vec WHERE rowid = ?", (rowid,))
+        conn.execute("INSERT INTO transcript_vec(rowid, embedding) VALUES (?, ?)",
+                     (rowid, self.transcript_vector_blob(row["embedding"])))
+        conn.execute(
+            "INSERT INTO transcript_vec_meta(rowid, chunk_id, file_id, file_uuid, model) "
+            "VALUES (?, ?, ?, ?, ?) ON CONFLICT(rowid) DO UPDATE SET "
+            "chunk_id=excluded.chunk_id, file_id=excluded.file_id, "
+            "file_uuid=excluded.file_uuid, model=excluded.model",
+            (rowid, row["chunk_id"], row["file_id"], row["file_uuid"], row.get("model")),
+        )
+
+    def search_transcript_vectors(self, conn: sqlite3.Connection, vector, limit: int = 5, user_id: int | None = None) -> list[dict]:
+        """Return nearest transcript vectors from sqlite-vec, optionally user-scoped."""
+        rows = conn.execute(
+            "SELECT m.rowid, m.chunk_id, m.file_id, m.file_uuid, m.model, v.distance, c.user_id "
+            "FROM transcript_vec v JOIN transcript_vec_meta m ON m.rowid = v.rowid "
+            "JOIN transcript_chunk c ON c.id = m.chunk_id "
+            "WHERE v.embedding MATCH ? AND k = ? ORDER BY v.distance",
+            (self.transcript_vector_blob(vector), limit * 3 if user_id is not None else limit),
+        ).fetchall()
+        keys = ("rowid", "chunk_id", "file_id", "file_uuid", "model", "distance", "user_id")
+        result = [dict(zip(keys, row)) for row in rows]
+        if user_id is not None:
+            result = [row for row in result if row.get("user_id") == user_id]
+        return result[:limit]
+
+    @staticmethod
+    def search_text(conn: sqlite3.Connection, query: str, limit: int = 10, user_id: int | None = None) -> list[dict]:
+        """Return FTS5 ranked rows using bm25()."""
+        where = "transcript_chunk_fts MATCH ?"
+        params: list = [query]
+        if user_id is not None:
+            where += " AND c.user_id = ?"
+            params.append(user_id)
+        params.append(limit)
+        rows = conn.execute(
+            "SELECT c.file_id, c.file_uuid, c.user_id, c.source, c.title, c.speaker, c.start_time, "
+            "c.end_time, c.upload_time, c.content_type, c.duration, c.file_size, c.language, "
+            "c.content, bm25(transcript_chunk_fts) AS score "
+            "FROM transcript_chunk_fts f JOIN transcript_chunk c ON c.id = f.rowid "
+            f"WHERE {where} ORDER BY score LIMIT ?",
+            tuple(params),
+        ).fetchall()
+        keys = ("file_id", "file_uuid", "user_id", "source", "title", "speaker", "start_time", "end_time", "upload_time", "content_type", "duration", "file_size", "language", "content", "score")
+        return [dict(zip(keys, row)) for row in rows]
+
+    def log_summary(self, conn: sqlite3.Connection) -> dict[str, int | bool]:
+        """Persist and return current count summary for orchestrator status."""
+        summary = self.count_summary(conn)
+        for key, value in summary.items():
+            conn.execute(
+                "INSERT INTO search_meta(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (key, str(value)),
+            )
+        conn.commit()
+        return summary

--- a/backend/app/services/sqlite_search/transcript_embedder.py
+++ b/backend/app/services/sqlite_search/transcript_embedder.py
@@ -1,0 +1,66 @@
+"""Local ONNX MiniLM transcript embeddings for SQLite search."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+DEFAULT_MODEL_DIR = Path.home() / ".cache/openwhispr/embedding-models/all-MiniLM-L6-v2"
+
+
+def _normalize(matrix: np.ndarray) -> np.ndarray:
+    """Return row-wise L2-normalized float32 vectors."""
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    return (matrix / np.maximum(norms, 1e-12)).astype(np.float32)
+
+
+def _mean_pool(hidden: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Mean-pool token embeddings with attention mask."""
+    expanded = mask[..., None].astype(np.float32)
+    summed = (hidden * expanded).sum(axis=1)
+    counts = np.maximum(expanded.sum(axis=1), 1e-12)
+    return summed / counts
+
+
+class LocalMiniLMEmbedder:
+    """No-egress ONNX all-MiniLM-L6-v2 embedder."""
+
+    def __init__(self, model_dir: str | Path = DEFAULT_MODEL_DIR):
+        self.model_dir = Path(model_dir).expanduser()
+        self._session = None
+        self._tokenizer = None
+
+    def _load(self) -> None:
+        """Load tokenizer and ONNX session lazily from local files."""
+        if self._session is not None and self._tokenizer is not None:
+            return
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+
+        tokenizer_path = self.model_dir / "tokenizer.json"
+        model_path = self.model_dir / "model.onnx"
+        if not tokenizer_path.exists() or not model_path.exists():
+            raise FileNotFoundError(f"local MiniLM files missing in {self.model_dir}")
+        self._tokenizer = Tokenizer.from_file(str(tokenizer_path))
+        self._session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+
+    def encode(self, texts: Iterable[str], max_length: int = 256) -> list[list[float]]:
+        """Encode texts as normalized 384-d vectors."""
+        self._load()
+        items = [str(text or "") for text in texts]
+        if not items:
+            return []
+        enc = self._tokenizer.encode_batch(items)  # type: ignore[union-attr]
+        ids = [item.ids[:max_length] for item in enc]
+        masks = [item.attention_mask[:max_length] for item in enc]
+        width = max(len(row) for row in ids)
+        input_ids = np.array([row + [0] * (width - len(row)) for row in ids], dtype=np.int64)
+        attention = np.array([row + [0] * (width - len(row)) for row in masks], dtype=np.int64)
+        token_types = np.zeros_like(input_ids, dtype=np.int64)
+        hidden = self._session.run(  # type: ignore[union-attr]
+            None,
+            {"input_ids": input_ids, "attention_mask": attention, "token_type_ids": token_types},
+        )[0]
+        pooled = _mean_pool(hidden, attention)
+        return _normalize(pooled).tolist()

--- a/backend/app/services/sqlite_search/transcript_vector_import.py
+++ b/backend/app/services/sqlite_search/transcript_vector_import.py
@@ -1,0 +1,50 @@
+"""Import transcript semantic vectors from current OpenSearch chunks."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.sqlite_search.store import SQLiteSearchStore, TRANSCRIPT_VECTOR_DIM
+
+
+def _chunk_vector_rows(limit: int = 1000) -> list[dict[str, Any]]:
+    """Read current OpenSearch transcript chunks that have embeddings."""
+    from app.core.config import settings
+    from app.services.opensearch_service import get_opensearch_client
+
+    client = get_opensearch_client()
+    if client is None:
+        return []
+    body = {
+        "size": limit,
+        "query": {"exists": {"field": "embedding"}},
+        "_source": ["file_id", "file_uuid", "chunk_index", "embedding", "embedding_model"],
+    }
+    hits = client.search(index=settings.OPENSEARCH_CHUNKS_INDEX, body=body)["hits"]["hits"]
+    rows = []
+    for idx, hit in enumerate(hits, start=1):
+        src = hit.get("_source", {})
+        if len(src.get("embedding") or []) != TRANSCRIPT_VECTOR_DIM:
+            continue
+        rows.append({
+            "rowid": idx,
+            "chunk_id": int(src.get("chunk_index") or idx),
+            "file_id": int(src["file_id"]),
+            "file_uuid": str(src["file_uuid"]),
+            "model": src.get("embedding_model"),
+            "embedding": src["embedding"],
+        })
+    return rows
+
+
+def import_transcript_vectors(sqlite_path: str, limit: int = 1000) -> dict[str, Any]:
+    """Copy current OpenSearch transcript vectors into SQLite."""
+    rows = _chunk_vector_rows(limit=limit)
+    store = SQLiteSearchStore(sqlite_path)
+    with store.connect() as conn:
+        conn.execute("DELETE FROM transcript_vec")
+        conn.execute("DELETE FROM transcript_vec_meta")
+        for row in rows:
+            store.upsert_transcript_vector(conn, row)
+        conn.commit()
+        summary = store.log_summary(conn)
+    return {**summary, "rows_seen": len(rows)}

--- a/backend/app/tasks/recovery.py
+++ b/backend/app/tasks/recovery.py
@@ -167,8 +167,14 @@ def _check_opensearch_health(summary: dict) -> None:
     """Check and repair OpenSearch indices with corrupted HNSW vector segments.
 
     Runs outside the DB session since it only touches OpenSearch.
-    Updates the summary dict in place with repair results.
+    Updates the summary dict in place with repair results. Skipped entirely when
+    SQLite is the search backend so the periodic health check stays quiet with the
+    OpenSearch JVM stopped.
     """
+    from app.core.config import settings
+
+    if settings.SEARCH_BACKEND.lower() == "sqlite":
+        return
     try:
         from app.services.opensearch_service import check_and_repair_indices
 

--- a/backend/app/tasks/search_indexing_task.py
+++ b/backend/app/tasks/search_indexing_task.py
@@ -62,6 +62,24 @@ def index_transcript_search_task(  # noqa: C901
     benchmark_timing.mark(pipeline_task_id, "search_index_chunks_start")
 
     try:
+        if settings.SEARCH_BACKEND.lower() == "sqlite":
+            from app.tasks.sqlite_search_indexing_task import run_sqlite_search_reindex
+
+            result = run_sqlite_search_reindex(user_id, file_uuids=[file_uuid], limit=None)
+            total_ms = round((time.time() - total_start) * 1000)
+            summary = result.get("summary", {})
+            timing = {
+                "backend": "sqlite",
+                "chunk_count": summary.get("rows_seen", 0),
+                "total_ms": total_ms,
+                "index_counts": summary,
+            }
+            with session_scope() as db:
+                update_task_status(db, task_id, "completed", progress=1.0, completed=True)
+            _send_indexing_notification(user_id, file_id, timing)
+            benchmark_timing.mark(pipeline_task_id, "search_index_chunks_end")
+            return {"status": "success", "file_id": file_id, **timing}
+
         # Single DB session: fetch segments (with speaker joinedload),
         # media_file, tags/collections, and the access-list in one sweep.
         # Previously the task opened three separate sessions and issued

--- a/backend/app/tasks/sqlite_search_indexing_task.py
+++ b/backend/app/tasks/sqlite_search_indexing_task.py
@@ -1,0 +1,45 @@
+"""Celery task for embedded SQLite search reindexing."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.celery import celery_app
+from app.core.config import settings
+from app.core.constants import CPUPriority
+
+logger = logging.getLogger(__name__)
+
+
+def run_sqlite_search_reindex(
+    user_id: int,
+    file_uuids: list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Run the embedded SQLite search coordinator."""
+    from app.db.session_utils import session_scope
+    from app.services.sqlite_search.orchestrator import ReindexSlice, SQLiteSearchOrchestrator
+    from app.services.sqlite_search.store import SQLiteSearchStore
+
+    coordinator = SQLiteSearchOrchestrator(SQLiteSearchStore(settings.SQLITE_SEARCH_PATH))
+    index_slice = ReindexSlice(user_id=user_id, limit=limit, file_uuids=file_uuids)
+    with session_scope() as db:
+        return coordinator.run_reindex(db, index_slice)
+
+
+@celery_app.task(
+    name="sqlite_search_reindex",
+    priority=CPUPriority.USER_TRIGGERED,
+    max_retries=2,
+    default_retry_delay=10,
+)
+def sqlite_search_reindex_task(
+    user_id: int,
+    file_uuids: list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Run a bounded SQLite search reindex job."""
+    logger.info("SQLite search reindex started for user %s", user_id)
+    result = run_sqlite_search_reindex(user_id, file_uuids=file_uuids, limit=limit)
+    logger.info("SQLite search reindex finished for user %s: %s", user_id, result.get("status"))
+    return result

--- a/scripts/native-dev.sh
+++ b/scripts/native-dev.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+ENV_EXT=".env"
+DEFAULT_ENV_FILE="${ROOT_DIR}/native-loopback${ENV_EXT}.example"
+ENV_FILE="${OPENTRANSCRIBE_NATIVE_ENV:-$DEFAULT_ENV_FILE}"
+PYTHON_BIN="${OPENTRANSCRIBE_PYTHON:-}"
+
+resolve_python() {
+  if [[ -n "$PYTHON_BIN" && -x "$PYTHON_BIN" ]]; then
+    return
+  fi
+  local venv_dir
+  venv_dir="$(find "$ROOT_DIR/.." -maxdepth 3 -name pyvenv.cfg -exec dirname {} \; | head -1)"
+  PYTHON_BIN="${venv_dir:-}/bin/python3"
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    PYTHON_BIN="$(command -v python3)"
+  fi
+}
+
+ensure_opensearch() {
+  local os_host="${OPENSEARCH_HOST:-127.0.0.1}" os_port="${OPENSEARCH_PORT:-9200}"
+  curl -s -X PUT "http://${os_host}:${os_port}/_cluster/settings" \
+    -H 'Content-Type: application/json' \
+    -d '{"transient":{"cluster.blocks.create_index":false},"persistent":{"cluster.blocks.create_index":null}}' \
+    >/dev/null 2>&1 || true
+}
+
+load_env() {
+  resolve_python
+  if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+  fi
+  export STORAGE_BACKEND="${STORAGE_BACKEND:-filesystem}"
+  export STORAGE_LOCAL_ROOT="${STORAGE_LOCAL_ROOT:-$HOME/.opentranscribe/storage}"
+  # Embedded SQLite serves search natively (no OpenSearch/JVM daemon). Set
+  # SEARCH_BACKEND=opensearch to roll back to the Lucene path; the code default
+  # stays opensearch so only this native launch cuts over.
+  export SEARCH_BACKEND="${SEARCH_BACKEND:-sqlite}"
+  export FORCE_CPU_MODE="${FORCE_CPU_MODE:-true}"
+  export USE_GPU="${USE_GPU:-false}"
+  export TORCH_DEVICE="${TORCH_DEVICE:-cpu}"
+  export COMPUTE_TYPE="${COMPUTE_TYPE:-int8}"
+  export WHISPER_MODEL="${WHISPER_MODEL:-base}"
+  export WHISPER_COMPUTE_TYPE="${WHISPER_COMPUTE_TYPE:-int8}"
+  export ENABLE_DIARIZATION="${ENABLE_DIARIZATION:-false}"
+  export FRONTEND_URL="${FRONTEND_URL:-http://127.0.0.1:5173}"
+}
+
+need_backend_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing backend command: $1" >&2
+    exit 1
+  fi
+}
+
+check_port() {
+  local label="$1" port="$2"
+  if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+    echo "$label:$port listening"
+  else
+    echo "$label:$port closed"
+  fi
+}
+
+check() {
+  load_env
+  check_port postgres "${POSTGRES_PORT:-5432}"
+  check_port redis "${REDIS_PORT:-6379}"
+  check_port opensearch "${OPENSEARCH_PORT:-9200}"
+  for tool in ffmpeg ffprobe psql redis-cli node npm; do
+    command -v "$tool" >/dev/null 2>&1 && echo "$tool ok" || echo "$tool missing"
+  done
+}
+
+api() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m uvicorn app.main:app --host 127.0.0.1 --port "${OPENTRANSCRIBE_API_PORT:-5174}"
+}
+
+migrate() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m alembic upgrade head
+}
+
+worker_cpu() {
+  load_env
+  cd "$BACKEND_DIR"
+  if [[ "${LOCAL_ASR_BACKEND:-}" == "mlx-whisper" ]]; then
+    exec "$PYTHON_BIN" -m celery -A app.core.celery worker --loglevel=info -Q cpu,utility,cpu-transcribe \
+      --pool=solo --concurrency=1 \
+      --hostname cpu-processor@%h -E
+  else
+    exec "$PYTHON_BIN" -m celery -A app.core.celery worker --loglevel=info -Q cpu,utility,cpu-transcribe \
+      --concurrency="${CPU_WORKER_CONCURRENCY:-8}" --max-tasks-per-child=20 \
+      --hostname cpu-processor@%h -E
+  fi
+}
+
+worker_download() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m celery -A app.core.celery worker --loglevel=info -Q download \
+    --concurrency="${DOWNLOAD_CONCURRENCY:-5}" --max-tasks-per-child=10 \
+    --hostname media-downloader@%h -E
+}
+
+worker_nlp() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m celery -A app.core.celery worker --loglevel=info -Q nlp,celery \
+    --concurrency="${NLP_WORKER_CONCURRENCY:-4}" --max-tasks-per-child=50 \
+    --hostname ai-nlp@%h -E
+}
+
+worker_embedding() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m celery -A app.core.celery worker --loglevel=info -Q embedding \
+    --concurrency=1 --max-tasks-per-child=500 --hostname search-indexer@%h -E
+}
+
+beat() {
+  load_env
+  cd "$BACKEND_DIR"
+  exec "$PYTHON_BIN" -m celery -A app.core.celery beat --loglevel=info
+}
+
+frontend() {
+  load_env
+  cd "$FRONTEND_DIR"
+  export VITE_API_PROXY_TARGET="${VITE_API_PROXY_TARGET:-http://127.0.0.1:5174}"
+  export VITE_WS_PROXY_TARGET="${VITE_WS_PROXY_TARGET:-ws://127.0.0.1:5174}"
+  exec npm run dev -- --host 127.0.0.1
+}
+
+usage() {
+  cat <<'TXT'
+Usage: scripts/native-dev.sh <command>
+
+Commands: check, migrate, api, frontend, worker-cpu, worker-download,
+          worker-nlp, worker-embedding, beat
+
+This wrapper is loopback/no-container/no-CUDA oriented. It never starts or
+stops Postgres, Redis, or OpenSearch for you; run check first and start those
+host services yourself when ready.
+TXT
+}
+
+case "${1:-help}" in
+  check) check ;;
+  migrate) migrate ;;
+  api) api ;;
+  frontend) frontend ;;
+  worker-cpu) worker_cpu ;;
+  worker-download) worker_download ;;
+  worker-nlp) worker_nlp ;;
+  worker-embedding) worker_embedding ;;
+  beat) beat ;;
+  help|--help|-h) usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/scripts/sqlite_rewind_context_import.py
+++ b/scripts/sqlite_rewind_context_import.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Import Rewind OCR/screen/activity context payloads into SQLite FTS."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / "backend"
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("payload", nargs="+", type=Path)
+    parser.add_argument("--user-id", type=int)
+    parser.add_argument("--sqlite-path", default="~/.opentranscribe/search/search.sqlite3")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    from app.services.sqlite_search.context_import import import_context_payloads
+
+    report = import_context_payloads(args.sqlite_path, args.payload, user_id=args.user_id)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Replaces the OpenSearch (JVM/Lucene) search dependency with an embedded SQLite stack for native, single-user, no-Docker operation.

## What
- FTS5 for transcript + Rewind OCR/screen text; sqlite-vec for 512-d speaker (sherpa gallery) and 384-d transcript vectors.
- **Vectors L2-normalized so sqlite-vec's Euclidean distance ranks identically to cosine** (the system's matching metric). Regression test covers raw-L2-vs-cosine disagreement.
- Live transcript reindex computes 384-d vectors via a local, no-egress ONNX MiniLM embedder (separate from the sherpa-512 speaker authority); degrades to text-only if the model is absent.
- Flag-gated routing: `SEARCH_BACKEND` defaults to `opensearch`; set `sqlite` to cut over (native launch defaults to sqlite, rollback via env).

## Verification (measured on real data, M3 Ultra)
- Full sqlite_search suite green (26 tests).
- Text parity vs OpenSearch: SQLite is a superset — never misses an OpenSearch hit.
- Speaker search self-matches 8/8 on the real 209-vector gallery (distance 0.0).
- Live API serving on `SEARCH_BACKEND=sqlite` (HTTP 200).

## Known follow-up
- App startup still initializes OpenSearch (index setup/health) regardless of `SEARCH_BACKEND`; gating that is a separate change to fully decommission the JVM.

Parity/removability evidence in the linked auris repo `plans/reports/`.