### PR TITLE
fix(status): repair always-False FileStatus comparisons (issue #272)

### DIFF
--- a/backend/app/api/endpoints/files/__init__.py
+++ b/backend/app/api/endpoints/files/__init__.py
@@ -1009,7 +1009,9 @@ def get_file_analytics(
     db_file = get_media_file_by_uuid(
         db, file_uuid, current_user.id, is_admin=is_admin, organization_id=ctx.org_id
     )
-    analytics = _get_or_compute_analytics(db, db_file.id, str(db_file.status))
+    # Enum comparison (issue #272) — str(status) never matched "completed",
+    # so this endpoint could also never compute analytics on demand.
+    analytics = _get_or_compute_analytics(db, db_file.id, db_file.status)
     return {
         "analytics": AnalyticsSchema.model_validate(analytics) if analytics else None,
     }

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -187,7 +187,9 @@ def set_file_urls(db_file: MediaFile) -> None:
                 db_file.thumbnail_url = f"/api/files/{db_file.uuid}/thumbnail"  # type: ignore[attr-defined]
 
 
-def _get_or_compute_analytics(db: Session, file_id: int, file_status: str) -> Analytics | None:
+def _get_or_compute_analytics(
+    db: Session, file_id: int, file_status: FileStatus
+) -> Analytics | None:
     """
     Get analytics for a file, computing them on-demand if needed.
 
@@ -201,7 +203,10 @@ def _get_or_compute_analytics(db: Session, file_id: int, file_status: str) -> An
     """
     analytics = db.query(Analytics).filter(Analytics.media_file_id == file_id).first()
 
-    if analytics or file_status != "completed":
+    # Enum comparison — the old str-based form compared "FileStatus.COMPLETED"
+    # against "completed" and was always True, so the on-demand computation
+    # below never ran (issue #272).
+    if analytics or file_status != FileStatus.COMPLETED:
         return analytics  # type: ignore[no-any-return]
 
     # Compute analytics on-demand for completed files
@@ -642,7 +647,7 @@ def get_media_file_detail(
             SpeakerStatusService.add_computed_status(speaker)
 
         # Get analytics (compute on-demand if needed)
-        analytics = _get_or_compute_analytics(db, file_id, str(db_file.status))
+        analytics = _get_or_compute_analytics(db, file_id, db_file.status)
 
         # Get transcript segments with pagination
         transcript_segments, total_segments = _get_transcript_segments(

--- a/backend/app/tasks/redaction_task.py
+++ b/backend/app/tasks/redaction_task.py
@@ -35,6 +35,7 @@ def redaction_detect_task(
     pipeline_task_id: str | None = None,
 ) -> dict[str, Any]:
     """Detect + cache redaction spans for every segment of a file."""
+    from app.core.enums import FileStatus
     from app.db.session_utils import session_scope
     from app.models.media import MediaFile
     from app.services.redaction.service import RedactionService
@@ -50,8 +51,13 @@ def redaction_detect_task(
             if media is None:
                 return {"status": "skipped", "reason": "file_not_found"}
             owner_id = int(media.user_id)
-            # Guard: don't run while the file is being reprocessed.
-            if str(media.status) in ("processing", "cancelling") and not media.transcript_segments:
+            # Guard: don't run while the file is being reprocessed. Enum
+            # comparison — str(FileStatus.X) is "FileStatus.X", so the old
+            # string form never matched (issue #272).
+            if (
+                media.status in (FileStatus.PROCESSING, FileStatus.CANCELLING)
+                and not media.transcript_segments
+            ):
                 return {"status": "skipped", "reason": "no_segments"}
 
             result = RedactionService.detect_and_store(db, file_id)

--- a/backend/tests/unit/test_issue272_status_comparisons.py
+++ b/backend/tests/unit/test_issue272_status_comparisons.py
@@ -1,0 +1,90 @@
+"""Regression tests for issue #272 — always-False FileStatus string comparisons.
+
+``str(FileStatus.X)`` renders as ``"FileStatus.X"`` (deliberately pinned by the
+status-detail API test), so comparisons against bare value strings like
+``"completed"`` never matched. Two dormant sites were fixed to compare enum
+members; these tests pin the now-active behavior.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from app.api.endpoints.files.crud import _get_or_compute_analytics
+from app.core.enums import FileStatus
+
+
+def _db_returning_analytics(existing):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = existing
+    return db
+
+
+class TestAnalyticsOnDemandGate:
+    def test_completed_file_without_analytics_computes_on_demand(self):
+        """The on-demand path was dead pre-fix: the str-compare gate always
+        early-returned. A COMPLETED file with no stored analytics must trigger
+        computation now."""
+        db = _db_returning_analytics(None)
+        with patch(
+            "app.services.analytics_service.AnalyticsService.compute_and_save_analytics",
+            return_value=False,
+        ) as compute:
+            result = _get_or_compute_analytics(db, 123, FileStatus.COMPLETED)
+        compute.assert_called_once_with(db, 123)
+        assert result is None  # compute reported failure; nothing to fetch
+
+    def test_incomplete_file_never_computes(self):
+        db = _db_returning_analytics(None)
+        with patch(
+            "app.services.analytics_service.AnalyticsService.compute_and_save_analytics"
+        ) as compute:
+            for status in (FileStatus.PENDING, FileStatus.PROCESSING, FileStatus.ERROR):
+                assert _get_or_compute_analytics(db, 123, status) is None
+        compute.assert_not_called()
+
+    def test_existing_analytics_short_circuits(self):
+        existing = MagicMock()
+        db = _db_returning_analytics(existing)
+        with patch(
+            "app.services.analytics_service.AnalyticsService.compute_and_save_analytics"
+        ) as compute:
+            assert _get_or_compute_analytics(db, 123, FileStatus.COMPLETED) is existing
+        compute.assert_not_called()
+
+
+class TestRedactionReprocessGuard:
+    def test_guard_matches_enum_status(self):
+        """The reprocess guard's membership test must match actual enum
+        statuses (the pre-fix str() form matched nothing)."""
+        for status in (FileStatus.PROCESSING, FileStatus.CANCELLING):
+            assert status in (FileStatus.PROCESSING, FileStatus.CANCELLING)
+        # And the old broken form stays broken — documenting WHY the fix exists.
+        assert str(FileStatus.PROCESSING) not in ("processing", "cancelling")
+
+    def test_task_skips_mid_reprocess_file_without_segments(self):
+        """End-to-end through the task body: PROCESSING + no segments → skipped."""
+        from app.tasks.redaction_task import redaction_detect_task
+
+        media = MagicMock()
+        media.status = FileStatus.PROCESSING
+        media.transcript_segments = []
+        media.user_id = 1
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = media
+
+        class _Scope:
+            def __enter__(self):
+                return session
+
+            def __exit__(self, *a):
+                return False
+
+        with (
+            patch("app.db.session_utils.session_scope", return_value=_Scope()),
+            patch("app.services.redaction.service.RedactionService.detect_and_store") as detect,
+        ):
+            result = redaction_detect_task.run(file_id=1)
+
+        assert result == {"status": "skipped", "reason": "no_segments"}
+        detect.assert_not_called()


### PR DESCRIPTION
Fixes the dormant comparisons the #271 codemod audit surfaced: the redaction reprocess guard (never fired) and the on-demand analytics gate at **three** sites — the helper plus both callers, the second caller surfaced by mypy during this fix (**on-demand analytics never computed anywhere**). All now compare enum members; 5 regression tests pin the behavior. StrEnum conversion deliberately out of scope (would change the pinned API string). Closes #272.