### PR TITLE
ci: make the backend test gate honest (pipefail) + fix the 7 failures it was masking

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -132,6 +132,10 @@ jobs:
       - name: Run unit/API test suite (with coverage, report-only)
         working-directory: backend
         run: |
+          # pipefail is REQUIRED: GitHub's default shell is `bash -e {0}` WITHOUT
+          # pipefail, so `pytest | tee` exits with tee's status (0) and pytest
+          # failures silently pass the job. This masked real failures for months.
+          set -o pipefail
           pytest tests/ --cov=app --cov-report=term | tee pytest-output.txt
           {
             echo "## Backend Test Coverage (report-only)"

--- a/backend/app/api/endpoints/embedding_migration.py
+++ b/backend/app/api/endpoints/embedding_migration.py
@@ -83,6 +83,11 @@ async def get_migration_status(
     - Document counts in each index
     - Progress tracking (if migration is running)
     - Stalled migration detection (when Redis data expired)
+
+    Degrades gracefully when OpenSearch is unavailable: still 200, with
+    ``{"status": "error", "message": "OpenSearch not available"}`` in place of
+    the index fields; ``mode_info``/``progress``/``stalled`` are always present
+    (mode defaults to v4, progress to the not-running envelope).
     """
     from app.tasks.embedding_migration_v4 import get_migration_status
 

--- a/backend/app/api/endpoints/speaker_profiles.py
+++ b/backend/app/api/endpoints/speaker_profiles.py
@@ -572,9 +572,11 @@ def get_speaker_profile_occurrences(
             raise HTTPException(status_code=403, detail="Not authorized to access this profile")
         profile_id = profile.id
 
-        # Initialize matching service
-        embedding_service = SpeakerEmbeddingService()
-        matching_service = SpeakerMatchingService(db, embedding_service)
+        # find_speaker_occurrences is a pure DB read — never construct
+        # SpeakerEmbeddingService here: it imports pyannote and loads the
+        # embedding model, which the API/CI image doesn't ship (→ 500) and
+        # which would waste model loads per request even where it does.
+        matching_service = SpeakerMatchingService(db, None)
 
         # Get occurrences
         occurrences = matching_service.find_speaker_occurrences(int(profile_id), current_user.id)

--- a/backend/app/tasks/embedding_migration_v4.py
+++ b/backend/app/tasks/embedding_migration_v4.py
@@ -16,6 +16,7 @@ Key features:
 - Safe finalize with count validation, backup, and finally-block cleanup
 """
 
+import contextlib
 import datetime
 import json
 import logging
@@ -54,7 +55,15 @@ _BATCH_SIZE = 25
 
 
 def get_migration_status() -> dict:
-    """Get the current migration status."""
+    """Get the current migration status.
+
+    Degrades gracefully when OpenSearch is unreachable: constructing the client
+    never touches the network, so an outage only surfaces on the first real call
+    — return the same "not available" envelope as the no-client branch instead
+    of letting a connection error bubble up as a 500 from the status endpoint.
+    """
+    from opensearchpy.exceptions import OpenSearchException
+
     from app.services.opensearch_service import get_opensearch_client
 
     client = get_opensearch_client()
@@ -65,7 +74,12 @@ def get_migration_status() -> dict:
     v3_index = get_speaker_index_v3()
     v4_index = get_speaker_index_v4()
     backup_index = get_speaker_index_v3_backup()
-    v4_exists = client.indices.exists(index=v4_index)
+    try:
+        v4_exists = client.indices.exists(index=v4_index)
+        backup_exists = client.indices.exists(index=backup_index)
+    except OpenSearchException as e:
+        logger.warning("OpenSearch unreachable while reading migration status: %s", e)
+        return {"status": "error", "message": "OpenSearch not available"}
 
     # Count only speaker documents (exclude profile_ and cluster_ documents
     # which share the same index but have a document_type field)
@@ -88,15 +102,10 @@ def get_migration_status() -> dict:
     except Exception:
         v4_document_count = 0
 
-    # If v3 concrete index is empty, check the legacy backup
-    if v3_document_count == 0:
-        try:
-            if client.indices.exists(index=backup_index):
-                v3_document_count = client.count(index=backup_index, body=speaker_only_query)[
-                    "count"
-                ]
-        except Exception:  # noqa: S110  # nosec B110 — backup index check is non-critical
-            pass
+    # If v3 concrete index is empty, check the legacy backup (non-critical)
+    if v3_document_count == 0 and backup_exists:
+        with contextlib.suppress(Exception):
+            v3_document_count = client.count(index=backup_index, body=speaker_only_query)["count"]
 
     return {
         "current_mode": current_mode,
@@ -104,8 +113,7 @@ def get_migration_status() -> dict:
         "v3_document_count": v3_document_count,
         "v4_document_count": v4_document_count,
         "migration_needed": current_mode == "v3",
-        "migration_complete": current_mode == "v4"
-        and not client.indices.exists(index=get_speaker_index_v3_backup()),
+        "migration_complete": current_mode == "v4" and not backup_exists,
         "transcription_paused": False,
     }
 

--- a/backend/tests/api/test_files_streaming.py
+++ b/backend/tests/api/test_files_streaming.py
@@ -300,16 +300,22 @@ def test_download_stream_unauthorized(client, normal_user, db_session):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_download_stream_content_type(client, user_token_headers, normal_user, db_session):
+def test_download_stream_content_type(
+    client, user_token_headers, normal_user, db_session, monkeypatch
+):
     """For an audio_original passthrough the SSE response advertises event-stream.
 
     We assert only the response contract (status + content type + SSE headers)
-    without consuming the (potentially long-lived) stream. The audio_original
-    mode hits the ready/passthrough path, which under SKIP_S3 resolves a presigned
-    URL synchronously, so the first ``ready`` event is produced immediately and the
-    generator returns — but TestClient buffers the body, so we keep the assertion to
-    the headers to avoid coupling to MinIO availability.
+    without consuming the (potentially long-lived) stream. The audio_original mode
+    hits the ready/passthrough path, which presigns via minio-py — and presigning
+    is NOT purely local: the SDK issues a bucket-region lookup over the network,
+    and ``_resolve_ready_download`` has no SKIP_S3 branch. Stub the presign so the
+    test is hermetic (no MinIO needed); the URL itself is never asserted here.
     """
+    monkeypatch.setattr(
+        "app.services.minio_service.get_presigned_download_url",
+        lambda *args, **kwargs: "https://storage.test/presigned/clip.wav",
+    )
     media_file = _make_file(db_session, normal_user, filename="clip.wav")
     with client.stream(
         "GET",

--- a/backend/tests/api/test_migration_endpoints.py
+++ b/backend/tests/api/test_migration_endpoints.py
@@ -26,8 +26,14 @@ internal exception, which the happy/auth paths below do not trigger).
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from fastapi import status
+
+# Mirrors conftest's stack detection: False on the dev host (OpenSearch reachable
+# on localhost:5180), True on bare CI runners — both response shapes are pinned.
+_OPENSEARCH_ABSENT = os.environ.get("SKIP_OPENSEARCH", "True").lower() == "true"
 
 FAKE_TASK_ID = "test-task-id"  # from conftest _skip_celery_dispatch
 
@@ -108,13 +114,25 @@ def test_delete_routes_non_superuser_forbidden(client, user_token_headers, path)
 
 
 def test_embedding_status_admin_ok(client, super_admin_token_headers):
-    """Status returns 200 with mode/progress fields (OpenSearch degrades to v4)."""
+    """Status returns 200 with mode/progress fields in BOTH availability states.
+
+    With OpenSearch up, the body carries the index-derived fields. With
+    OpenSearch absent the endpoint must degrade — the documented contract is a
+    200 carrying ``status: error`` / ``OpenSearch not available`` plus the
+    always-present mode/progress/stalled fields, never a 500.
+    """
     response = client.get(f"{EMBEDDING}/status", headers=super_admin_token_headers)
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
     assert "progress" in body
     assert "mode_info" in body
     assert "stalled" in body
+    if _OPENSEARCH_ABSENT:
+        assert body["status"] == "error"
+        assert body["message"] == "OpenSearch not available"
+    else:
+        assert "current_mode" in body
+        assert "v4_document_count" in body
 
 
 def test_embedding_progress_admin_ok(client, super_admin_token_headers):

--- a/backend/tests/unit/test_backup_alerts.py
+++ b/backend/tests/unit/test_backup_alerts.py
@@ -1,7 +1,9 @@
 """Unit tests for backup admin alerting (issue #244) + the one-time keys notice (#243).
 
-The WebSocket boundary (``send_task_notification``) is mocked; recipient selection and
-message content are asserted against the real admin users in the test database.
+The WebSocket boundary (``send_task_notification``) is mocked. Recipient tests take the
+``admin_user`` fixture so at least one admin exists even on a fresh CI database — they
+must never assume the dev stack's seeded admin. Counts are always recomputed from
+``_admin_user_ids`` on the same savepoint session, so extra ambient admins are fine.
 """
 
 from __future__ import annotations
@@ -51,9 +53,9 @@ def test_collect_warnings_flags_prune_snapshot_and_recovery():
 # =============================================================================
 # notify_backup_result — failure / warning / silence
 # =============================================================================
-def test_failure_sends_admin_notification(db_session):
+def test_failure_sends_admin_notification(db_session, admin_user):
     admin_ids = backup_alerts._admin_user_ids(db_session)
-    assert admin_ids, "test DB must contain at least one admin user"
+    assert admin_user.id in admin_ids
 
     with mock.patch("app.services.notification_service.send_task_notification") as sender:
         backup_alerts.notify_backup_result(
@@ -77,7 +79,7 @@ def test_clean_success_sends_nothing(db_session):
     sender.assert_not_called()
 
 
-def test_success_with_warnings_notifies(db_session):
+def test_success_with_warnings_notifies(db_session, admin_user):
     _clear_backup_keys(db_session)
     result = {
         "ok": True,
@@ -92,8 +94,9 @@ def test_success_with_warnings_notifies(db_session):
     assert "disk gone" in sender.call_args.kwargs["message"]
 
 
-def test_failure_alerting_never_raises(db_session):
-    # Even if the notification layer explodes, the backup run must not.
+def test_failure_alerting_never_raises(db_session, admin_user):
+    # Even if the notification layer explodes, the backup run must not. Needs a
+    # real recipient or the raising mock is never called (vacuous on a fresh DB).
     with mock.patch(
         "app.services.notification_service.send_task_notification",
         side_effect=RuntimeError("redis down"),
@@ -104,7 +107,7 @@ def test_failure_alerting_never_raises(db_session):
 # =============================================================================
 # One-time "backups exclude your encryption keys" notice (#243)
 # =============================================================================
-def test_keys_notice_sent_once(db_session):
+def test_keys_notice_sent_once(db_session, admin_user):
     _clear_backup_keys(db_session)
     result = {"ok": True, "status": "success", "recovery": {"status": "readme_written"}}
 

--- a/backend/tests/unit/test_uuid7_migration_guard.py
+++ b/backend/tests/unit/test_uuid7_migration_guard.py
@@ -2,11 +2,13 @@
 
 Exercises the exact DO-block convert SQL shipped in
 ``alembic/versions/v368_uuid_native_type_guard.py`` against a real PostgreSQL
-instance (the dev stack on localhost:5176). The test works inside a transaction
-that is always rolled back, so it never mutates the dev schema — it creates a
-throwaway table with a legacy ``varchar(36)`` ``uuid`` column, runs the guard,
-and asserts the column becomes native ``uuid`` with the value preserved and that
-a second run is a no-op.
+instance — the same one the rest of the suite talks to (``settings.POSTGRES_*``,
+which conftest pins from the environment / ``.env`` before test modules import;
+CI's service container provides its own values). The test works inside a
+transaction that is always rolled back, so it never mutates the schema — it
+creates a throwaway table with a legacy ``varchar(36)`` ``uuid`` column, runs
+the guard, and asserts the column becomes native ``uuid`` with the value
+preserved and that a second run is a no-op.
 
 Skips cleanly when no PostgreSQL is reachable (mirrors conftest's TCP probe).
 
@@ -23,6 +25,8 @@ from __future__ import annotations
 import socket
 
 import pytest
+
+from app.core.config import settings
 
 # The exact convert block from v368's upgrade().
 _GUARD_SQL = """
@@ -46,8 +50,15 @@ END
 $$;
 """
 
-_HOST = "localhost"
-_PORT = 5176
+# Connect exactly where the rest of the suite connects: settings.POSTGRES_* is
+# the canonical config (conftest pins the env from .env / CI before any test
+# module imports, and builds its engine from the same settings). No credentials
+# are hardcoded here — dev stack and CI service container both flow through env.
+_HOST = settings.POSTGRES_HOST
+_PORT = int(settings.POSTGRES_PORT)
+_USER = settings.POSTGRES_USER
+_PASSWORD = settings.POSTGRES_PASSWORD
+_DBNAME = settings.POSTGRES_DB
 
 
 def _pg_reachable() -> bool:
@@ -58,16 +69,16 @@ def _pg_reachable() -> bool:
         return False
 
 
-@pytest.mark.skipif(not _pg_reachable(), reason="dev PostgreSQL not reachable on localhost:5176")
+@pytest.mark.skipif(not _pg_reachable(), reason=f"PostgreSQL not reachable on {_HOST}:{_PORT}")
 def test_v368_guard_converts_legacy_varchar_uuid_and_is_idempotent():
     psycopg2 = pytest.importorskip("psycopg2")
 
     conn = psycopg2.connect(
         host=_HOST,
         port=_PORT,
-        user="postgres",
-        password="CHANGE_ME_auto_generated_on_install",
-        dbname="opentranscribe",
+        user=_USER,
+        password=_PASSWORD,
+        dbname=_DBNAME,
     )
     try:
         cur = conn.cursor()


### PR DESCRIPTION
## Root cause: a pipe-masked CI gate

The **Backend Tests** job's main step runs `pytest tests/ ... | tee pytest-output.txt`. GitHub's default run shell is `bash -e {0}` **without** `pipefail`, so the step's exit code was `tee`'s (always 0) — pytest failures have been merging under green checkmarks. The latest "green" master run actually contained **7 real test failures**.

**Fix:** `set -o pipefail` as the first line of that run block (with a comment explaining why it must stay).

**Workflow audit** (all 5 workflows checked for the same hazard):
- `pre-commit.yml` — the one masked pipe, fixed here.
- `seam-guard.yml` — already `set -euo pipefail`. ✅
- `security-scan.yml` — the `|| echo ::warning::` fallbacks are deliberately non-blocking and documented as such; no masking pipes. ✅
- `docker-publish.yml`, `deploy-docs.yml` — no piped run commands. ✅

## The 7 masked failures — root cause and fix per test

| Test | Root cause | Fix (contract, not patch) |
|---|---|---|
| `test_files_streaming.py::test_download_stream_content_type` | The `audio_original` SSE ready-path presigns via minio-py, and presigning is **not purely local** — the SDK issues a bucket-region network lookup. `_resolve_ready_download` has **no SKIP_S3 branch** (the old docstring's claim was false), so CI hit a dead MinIO. | Test asserts only the SSE response contract, so the presign is stubbed at the service seam (`get_presigned_download_url`) — hermetic, no MinIO needed; docstring corrected. |
| `test_migration_endpoints.py::test_embedding_status_admin_ok` | **Real endpoint bug.** `get_migration_status()` only guarded `client is None`, but the OpenSearch client is constructed lazily without touching the network — with OpenSearch down, the first real call (`indices.exists`) raised and `GET /api/embeddings/migration/status` returned **500**. | Endpoint fixed: `OpenSearchException` on the index reads now returns the same documented degraded envelope as the no-client branch (`status: error, message: OpenSearch not available`) inside a 200; `mode_info`/`progress`/`stalled` always present. Contract documented in the endpoint docstring and asserted for **both** availability states in the test. |
| `test_speaker_profiles.py::test_occurrences_owner_200_empty` | **Real endpoint bug — not OS-related.** `GET /profiles/{uuid}/occurrences` eagerly constructed `SpeakerEmbeddingService`, whose `__init__` imports pyannote and loads the embedding model. pyannote is deliberately absent from `requirements-ci.txt` (GPU-worker-only), so the endpoint 500'd in CI — and wasted a model load per request everywhere else. `find_speaker_occurrences()` is a pure DB read. | Endpoint fixed: pass `SpeakerMatchingService(db, None)` (the same explicit-None pattern the suggestion endpoints in the same module already use). No test change needed — the 200-with-empty-list contract was already right. |
| `test_backup_alerts.py::{test_failure_sends_admin_notification, test_success_with_warnings_notifies, test_keys_notice_sent_once}` | Tests depended on ambient state — the dev DB's seeded admin as notification recipient. CI's fresh DB has zero admins, so recipient fan-out was empty (and the never-raises test was **vacuous**: the raising mock was never called). The alerts code itself is correct — recipient selection and fan-out behave as designed. | Tests take the existing `admin_user` fixture (savepoint-isolated), so a recipient always exists; all count assertions were already recomputed from `_admin_user_ids` on the same session, so extra ambient admins remain fine. `test_failure_alerting_never_raises` now actually exercises the guard. |
| `test_uuid7_migration_guard.py::test_v368_guard_...` | Hardcoded the local install's Postgres password (`CHANGE_ME_auto_generated_on_install`) and dbname `opentranscribe`; CI's service container uses `postgres`/`postgres` and db `transcribe_app`. | Connects via `settings.POSTGRES_*` — the exact canonical config the suite's engine is built from (conftest pins env before test modules import). **No credentials hardcoded anywhere**; reachability probe uses the same host/port. |

## Verification

- Full backend suite vs the live dev stack: **2282 passed, 373 skipped, exit 0**.
- CI-emulation run (`SKIP_S3=True SKIP_OPENSEARCH=True`, MinIO/OpenSearch pointed at dead ports): all affected files green, including the new degraded-contract assertions.
- ruff (check + format), mypy, and all pre-commit hooks pass on the touched files.
- The real proof is this PR's **Backend Tests** check running with the now-strict gate — watching it before this is mergeable.

Do not merge yet — awaiting the strict-gate CI result.