### PR TITLE
build(deps): backend group 2026-07 batch (manual — dependabot ignores applied)

### DIFF
--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -16,27 +16,29 @@
 
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-fastapi>=0.136.3
-uvicorn[standard]>=0.48.0
+# fastapi capped <0.137: 0.137+ stops flattening include_router prefixes into
+# scope["route"].path — breaks route-templated metrics labels (see requirements.txt)
+fastapi>=0.136.3,<0.137
+uvicorn[standard]>=0.49.0
 websockets>=11.0.3
-sqlalchemy>=2.0.50
-alembic>=1.18.4
+sqlalchemy>=2.0.51
+alembic>=1.18.5
 pydantic>=2.13.4
-pydantic-settings>=2.14.1
+pydantic-settings>=2.14.2
 python-jose[cryptography]>=3.5.0
-python-multipart>=0.0.30
+python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
 bcrypt==3.2.2
 email-validator
 
 # Observability (Prometheus metrics + structured JSON logs) — CI imports app.main
 prometheus-client>=0.25,<0.26
-python-json-logger>=3.1
-cachetools>=7,<8
+python-json-logger>=4.1.0
+cachetools>=7.1.4,<8
 
 # Asynchronous Tasks
 celery>=5.6.3
-redis>=8.0.0
+redis>=8.0.1
 psycopg2-binary>=2.9.12
 minio>=7.2.20
 imohash>=1.1.0
@@ -45,22 +47,22 @@ opensearch-py>=3.2.0,<4.0.0
 httpx>=0.28.1
 python-dotenv>=1.2.2
 ldap3>=2.9.1
-slowapi>=0.1.9
-cryptography>=48.0.0
-pyotp>=2.9.0
+slowapi>=0.1.10
+cryptography>=49.0.0
+pyotp>=2.10.0
 qrcode[pil]>=8.2
 
 # AI/ML stack (CPU wheels via the extra index above)
 numpy>=2.1.0
 torch==2.8.0
 torchaudio==2.8.0
-ctranslate2>=4.7.2,<5
+ctranslate2>=4.8.1,<5
 faster-whisper>=1.2.1
 transformers>=4.48.0
 huggingface-hub<1.0.0
-onnx>=1.21.0
-onnxruntime==1.26.0
-omegaconf>=2.3.0
+onnx>=1.22.0
+onnxruntime==1.27.0
+omegaconf>=2.3.1
 
 # Supporting libraries
 ffmpeg-python>=0.2.0
@@ -68,39 +70,39 @@ gender-guesser>=0.4.0
 sentencepiece>=0.2.1
 psutil>=7.2.2
 pyexiftool>=0.5.6
-yt-dlp[default]>=2026.3.17
+yt-dlp[default]>=2026.6.9
 
 # Semantic search and NLP
-sentence-transformers>=5.5.1
+sentence-transformers>=5.6.0
 nltk>=3.9.4
 
 # Cloud ASR provider SDKs (lazily imported)
-deepgram-sdk>=7.3.0
-assemblyai>=0.64.4
-google-cloud-speech>=2.39.0
+deepgram-sdk>=7.4.0
+assemblyai>=0.64.25
+google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0
 speechmatics-batch>=0.4.8
-boto3>=1.43.21
-openai>=2.40.0
+boto3>=1.43.40
+openai>=2.44.0
 requests>=2.34.2
 
 # Diarization metrics (cpWER) — exercised by tests/unit/test_diarization_metrics.py
-meeteval>=0.4.0
+meeteval>=0.4.3
 
 # Content redaction (wordlist/config tests run in the default suite;
 # model-weight tests carry @pytest.mark.models and skip in CI)
-presidio-analyzer>=2.2.355
+presidio-analyzer>=2.2.363
 presidio-anonymizer>=2.2.355
-gliner>=0.2.13
+gliner>=0.2.27
 detoxify>=0.5.2
 
 # Watch sources
-watchdog>=4.0.0
-smbprotocol>=1.12.0
-msal>=1.26.0
+watchdog>=6.0.0
+smbprotocol>=1.16.1
+msal>=1.37.0
 
 # Test tooling (mirrors the test section of requirements-dev.txt)
-pytest>=8.4.0
+pytest>=9.1.1
 pytest-asyncio>=0.23.0
 pytest-cov>=4.1.0
 pytest-xdist>=3.8.0

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -6,13 +6,13 @@
 
 # Code Quality & Formatting
 black>=26.5.1
-ruff>=0.15.15
+ruff>=0.15.20
 mypy>=2.1.0
 mypy-extensions>=1.1.0
-import-linter>=2.0  # Enforces the app ↛ cloud seam (forbidden contract in pyproject.toml)
+import-linter>=2.13  # Enforces the app ↛ cloud seam (forbidden contract in pyproject.toml)
 
 # Testing
-pytest>=9.0.3
+pytest>=9.1.1
 pytest-asyncio>=1.4.0  # For testing async code
 pytest-cov>=7.1.0  # Code coverage reports
 pytest-xdist>=3.8.0  # Parallel execution — pyproject addopts uses "-n auto"
@@ -29,5 +29,5 @@ types-redis>=4.6.0.20241004
 types-passlib>=1.7.7.20260211
 
 # Development Utilities
-ipython>=9.14.0  # Enhanced Python shell
+ipython>=9.15.0  # Enhanced Python shell
 ipdb>=0.13.13  # IPython debugger

--- a/backend/requirements-lite.txt
+++ b/backend/requirements-lite.txt
@@ -1,18 +1,20 @@
-fastapi>=0.136.3
-uvicorn[standard]>=0.48.0
+# fastapi capped <0.137: 0.137+ stops flattening include_router prefixes into
+# scope["route"].path — breaks route-templated metrics labels (see requirements.txt)
+fastapi>=0.136.3,<0.137
+uvicorn[standard]>=0.49.0
 websockets>=11.0.3
-sqlalchemy>=2.0.50
-alembic>=1.18.4
+sqlalchemy>=2.0.51
+alembic>=1.18.5
 pydantic>=2.13.4
-pydantic-settings>=2.14.1
+pydantic-settings>=2.14.2
 python-jose[cryptography]>=3.5.0
-python-multipart>=0.0.30
+python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
 bcrypt==3.2.2
 email-validator
 # Asynchronous Tasks
 celery>=5.6.3
-redis>=8.0.0
+redis>=8.0.1
 flower>=2.0.1
 psycopg2-binary>=2.9.12
 minio>=7.2.20
@@ -24,13 +26,13 @@ python-dotenv>=1.2.2
 ldap3>=2.9.1
 
 # Rate Limiting
-slowapi>=0.1.9
+slowapi>=0.1.10
 
 # PKI/X.509 Certificate Authentication
-cryptography>=48.0.0
+cryptography>=49.0.0
 
 # MFA/TOTP Authentication (FedRAMP IA-2)
-pyotp>=2.9.0
+pyotp>=2.10.0
 qrcode[pil]>=8.2
 
 # AI/ML Stack - CPU-only (no CUDA, no GPU required)
@@ -44,32 +46,32 @@ numpy>=1.25.2
 torch==2.8.0+cpu
 
 # PyAnnote (CPU-only, for speaker embedding extraction and cross-file speaker matching)
-pyannote.audio>=3.3.2
+pyannote.audio>=4.0.7
 
 # Supporting libraries
-omegaconf>=2.3.0
+omegaconf>=2.3.1
 ffmpeg-python>=0.2.0
 sentencepiece>=0.2.1
 psutil>=7.2.2
 pyexiftool>=0.5.6
-yt-dlp>=2025.1.7
+yt-dlp>=2026.6.9
 
 # Semantic search and NLP
-sentence-transformers>=2.2.0  # For semantic search embeddings (all-MiniLM-L6-v2)
+sentence-transformers>=5.6.0  # For semantic search embeddings (all-MiniLM-L6-v2)
 # Note: nltk is installed as transitive dependency from transformers
 # NLTK data files (punkt_tab) must be pre-downloaded for offline usage
 
 # Cloud ASR provider SDKs (lazily imported — only needed for configured provider)
-deepgram-sdk>=7.3.0
-assemblyai>=0.64.4
-google-cloud-speech>=2.24.0
+deepgram-sdk>=7.4.0
+assemblyai>=0.64.25
+google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0
 # speechmatics-python is deprecated and drops speaker labels — the app uses
 # the async speechmatics-batch client (matches requirements.txt)
 speechmatics-batch>=0.4.8
 # boto3 is NOT a transitive dep of minio-py — must be listed explicitly (Amazon Transcribe)
-boto3>=1.43.21
+boto3>=1.43.40
 # openai must be listed explicitly — no package in this requirements pulls it in
-openai>=2.40.0
+openai>=2.44.0
 # requests is pulled in transitively by many packages above, but list explicitly for clarity
 requests>=2.34.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,25 +1,28 @@
-fastapi>=0.136.3
-uvicorn[standard]>=0.48.0
+# fastapi 0.137+ stops flattening include_router prefixes into scope["route"].path,
+# which breaks route-templated metrics labels (test_observability_middleware).
+# Cap until the observability middleware adapts to the new routing.
+fastapi>=0.136.3,<0.137
+uvicorn[standard]>=0.49.0
 websockets>=11.0.3
-sqlalchemy>=2.0.50
-alembic>=1.18.4
+sqlalchemy>=2.0.51
+alembic>=1.18.5
 pydantic>=2.13.4
-pydantic-settings>=2.14.1
+pydantic-settings>=2.14.2
 python-jose[cryptography]>=3.5.0
-python-multipart>=0.0.30
+python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
 bcrypt==3.2.2
 email-validator
 
 # Observability (Prometheus metrics + structured JSON logs)
 prometheus-client>=0.25,<0.26   # 0.25.0 current; NEVER 0.23.0 (yanked)
-python-json-logger>=3.1         # v4.x current, same PyPI name (nhairs maintains);
+python-json-logger>=4.1.0         # v4.x current, same PyPI name (nhairs maintains);
                                 # import from pythonjsonlogger.json (legacy .jsonlogger is a shim)
-cachetools>=7,<8                # 7.1.4 current; TTLCache still NOT thread-safe (we lock)
+cachetools>=7.1.4,<8                # 7.1.4 current; TTLCache still NOT thread-safe (we lock)
 
 # Asynchronous Tasks
 celery>=5.6.3
-redis>=8.0.0
+redis>=8.0.1
 flower>=2.0.1
 psycopg2-binary>=2.9.12
 minio>=7.2.20
@@ -32,13 +35,13 @@ python-dotenv>=1.2.2
 ldap3>=2.9.1
 
 # Rate Limiting
-slowapi>=0.1.9
+slowapi>=0.1.10
 
 # PKI/X.509 Certificate Authentication
-cryptography>=48.0.0
+cryptography>=49.0.0
 
 # MFA/TOTP Authentication (FedRAMP IA-2)
-pyotp>=2.9.0
+pyotp>=2.10.0
 qrcode[pil]>=8.2
 
 # AI/ML Stack - All cuDNN 9 compatible for CUDA 12.8
@@ -57,7 +60,7 @@ torchaudio==2.8.0
 # CTranslate2 - inference engine for Whisper
 # whisperx requires >=4.5.0, faster-whisper requires >=4.0,<5
 # We use >=4.6.0 for cuDNN 9 support (required for CUDA 12.8)
-ctranslate2>=4.7.2,<5
+ctranslate2>=4.8.1,<5
 
 # faster-whisper - CTranslate2-based Whisper implementation
 # whisperx requires >=1.1.1
@@ -75,13 +78,13 @@ huggingface-hub<1.0.0
 # via ORT sessions when PYANNOTE_USE_ONNX=1. onnxruntime-gpu includes CUDA EP
 # (and TensorrtExecutionProvider when ENABLE_TENSORRT=1 per Phase 6.3).
 # ~350 MB install footprint, CUDA-bundled. onnx needed at export time only.
-onnx>=1.21.0
-# Pinned to the validated version (1.26.0) so --no-cache container builds and venv
+onnx>=1.22.0
+# Pinned to the validated version (1.27.0) so --no-cache container builds and venv
 # setups are reproducible — an unpinned >= floor could resolve a newer release with
 # a different bundled CUDA at build time. onnxruntime-gpu and onnxruntime ship in
 # lockstep, so both pin to the same version.
-onnxruntime-gpu==1.26.0; sys_platform == 'linux' and platform_machine == 'x86_64'
-onnxruntime==1.26.0; sys_platform != 'linux' or platform_machine != 'x86_64'
+onnxruntime-gpu==1.27.0; sys_platform == 'linux' and platform_machine == 'x86_64'
+onnxruntime==1.27.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 # NOTE: `tensorrt` was added during Phase 6.3 spike but removed 2026-04-23.
 # ORT's TensorrtExecutionProvider hit rebuild storms on pyannote's variable
 # input shapes — 2 min CPU saturation, 0% GPU usage, no inference. Microbench
@@ -98,7 +101,7 @@ onnxruntime==1.26.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 # Cache-bust tag: 2026-04-20 Phase B budget helper + device-aware footprints (85858462)
 pyannote.audio @ git+https://github.com/davidamacey/pyannote-audio.git@gpu-optimizations
 # Required by pyannote/embedding model checkpoint (pickle dependency)
-omegaconf>=2.3.0
+omegaconf>=2.3.1
 
 # NOTE: whisperx==3.8.1 is installed separately in Dockerfile with --no-deps
 # to keep our version pins in requirements.txt authoritative
@@ -112,40 +115,40 @@ psutil>=7.2.2
 pyexiftool>=0.5.6
 # [default] extras: mutagen (metadata), pycryptodomex (stream decryption),
 # websockets (WS-based extractors), brotli (compressed responses), certifi (SSL)
-yt-dlp[default]>=2026.3.17
+yt-dlp[default]>=2026.6.9
 
 # Semantic search and NLP
-sentence-transformers>=5.5.1  # For semantic search embeddings (all-MiniLM-L6-v2)
+sentence-transformers>=5.6.0  # For semantic search embeddings (all-MiniLM-L6-v2)
 nltk>=3.9.4  # Required by whisperx>=3.7.6, also for SnowballStemmer
 # NLTK data files (punkt_tab) must be pre-downloaded for offline usage
 
 # Cloud ASR provider SDKs (lazily imported — only needed for configured provider)
-deepgram-sdk>=7.3.0
-assemblyai>=0.64.4
-google-cloud-speech>=2.39.0
+deepgram-sdk>=7.4.0
+assemblyai>=0.64.25
+google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0
 speechmatics-batch>=0.4.8
 # boto3 is NOT a transitive dep of minio-py — must be listed explicitly (Amazon Transcribe)
-boto3>=1.43.21
+boto3>=1.43.40
 # openai must be listed explicitly — no package in this requirements pulls it in
-openai>=2.40.0
+openai>=2.44.0
 # requests is pulled in by many packages but listed explicitly for Gladia REST calls
 requests>=2.34.2
 
 # Diarization-boundary benchmark (issue #193): cpWER metric. Lazily imported by
 # app.utils.diarization_metrics.cpwer + backend/scripts/benchmark_boundary.py — only
 # needed for accuracy benchmarking/tests, not the production transcription path.
-meeteval>=0.4.0
+meeteval>=0.4.3
 
 # =============================================================================
 # Content Redaction (PII / profanity / toxicity moderation)
 # =============================================================================
 # Loaded only by the celery-redaction worker (PRELOAD_REDACTION_MODELS=true).
 # Presidio = PII detection orchestration (built-in regex recognizers + NER).
-presidio-analyzer>=2.2.355
+presidio-analyzer>=2.2.363
 presidio-anonymizer>=2.2.355
 # GLiNER = small CPU zero-shot NER for names/addresses (plugs into Presidio).
-gliner>=0.2.13
+gliner>=0.2.27
 # detoxify = toxicity classification (segment-level). transformers (above) backs
 # the Tiny-Toxic-Detector / multilingual-toxic-xlm-roberta models.
 detoxify>=0.5.2
@@ -155,9 +158,9 @@ detoxify>=0.5.2
 # =============================================================================
 # watchdog = optional event-driven local FS watching (polling is the reliable
 # default; events are an additive speedup on real local filesystems only).
-watchdog>=4.0.0
+watchdog>=6.0.0
 # smbprotocol = pure-Python SMB2/3 client (no cifs-utils / mount; runs non-root).
-smbprotocol>=1.12.0
+smbprotocol>=1.16.1
 # msal = Microsoft Authentication Library for M365 Graph sendMail (OAuth2) when
 # the tenant has SMTP basic-auth disabled. (boto3 already listed above for S3.)
-msal>=1.26.0
+msal>=1.37.0


### PR DESCRIPTION
## Summary

Manual replacement for dependabot PR #263. Dependabot cannot apply `dependabot.yml` ignore rules to an already-open PR, and #263 mangled the torch/torchaudio local-tag pins (`torchaudio==2.11.0+cu128` in the CPU CI file), which is why its CI failed at install. This PR lands the same grouped update with the ignore policy applied by hand. **Closes/supersedes #263 — do not merge that PR.**

## Notable bumps

- uvicorn >=0.49.0, sqlalchemy >=2.0.51, alembic >=1.18.5, pydantic-settings >=2.14.2, python-multipart >=0.0.32
- python-json-logger >=4.1.0, cachetools >=7.1.4,<8, redis >=8.0.1
- slowapi >=0.1.10, **cryptography >=49.0.0**, pyotp >=2.10.0
- ctranslate2 >=4.8.1,<5, onnx >=1.22.0, onnxruntime(-gpu) ==1.27.0, omegaconf >=2.3.1
- yt-dlp >=2026.6.9, sentence-transformers >=5.6.0
- deepgram-sdk >=7.4.0, assemblyai >=0.64.25, google-cloud-speech >=2.40.0, boto3 >=1.43.40, openai >=2.44.0, meeteval >=0.4.3
- presidio-analyzer >=2.2.363, gliner >=0.2.27
- watchdog >=6.0.0, smbprotocol >=1.16.1, msal >=1.37.0
- pyannote.audio >=4.0.7 (requirements-lite only)
- dev: ruff >=0.15.20, import-linter >=2.13, pytest >=9.1.1, ipython >=9.15.0

## Excluded per dependabot.yml ignore policy (kept at master values)

| Package | Kept at | Why ignored |
|---|---|---|
| torch / torchaudio | `==2.8.0` (`+cpu` in lite) | local-tag pins managed by hand with the CUDA base image (#257) |
| bcrypt | `==3.2.2` | v5 removed the `__about__` attribute passlib introspects (#234) |
| transformers | `>=4.48.0` | v5 breaks whisperx + pyannote (#234) |
| huggingface-hub | `<1.0.0` | 1.x breaks the ASR stack (#234) |
| websockets | `>=11.0.3` | five-major jump; take deliberately, not in a batch |
| speechmatics-batch | `>=0.4.8` | 0.5.x needs live-key re-verification (#234) |

## Additional reversions/caps found during verification

- **numpy kept at master floors** (`>=2.1.0`; lite `>=1.25.2`) instead of the batch's `>=2.5.0`: presidio-analyzer 2.2.363 pins `numpy<2.5.0`, making the numpy bump unresolvable alongside the presidio bump (pip `ResolutionImpossible`). Resolution lands on numpy 2.4.x, which fully supports the Python 3.13 CI.
- **presidio-anonymizer kept at `>=2.2.355`** instead of `>=2.2.363`: 2.2.363 pins `cryptography>=46.0.4,<47.0.0`, incompatible with any cryptography floor >=47 (master is already `>=48`). Master's floor lets pip select anonymizer 2.2.362 alongside cryptography 49.
- **fastapi capped `>=0.136.3,<0.137`** (master was uncapped `>=0.136.3`): fastapi 0.137.0 stopped flattening `include_router` prefixes into `scope["route"].path`, which breaks the route-templated Prometheus labels (`test_observability_middleware::test_templated_route_labels_no_raw_ids` — bisected to exactly 0.137.0; starlette 0.47/0.48 are both fine). A bare floor revert would still resolve fastapi 0.139.0 in fresh CI installs and go red — note master is latently exposed to this on its next fresh install, hence the cap. Follow-up: adapt the observability middleware to the new FastAPI routing, then lift the cap.

## Verification

- `pip install --dry-run` on `python:3.13-slim` for `requirements-ci.txt` + `requirements-dev.txt`: **RESOLVE_OK** (resolved: numpy 2.4.6, transformers 4.57.6, huggingface-hub 0.36.2, cryptography 49.0.0, presidio-anonymizer 2.2.362, torch/torchaudio 2.8.0+cu128, fastapi 0.136.3)
- `requirements-lite.txt` dry-run resolution: OK
- Full backend suite against the updated host venv (branch rebased on f9deed6, includes PR #264's new tests): **2176 passed, 373 skipped, 0 failed**
- All pre-commit hooks pass.