### PR TITLE
fix(build): bake APP_VERSION into backend images

### DIFF
--- a/backend/Dockerfile.blackwell
+++ b/backend/Dockerfile.blackwell
@@ -19,6 +19,12 @@
 
 FROM nvcr.io/nvidia/pytorch:25.01-py3
 
+# Bake the release version into the image so /health and /system/stats report
+# it without a repo checkout or env plumbing (version.py: file -> env -> unknown).
+# Passed by scripts/docker-build-push.sh from the repo-root VERSION file.
+ARG APP_VERSION=unknown
+ENV APP_VERSION=${APP_VERSION}
+
 LABEL org.opencontainers.image.title="OpenTranscribe Backend (Blackwell)" \
       org.opencontainers.image.description="AI-powered transcription backend for NVIDIA Blackwell/DGX Spark" \
       org.opencontainers.image.vendor="OpenTranscribe" \

--- a/backend/Dockerfile.lite
+++ b/backend/Dockerfile.lite
@@ -33,6 +33,12 @@ RUN pip install --user --no-cache-dir --no-warn-script-location -r requirements-
 # -----------------------------------------------------------------------------
 FROM python:3.13-slim-trixie
 
+# Bake the release version into the image so /health and /system/stats report
+# it without a repo checkout or env plumbing (version.py: file -> env -> unknown).
+# Passed by scripts/docker-build-push.sh from the repo-root VERSION file.
+ARG APP_VERSION=unknown
+ENV APP_VERSION=${APP_VERSION}
+
 # OCI annotations for container metadata and compliance
 LABEL org.opencontainers.image.title="OpenTranscribe Backend Lite" \
       org.opencontainers.image.description="Cloud-only ASR backend (no GPU required) with multi-provider support" \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -69,6 +69,12 @@ RUN pip uninstall -y --root-user-action=ignore triton || true
 # -----------------------------------------------------------------------------
 FROM python:3.13-slim-trixie
 
+# Bake the release version into the image so /health and /system/stats report
+# it without a repo checkout or env plumbing (version.py: file -> env -> unknown).
+# Passed by scripts/docker-build-push.sh from the repo-root VERSION file.
+ARG APP_VERSION=unknown
+ENV APP_VERSION=${APP_VERSION}
+
 # OCI annotations for container metadata and compliance
 LABEL org.opencontainers.image.title="OpenTranscribe Backend" \
       org.opencontainers.image.description="AI-powered transcription backend with WhisperX and PyAnnote" \

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -70,7 +70,7 @@ EXPOSE 8080
 
 # Health check to verify nginx is responding
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/ || exit 1
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:8080/ || exit 1
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -166,6 +166,7 @@ build_backend_blackwell() {
     docker buildx build \
         --platform "linux/arm64" \
         --file Dockerfile.blackwell \
+        --build-arg APP_VERSION="${VERSION_FULL}" \
         --tag "${REPO_BACKEND}:blackwell" \
         --tag "${REPO_BACKEND}:blackwell-${VERSION_FULL}" \
         ${CACHE_FLAG} \
@@ -193,6 +194,7 @@ build_backend() {
     docker buildx build \
         --platform "${PLATFORMS}" \
         --file Dockerfile.prod \
+        --build-arg APP_VERSION="${VERSION_FULL}" \
         --tag "${REPO_BACKEND}:latest" \
         --tag "${REPO_BACKEND}:${VERSION_FULL}" \
         ${CACHE_FLAG} \
@@ -220,6 +222,7 @@ build_frontend() {
     docker buildx build \
         --platform "${PLATFORMS}" \
         --file Dockerfile.prod \
+        --build-arg APP_VERSION="${VERSION_FULL}" \
         --tag "${REPO_FRONTEND}:latest" \
         --tag "${REPO_FRONTEND}:${VERSION_FULL}" \
         ${CACHE_FLAG} \


### PR DESCRIPTION
Prod images on Docker Hub report `version: unknown` today — `version.py` can't find the repo-root VERSION file (not in the backend build context) and the APP_VERSION env fallback is never set outside dev's bind-mount. Bakes it at build time via ARG→ENV in prod/lite/blackwell runtime stages, passed by `docker-build-push.sh` from the VERSION file. Found during live RC deployment verification of the cloud stack.