### PR TITLE
feat(search): macOS-style settings search + app-wide unified search

### DIFF
--- a/backend/app/api/endpoints/search.py
+++ b/backend/app/api/endpoints/search.py
@@ -116,6 +116,13 @@ def search_transcripts(
     title_filter: str | None = Query(
         None, description="Filter by filename/title (substring match)"
     ),
+    file_uuid: str | None = Query(
+        None,
+        description=(
+            "Scope results to a single file (its UUID). Used by the in-page transcript "
+            "find bar to list every match across the whole paginated transcript."
+        ),
+    ),
     db: Session = Depends(get_db),
     ctx: RequestContext = Depends(get_current_context),
     _active: User = Depends(get_current_active_user),  # preserve the is_active gate
@@ -190,6 +197,7 @@ def search_transcripts(
         language=language,
         title_filter=title_filter,
         organization_id=ctx.org_id,
+        file_uuid=file_uuid,
     )
 
     # Abuse/DMCA: the OpenSearch transcript index has no quarantine field, so
@@ -199,6 +207,30 @@ def search_transcripts(
         _drop_quarantined_search_hits(db, response)
 
     return _search_response_to_schema(response)
+
+
+@router.get("/count")
+def search_match_count(
+    q: str = Query(..., min_length=1, description="Search query"),
+    file_uuid: str | None = Query(None, description="Scope the count to a single file (its UUID)."),
+    ctx: RequestContext = Depends(get_current_context),
+    _active: User = Depends(get_current_active_user),  # preserve the is_active gate
+) -> dict[str, int]:
+    """Lightweight transcript match-count for the in-page find bar.
+
+    Returns just ``{"total": N}`` — the number of transcript chunks matching ``q``
+    (optionally within a single file). This is intentionally far cheaper than the full
+    hybrid ``/search`` (no query embedding, RRF pipeline, snippets, or highlighting),
+    so it stays fast under concurrent use: the find bar polls it as the user types to
+    learn whether matches exist beyond the segments currently loaded in the browser.
+    """
+    from app.services.search.hybrid_search_service import HybridSearchService
+
+    service = HybridSearchService()
+    total = service.count_matches(
+        q, user_id=ctx.user.id, file_uuid=file_uuid, organization_id=ctx.org_id
+    )
+    return {"total": total}
 
 
 def _drop_quarantined_search_hits(db: Session, response: Any) -> None:

--- a/backend/app/services/search/hybrid_search_service.py
+++ b/backend/app/services/search/hybrid_search_service.py
@@ -514,6 +514,7 @@ class HybridSearchService:
         language: str | None = None,
         title_filter: str | None = None,
         organization_id: int | None = None,
+        file_uuid: str | None = None,
     ) -> SearchResponse:
         """Execute hybrid search and return grouped results.
 
@@ -565,6 +566,7 @@ class HybridSearchService:
             language=language,
             title_filter=title_filter,
             organization_id=organization_id,
+            file_uuid=file_uuid,
         )
         cached = _get_cached_response(cache_key)
         if cached:
@@ -599,6 +601,7 @@ class HybridSearchService:
             language=language,
             title_filter=title_filter,
             organization_id=organization_id,
+            file_uuid=file_uuid,
         )
         filters_applied = _collect_filters_applied(
             speakers=speakers,
@@ -1062,6 +1065,7 @@ class HybridSearchService:
         language: str | None = None,
         title_filter: str | None = None,
         organization_id: int | None = None,
+        file_uuid: str | None = None,
     ) -> list[dict[str, Any]]:
         """Build OpenSearch filter clauses.
 
@@ -1069,12 +1073,18 @@ class HybridSearchService:
         adds the default-deny tenant gate (org term when set, else exclude any
         org-stamped doc). Community-edition invariance: ``organization_id`` is
         always None and docs are org-less, so the personal gate is a no-op.
+
+        ``file_uuid`` scopes results to a single file — used by the in-page
+        transcript find bar so it can list every match across the whole
+        (paginated) transcript, including segments not yet loaded in the browser.
         """
         from app.services.search.tenant_scope import org_filter_clauses
 
         filters: list[dict[str, Any]] = [{"terms": {"accessible_user_ids": [user_id]}}]
         filters.extend(org_filter_clauses(organization_id))
 
+        if file_uuid:
+            filters.append({"term": {"file_uuid": file_uuid}})
         if speakers:
             filters.append({"terms": {"speaker": speakers}})
         if tags:
@@ -1098,6 +1108,57 @@ class HybridSearchService:
         _append_range_filter(filters, "file_size", min_file_size, max_file_size)
 
         return filters
+
+    def count_matches(
+        self,
+        query: str,
+        user_id: int,
+        file_uuid: str | None = None,
+        organization_id: int | None = None,
+    ) -> int:
+        """Count transcript chunks matching ``query`` (optionally within one file).
+
+        A deliberately lightweight path for the in-page transcript find bar. It runs a
+        single ``size=0`` OpenSearch query — no query embedding, no RRF pipeline, no
+        snippet extraction, no highlighting — so it stays cheap even when many users
+        search at once (FastAPI runs this sync call in its threadpool and OpenSearch
+        serves the searches concurrently). Returns the exact matching-chunk count
+        (``track_total_hits``), used purely as a "matches exist beyond the loaded
+        window" signal for progressive loading.
+        """
+        clean = (query or "").strip()
+        if not clean:
+            return 0
+        client = get_opensearch_client()
+        if not client:
+            return 0
+
+        _ensure_infrastructure()
+        filters = self._build_filters(
+            user_id,
+            None,
+            None,
+            None,
+            None,
+            file_uuid=file_uuid,
+            organization_id=organization_id,
+        )
+        text_query = self._build_text_query(clean, ["content", "content.exact"])
+        body = {
+            "size": 0,
+            "track_total_hits": True,
+            "query": {"bool": {"filter": filters, "must": [text_query]}},
+        }
+        try:
+            resp = client.search(index=settings.OPENSEARCH_CHUNKS_INDEX, body=body)
+        except Exception as exc:  # noqa: BLE001 — degrade to "unknown" on any OS error
+            logger.warning(f"count_matches failed: {exc}")
+            return 0
+
+        total = resp.get("hits", {}).get("total", {})
+        if isinstance(total, dict):
+            return int(total.get("value", 0))
+        return int(total or 0)
 
     def _build_highlight_fields(
         self,

--- a/backend/tests/e2e/test_file_detail_transcript.py
+++ b/backend/tests/e2e/test_file_detail_transcript.py
@@ -299,3 +299,84 @@ class TestSpeakerEditor:
         editor = detail_page.locator(".speaker-editor-container")
         expect(editor).to_be_visible(timeout=10000)
         expect(detail_page.locator(".speaker-editor-header")).to_be_visible(timeout=5000)
+
+
+def _pick_search_word(page: Page) -> str:
+    """Pick a real word (>=4 letters) from the first transcript segment.
+
+    Guarantees the transcript find bar will have at least one literal match to
+    highlight and navigate, without mutating any data.
+    """
+    text = (page.locator(".transcript-segment .segment-text").first.text_content() or "").strip()
+    for token in text.split():
+        cleaned = "".join(ch for ch in token if ch.isalpha())
+        if len(cleaned) >= 4:
+            return cleaned
+    return "the"
+
+
+def _open_transcript_search(page: Page):  # type: ignore[no-untyped-def]
+    """Open the in-transcript find bar and return its input locator."""
+    trigger = page.locator(".search-trigger-button")
+    expect(trigger).to_be_visible(timeout=10000)
+    trigger.click()
+    search_input = page.locator(".transcript-search input")
+    expect(search_input).to_be_visible(timeout=5000)
+    return search_input
+
+
+class TestTranscriptSearch:
+    """In-transcript find bar: open, match, highlight, navigate, close.
+
+    Read-only: search never edits the transcript.
+    """
+
+    def test_search_bar_opens_from_trigger(self, detail_page: Page) -> None:
+        """The find trigger reveals a search input in the transcript header."""
+        _open_transcript_search(detail_page)
+        expect(detail_page.locator(".transcript-search .search-bar")).to_be_visible(timeout=5000)
+
+    def test_query_highlights_and_counts_matches(self, detail_page: Page) -> None:
+        """Typing a real word highlights matches and shows an 'N of M' counter."""
+        search_input = _open_transcript_search(detail_page)
+        word = _pick_search_word(detail_page)
+        search_input.fill(word)
+
+        # Literal matches highlight in the (loaded) transcript.
+        expect(detail_page.locator(".transcript-search-highlight").first).to_be_visible(
+            timeout=8000
+        )
+        # The counter resolves to a match count (backend completeness probe may add '+').
+        # The loading status reuses .search-bar-counter, so target the match counter only.
+        counter = detail_page.locator(
+            ".transcript-search .search-bar-counter:not(.search-bar-status-text)"
+        )
+        expect(counter).to_be_visible(timeout=10000)
+        assert "of" in (counter.text_content() or ""), "Counter should read 'N of M'"
+
+    def test_next_navigation_flashes_current_match(self, detail_page: Page) -> None:
+        """Advancing to the next match scrolls to and flashes that segment."""
+        search_input = _open_transcript_search(detail_page)
+        search_input.fill(_pick_search_word(detail_page))
+        expect(detail_page.locator(".transcript-search-highlight").first).to_be_visible(
+            timeout=8000
+        )
+        # Second nav button in the shared SearchBar is "next".
+        detail_page.locator(".transcript-search .search-bar-btn").nth(1).click()
+        # The active match gets the whole-segment pulse class.
+        expect(detail_page.locator(".search-current-match").first).to_be_visible(timeout=5000)
+
+    def test_escape_closes_search(self, detail_page: Page) -> None:
+        """Escape closes the find bar and restores the trigger button."""
+        search_input = _open_transcript_search(detail_page)
+        search_input.fill(_pick_search_word(detail_page))
+        detail_page.keyboard.press("Escape")
+        expect(detail_page.locator(".search-trigger-button")).to_be_visible(timeout=5000)
+
+    def test_transcript_search_no_unexpected_console_errors(self, detail_page: Page) -> None:
+        """Searching the transcript produces no new (non-benign) console errors."""
+        search_input = _open_transcript_search(detail_page)
+        search_input.fill(_pick_search_word(detail_page))
+        detail_page.wait_for_timeout(3500)  # allow the backend completeness probe to resolve
+        unexpected = _unexpected_console_errors(detail_page._console_errors)  # type: ignore[attr-defined]
+        assert not unexpected, f"Unexpected console errors during transcript search: {unexpected}"

--- a/backend/tests/e2e/test_settings_modal.py
+++ b/backend/tests/e2e/test_settings_modal.py
@@ -236,3 +236,86 @@ class TestTranscriptionSection:
         if app_page.locator("#min-speakers").count():
             expect(app_page.locator("#min-speakers")).to_be_visible()
             expect(app_page.locator("#max-speakers")).to_be_visible()
+
+
+# ---------------------------------------------------------------------------
+# macOS-style settings search (search box above the sidebar tabs).
+# ---------------------------------------------------------------------------
+SEARCH_INPUT = "#settings-search-desktop-input"
+RESULT_ITEMS = '[id^="settings-search-desktop-result-"]'
+NAV_GROUPS = ".settings-sidebar .sidebar-section"
+
+
+def _open_settings_search(page: Page):  # type: ignore[no-untyped-def]
+    """Open the modal and return the sidebar search input locator."""
+    _open_settings_modal(page)
+    search_input = page.locator(SEARCH_INPUT)
+    expect(search_input).to_be_visible(timeout=8000)
+    return search_input
+
+
+class TestSettingsSearch:
+    """macOS-style settings search: query -> ranked results -> jump to section."""
+
+    def test_search_input_present(self, app_page: Page) -> None:
+        """A search box renders at the top of the settings sidebar."""
+        _open_settings_search(app_page)
+        # Normal grouped nav is visible before any query.
+        assert app_page.locator(NAV_GROUPS).count() >= 1
+
+    def test_query_shows_results_and_replaces_nav(self, app_page: Page) -> None:
+        """Typing a query lists matching settings and hides the grouped nav."""
+        search_input = _open_settings_search(app_page)
+        search_input.fill("transcription")
+        results = app_page.locator(RESULT_ITEMS)
+        expect(results.first).to_be_visible(timeout=5000)
+        assert results.count() >= 1, "Expected at least one settings search result"
+        # The grouped nav is replaced by the results list while searching.
+        expect(app_page.locator(NAV_GROUPS)).to_have_count(0, timeout=3000)
+        # Result rows highlight the matched term.
+        assert app_page.locator(f"{RESULT_ITEMS} .transcript-search-highlight").count() >= 1
+
+    def test_result_navigates_to_section_and_restores_nav(self, app_page: Page) -> None:
+        """Selecting a result switches the panel and restores the grouped nav."""
+        search_input = _open_settings_search(app_page)
+        search_input.fill("transcription")
+        expect(app_page.locator(RESULT_ITEMS).first).to_be_visible(timeout=5000)
+        app_page.locator(RESULT_ITEMS).first.click()
+
+        # A section panel is now shown, and the query cleared -> grouped nav is back.
+        expect(app_page.locator(".settings-content .section-title").first).to_be_visible(
+            timeout=8000
+        )
+        expect(app_page.locator(NAV_GROUPS).first).to_be_visible(timeout=5000)
+        expect(app_page.locator(SEARCH_INPUT)).to_have_value("")
+
+    def test_no_results_state(self, app_page: Page) -> None:
+        """A query with no matches shows an empty state and no result rows."""
+        search_input = _open_settings_search(app_page)
+        search_input.fill("zzzqqxnotarealsetting")
+        expect(app_page.locator(RESULT_ITEMS)).to_have_count(0, timeout=3000)
+        expect(app_page.locator(".settings-search-results .empty-state")).to_be_visible(
+            timeout=5000
+        )
+
+    def test_escape_clears_query_and_restores_nav(self, app_page: Page) -> None:
+        """Escape with a non-empty query clears it (does not close the modal)."""
+        search_input = _open_settings_search(app_page)
+        search_input.fill("download")
+        expect(app_page.locator(RESULT_ITEMS).first).to_be_visible(timeout=5000)
+        search_input.press("Escape")
+        expect(app_page.locator(SEARCH_INPUT)).to_have_value("")
+        expect(app_page.locator(NAV_GROUPS).first).to_be_visible(timeout=5000)
+        # The modal is still open (first Escape only cleared the query).
+        expect(app_page.locator(".settings-modal")).to_be_visible()
+
+    def test_search_emits_no_unexpected_console_errors(self, app_page: Page) -> None:
+        """Searching + navigating produces no new (non-benign) console errors."""
+        search_input = _open_settings_search(app_page)
+        search_input.fill("redaction")
+        app_page.wait_for_timeout(400)
+        if app_page.locator(RESULT_ITEMS).count():
+            app_page.locator(RESULT_ITEMS).first.click()
+            app_page.wait_for_timeout(400)
+        unexpected = _unexpected_console_errors(app_page._console_errors)  # type: ignore[attr-defined]
+        assert not unexpected, f"Unexpected console errors during settings search: {unexpected}"

--- a/backend/tests/services/test_search_file_scope.py
+++ b/backend/tests/services/test_search_file_scope.py
@@ -1,0 +1,62 @@
+"""Unit tests for the single-file (`file_uuid`) search scope filter.
+
+GPU/OpenSearch-free: exercises ``HybridSearchService._build_filters`` directly to
+verify that scoping to one file adds the expected OpenSearch term clause. This is
+what lets the in-page transcript find bar list every match across the whole
+paginated transcript (including segments not yet loaded in the browser).
+"""
+
+from app.services.search.hybrid_search_service import HybridSearchService
+
+FILE_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+def _term_file_uuid_clauses(filters: list[dict]) -> list[dict]:
+    return [f for f in filters if f.get("term", {}).get("file_uuid") is not None]
+
+
+def test_no_file_uuid_scope_by_default():
+    """Global search must not restrict to a single file."""
+    service = HybridSearchService()
+    filters = service._build_filters(
+        user_id=7,
+        speakers=None,
+        tags=None,
+        date_from=None,
+        date_to=None,
+    )
+    assert _term_file_uuid_clauses(filters) == []
+
+
+def test_file_uuid_scope_adds_term_filter():
+    """Passing file_uuid restricts results to that file via a term filter."""
+    service = HybridSearchService()
+    filters = service._build_filters(
+        user_id=7,
+        speakers=None,
+        tags=None,
+        date_from=None,
+        date_to=None,
+        file_uuid=FILE_UUID,
+    )
+    clauses = _term_file_uuid_clauses(filters)
+    assert clauses == [{"term": {"file_uuid": FILE_UUID}}]
+
+
+def test_file_uuid_scope_composes_with_other_filters():
+    """The file scope coexists with other filters (e.g. language)."""
+    service = HybridSearchService()
+    filters = service._build_filters(
+        user_id=7,
+        speakers=["Alice"],
+        tags=None,
+        date_from=None,
+        date_to=None,
+        language="en",
+        file_uuid=FILE_UUID,
+    )
+    assert {"term": {"file_uuid": FILE_UUID}} in filters
+    assert {"term": {"language": "en"}} in filters
+    assert {"terms": {"speaker": ["Alice"]}} in filters
+    # The caller scope (accessible_user_ids) is always present.
+    assert {"terms": {"accessible_user_ids": [7]}} in filters

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^4.4.0",
         "devalue": "^5.8.0",
         "dompurify": "^3.4.11",
+        "fuse.js": "^7.4.2",
         "i18next": "^25.10.10",
         "i18next-browser-languagedetector": "^8.2.1",
         "imohash": "^1.0.3",
@@ -2794,21 +2795,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -7031,16 +7017,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7131,6 +7117,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {
@@ -11254,9 +11253,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "date-fns": "^4.4.0",
     "devalue": "^5.8.0",
     "dompurify": "^3.4.11",
+    "fuse.js": "^7.4.2",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
     "imohash": "^1.0.3",

--- a/frontend/src/components/SettingsModal.svelte
+++ b/frontend/src/components/SettingsModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
+  import i18next from 'i18next';
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
   import { page } from '$app/stores';
   import { user as userStore } from '$stores/auth';
@@ -48,8 +49,17 @@
   import ConfirmationModal from '$components/ConfirmationModal.svelte';
   import ProcessingDetailsModal from '$components/settings/ProcessingDetailsModal.svelte';
 
+  import SettingsSearch from '$components/settings/SettingsSearch.svelte';
+  import {
+    buildSettingsSearchItems,
+    createSettingsFuzzyIndex,
+    type SettingsSearchItem,
+    type VisibleSection,
+  } from '$lib/search/settingsSearchIndex';
+  import type { FuzzyIndex } from '$lib/search/fuzzyMatcher';
+
   // Import i18n
-  import { t } from '$stores/locale';
+  import { t, locale } from '$stores/locale';
   import { getErrorMessage } from '$lib/utils/apiError';
 
   // Modal state
@@ -59,6 +69,12 @@
   // Settings state
   $: isOpen = $settingsModalStore.isOpen;
   $: activeSection = $settingsModalStore.activeSection;
+
+  // Settings search (macOS-style). Index is rebuilt when the visible-section set
+  // (capabilities/edition) or the locale changes; desktop + mobile instances share it.
+  let desktopSearchActive = false;
+  let mobileSearchActive = false;
+  let settingsSearchIndex: FuzzyIndex<SettingsSearchItem> | null = null;
 
   // Close modal when the user navigates to a different page
   let _prevPath = '';
@@ -232,6 +248,75 @@
       items: section.items.filter((item) => capOn(capState, (item as { cap?: string }).cap))
     }))
     .filter((section) => section.items.length > 0);
+
+  // Flat list of the sections this user can actually open — the search index is
+  // limited to these so it never surfaces a section the user can't navigate to.
+  $: visibleSections = sidebarSections.flatMap((section) =>
+    section.items.map((item) => ({ id: item.id, label: item.label }) as VisibleSection)
+  );
+
+  // Rebuild the fuzzy index only while the modal is open. `$locale` is referenced
+  // so the index refreshes when the UI language changes (labels are localized).
+  $: settingsSearchIndex = isOpen ? buildSettingsFuzzyIndex($locale, visibleSections) : null;
+
+  function buildSettingsFuzzyIndex(_locale: string, sections: VisibleSection[]) {
+    if (!i18next.isInitialized) return null;
+    const dict = i18next.getResourceBundle(i18next.language, 'translation') as Record<
+      string,
+      string
+    > | null;
+    const items = buildSettingsSearchItems(dict || {}, sections);
+    return createSettingsFuzzyIndex(items);
+  }
+
+  async function handleSettingsNavigate(
+    event: CustomEvent<{ sectionId: SettingsSection; anchorText: string }>
+  ) {
+    const { sectionId, anchorText } = event.detail;
+    switchSection(sectionId);
+    // Let the panel render (some load data async — flashSettingControl retries).
+    await tick();
+    flashSettingControl(anchorText);
+  }
+
+  // Tiered lookup: prefer labels/headings, then help text, then any element.
+  function findSettingElement(container: Element, needle: string): HTMLElement | null {
+    const target = needle.trim().toLowerCase();
+    if (!target) return null;
+    const tiers = [
+      'label, .section-title, .section-header, h3, h4, h5, legend',
+      '.form-text, .field-hint, .help-text, .field-desc, .input-hint, small, p',
+      '*',
+    ];
+    for (const selector of tiers) {
+      for (const el of Array.from(container.querySelectorAll(selector))) {
+        const text = (el.textContent || '').trim().toLowerCase();
+        if (text && text.includes(target)) return el as HTMLElement;
+      }
+    }
+    return null;
+  }
+
+  function flashSettingControl(anchorText: string, attempt = 0) {
+    if (!anchorText) return;
+    const container = modalElement?.querySelector('.settings-content');
+    const el = container ? findSettingElement(container, anchorText) : null;
+    if (!el) {
+      // Panel content may still be loading — retry briefly (~1s total) before giving up.
+      if (attempt < 20) window.setTimeout(() => flashSettingControl(anchorText, attempt + 1), 50);
+      return;
+    }
+    const scrollTarget =
+      (el.closest(
+        '.form-group, .form-row, .form-field, .settings-section, .content-section'
+      ) as HTMLElement) || el;
+    scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    document
+      .querySelectorAll('.settings-search-flash')
+      .forEach((node) => node.classList.remove('settings-search-flash'));
+    scrollTarget.classList.add('settings-search-flash');
+    window.setTimeout(() => scrollTarget.classList.remove('settings-search-flash'), 1600);
+  }
 
   // Reactive recording settings change detection
   $: {
@@ -575,47 +660,63 @@
       <div class="settings-modal-container">
         <!-- Desktop sidebar -->
         <aside class="settings-sidebar">
-          {#each sidebarSections as section}
-            <div class="sidebar-section">
-              <h3 class="section-heading">{section.title}</h3>
-              <nav class="section-nav">
-                {#each section.items as item}
-                  <button
-                    class="nav-item"
-                    class:active={activeSection === item.id}
-                    class:dirty={$settingsModalStore.dirtyState[item.id]}
-                    on:click={() => switchSection(item.id)}
-                  >
-                    <span class="nav-item-label">{item.label}</span>
-                    {#if $settingsModalStore.dirtyState[item.id]}
-                      <span class="dirty-indicator" title={$t('settings.unsavedChanges')}>●</span>
-                    {/if}
-                  </button>
-                {/each}
-              </nav>
-            </div>
-          {/each}
+          <SettingsSearch
+            index={settingsSearchIndex}
+            idPrefix="settings-search-desktop"
+            bind:active={desktopSearchActive}
+            on:navigate={handleSettingsNavigate}
+          />
+          {#if !desktopSearchActive}
+            {#each sidebarSections as section}
+              <div class="sidebar-section">
+                <h3 class="section-heading">{section.title}</h3>
+                <nav class="section-nav">
+                  {#each section.items as item}
+                    <button
+                      class="nav-item"
+                      class:active={activeSection === item.id}
+                      class:dirty={$settingsModalStore.dirtyState[item.id]}
+                      on:click={() => switchSection(item.id)}
+                    >
+                      <span class="nav-item-label">{item.label}</span>
+                      {#if $settingsModalStore.dirtyState[item.id]}
+                        <span class="dirty-indicator" title={$t('settings.unsavedChanges')}>●</span>
+                      {/if}
+                    </button>
+                  {/each}
+                </nav>
+              </div>
+            {/each}
+          {/if}
         </aside>
 
         <!-- Content Area -->
         <main class="settings-content">
           <!-- Mobile section navigation (hidden on desktop where sidebar is visible) -->
           <div class="mobile-section-nav">
-            <!-- svelte-ignore a11y_label_has_associated_control -->
-            <label class="mobile-nav-label">{$t('settings.title')}</label>
-            <select
-              class="mobile-nav-select"
-              value={activeSection}
-              on:change={(e) => switchSection(e.currentTarget.value as SettingsSection)}
-            >
-              {#each sidebarSections as section}
-                <optgroup label={section.title}>
-                  {#each section.items as item}
-                    <option value={item.id}>{item.label}</option>
-                  {/each}
-                </optgroup>
-              {/each}
-            </select>
+            <SettingsSearch
+              index={settingsSearchIndex}
+              idPrefix="settings-search-mobile"
+              bind:active={mobileSearchActive}
+              on:navigate={handleSettingsNavigate}
+            />
+            {#if !mobileSearchActive}
+              <!-- svelte-ignore a11y_label_has_associated_control -->
+              <label class="mobile-nav-label">{$t('settings.title')}</label>
+              <select
+                class="mobile-nav-select"
+                value={activeSection}
+                on:change={(e) => switchSection(e.currentTarget.value as SettingsSection)}
+              >
+                {#each sidebarSections as section}
+                  <optgroup label={section.title}>
+                    {#each section.items as item}
+                      <option value={item.id}>{item.label}</option>
+                    {/each}
+                  </optgroup>
+                {/each}
+              </select>
+            {/if}
           </div>
 
           <!-- Profile Section -->

--- a/frontend/src/components/SummarySearch.svelte
+++ b/frontend/src/components/SummarySearch.svelte
@@ -1,6 +1,15 @@
+<!--
+  SummarySearch.svelte — find-in-summary input.
+
+  Thin wrapper over the shared SearchBar so summary find looks/behaves like every
+  other search surface. Presentational only: SummaryModal owns the matching and
+  passes back totalMatches/currentMatchIndex. Public props/events are unchanged so
+  the parent needs no updates.
+-->
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { t } from '$stores/locale';
+  import SearchBar from '$components/ui/SearchBar.svelte';
 
   export let searchQuery: string = '';
   export let totalMatches: number = 0;
@@ -15,98 +24,35 @@
     keydown: KeyboardEvent;
   }>();
 
-  function handleInput(event: Event) {
-    const target = event.target as HTMLInputElement;
-    searchQuery = target.value;
-    dispatch('search', { query: searchQuery });
-  }
+  $: counterText = searchQuery && totalMatches > 0 ? `${currentMatchIndex + 1}/${totalMatches}` : '';
 
-  function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      event.stopPropagation();
-      if (event.shiftKey) {
-        previousMatch();
-      } else {
-        nextMatch();
-      }
-    } else {
-      dispatch('keydown', event);
-    }
-  }
-
-  function clearSearch() {
-    searchQuery = '';
-    dispatch('clearSearch');
-  }
-
-  function nextMatch() {
-    dispatch('nextMatch');
-  }
-
-  function previousMatch() {
-    dispatch('previousMatch');
+  function handleKeydown(event: CustomEvent<KeyboardEvent>) {
+    // Enter/Shift+Enter are handled by SearchBar (next/previous); forward the rest
+    // so the parent modal keeps its other shortcuts (matches prior behavior).
+    if (event.detail.key !== 'Enter') dispatch('keydown', event.detail);
   }
 </script>
 
 <div class="summary-search">
-  <div class="search-input-container">
-    <svg class="search-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-      <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
-    </svg>
-
-    <input
-      type="text"
-      placeholder={$t('search.placeholder')}
-      bind:value={searchQuery}
-      on:input={handleInput}
-      on:keydown={handleKeydown}
-      class="search-input"
-      {disabled}
-    />
-
-    {#if searchQuery && totalMatches > 0}
-      <div class="search-controls">
-        <span class="match-counter">{currentMatchIndex + 1}/{totalMatches}</span>
-        <button
-          class="nav-button"
-          on:click={previousMatch}
-          aria-label={$t('search.previousMatch')}
-          title={$t('search.previousMatchWithKey')}
-          disabled={totalMatches === 0}
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
-          </svg>
-        </button>
-        <button
-          class="nav-button"
-          on:click={nextMatch}
-          aria-label={$t('search.nextMatch')}
-          title={$t('search.nextMatchWithKey')}
-          disabled={totalMatches === 0}
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
-          </svg>
-        </button>
-      </div>
-    {/if}
-
-    {#if searchQuery}
-      <button
-        class="clear-button"
-        on:click={clearSearch}
-        aria-label={$t('search.clearSearch')}
-        title={$t('search.clearSearch')}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-          <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-        </svg>
-      </button>
-    {/if}
-  </div>
+  <SearchBar
+    bind:value={searchQuery}
+    {disabled}
+    size="sm"
+    debounceMs={0}
+    showNav
+    navDisabled={totalMatches === 0}
+    {counterText}
+    placeholder={$t('search.placeholder')}
+    ariaLabel={$t('search.placeholder')}
+    clearLabel={$t('search.clearSearch')}
+    nextLabel={$t('search.nextMatch')}
+    previousLabel={$t('search.previousMatch')}
+    on:search={({ detail }) => dispatch('search', { query: detail.value })}
+    on:clear={() => dispatch('clearSearch')}
+    on:next={() => dispatch('nextMatch')}
+    on:previous={() => dispatch('previousMatch')}
+    on:keydown={handleKeydown}
+  />
 
   {#if searchQuery && totalMatches === 0}
     <div class="no-results">
@@ -117,115 +63,18 @@
 
 <style>
   .summary-search {
-    border-bottom: 1px solid var(--border-color);
-    background-color: var(--bg-secondary);
-  }
-
-  .search-input-container {
-    position: relative;
     padding: 0.75rem 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--bg-secondary, var(--surface-color));
   }
-
-  .search-icon {
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .search-input {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background-color: var(--bg-primary);
-    color: var(--text-primary);
-    font-size: 0.9rem;
-    transition: border-color 0.2s ease;
-  }
-
-  .search-input:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.1);
-  }
-
-  .search-input:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .search-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-shrink: 0;
-  }
-
-  .match-counter {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    font-weight: 500;
-    min-width: 3rem;
-    text-align: center;
-  }
-
-  .nav-button {
-    background: none;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    color: var(--text-secondary);
-    padding: 0.25rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-  }
-
-  .nav-button:hover:not(:disabled) {
-    background-color: var(--hover-bg);
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-  }
-
-  .nav-button:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .clear-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-muted);
-    padding: 0.25rem;
-    border-radius: 3px;
-    transition: color 0.2s ease, background-color 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    flex-shrink: 0;
-  }
-
-  .clear-button:hover {
-    color: var(--text-primary);
-    background-color: var(--hover-bg);
-  }
-
 
   .no-results {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    padding: 1.5rem;
-    color: var(--text-muted);
+    padding: 1rem;
+    color: var(--text-muted, var(--text-secondary));
     font-size: 0.9rem;
   }
 </style>

--- a/frontend/src/components/TranscriptDisplay.svelte
+++ b/frontend/src/components/TranscriptDisplay.svelte
@@ -429,9 +429,13 @@
     <TranscriptSearch
       {transcriptSegments}
       {speakerList}
+      fileUuid={file?.uuid ?? ''}
+      {hasMoreSegments}
+      {loadingMoreSegments}
       disabled={!file?.transcript_segments?.length}
       on:searchResults={handleSearchResults}
       on:navigateToMatch={handleNavigateToMatch}
+      on:loadMore
     />
   </div>
 

--- a/frontend/src/components/TranscriptSearch.svelte
+++ b/frontend/src/components/TranscriptSearch.svelte
@@ -4,411 +4,355 @@
   import { type SearchMatch } from '$lib/utils/searchHighlight';
   import { t } from '$stores/locale';
   import { translateSpeakerLabel } from '$lib/i18n';
+  import axiosInstance from '$lib/axios';
+  import { isRequestCancelled } from '$lib/axios';
+  import { createDebouncedHandler } from '$lib/utils/debounce';
+  import SearchBar from '$components/ui/SearchBar.svelte';
 
   export let transcriptSegments: TranscriptSegment[] = [];
   export let speakerList: any[] = [];
   export let disabled: boolean = false;
+  /** File UUID — enables the whole-transcript completeness probe (backend, file-scoped). */
+  export let fileUuid: string = '';
+  /** Pagination state from the page: are there unloaded segments, and is a load in flight? */
+  export let hasMoreSegments: boolean = false;
+  export let loadingMoreSegments: boolean = false;
 
   const dispatch = createEventDispatcher();
 
   let searchQuery = '';
-  let currentMatch = 0;
-  let totalMatches = 0;
+  let currentMatch = 0; // 1-based index into loaded matches
+  let totalMatches = 0; // literal matches within the LOADED window
   let searchMatches: SearchMatch[] = [];
-  let searchInput: HTMLInputElement;
+  let searchBar: SearchBar;
   let isVisible = false;
-  let searchTimeout: ReturnType<typeof setTimeout>;
-  let isSearching = false;
-  let lastSearchQuery = '';
-  let previouslyHadResults = false;
 
-  // Debounced search functionality
-  $: if (searchQuery.trim()) {
-    // Only show searching state if query changed significantly
-    if (searchQuery !== lastSearchQuery) {
-      isSearching = true;
-      // Remember if we previously had results to maintain UI stability
-      if (totalMatches > 0) {
-        previouslyHadResults = true;
-      }
-    }
+  // Whole-transcript completeness (backend, file-scoped keyword search). OpenSearch
+  // tokenization means this count is approximate, so it is used only as a "there are
+  // more matches in unloaded segments" signal — never shown as the authoritative
+  // literal count. Literal matching stays consistent everywhere.
+  let backendTotal: number | null = null;
+  let backendLoading = false;
+  let reqSeq = 0;
+  let backendController: AbortController | null = null;
 
-    // Clear existing timeout
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
-    // Debounce search for better performance
-    searchTimeout = setTimeout(() => {
-      performSearch(searchQuery);
-      lastSearchQuery = searchQuery;
-      isSearching = false;
-      // Reset the flag once search is complete
-      previouslyHadResults = false;
-    }, 200);
-  } else {
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
-    isSearching = false;
-    previouslyHadResults = false;
-    clearSearch();
-  }
+  // Progressive navigation into unloaded segments.
+  let pendingAdvance = false;
+  let advanceLoads = 0; // bounds how many pages a single "next" will pull in
+  const MAX_ADVANCE_LOADS = 8;
+  let lastSegmentCount = 0;
 
-  // Keyboard shortcuts
-  function handleGlobalKeydown(event: KeyboardEvent) {
-    // Ctrl+F or Cmd+F to open search
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
-      event.preventDefault();
-      openSearch();
-    }
+  const backendDebounced = createDebouncedHandler(() => probeBackend(searchQuery), 300);
 
-    // Escape to close search
-    if (event.key === 'Escape' && isVisible) {
-      closeSearch();
-    }
+  // ---- Local (literal, in-loaded-window) search -----------------------------
 
-    // Enter/Shift+Enter for navigation when search is focused
-    if (isVisible && searchMatches.length > 0) {
-      if (event.key === 'Enter') {
-        event.preventDefault();
-        if (event.shiftKey) {
-          navigateToPrevious();
-        } else {
-          navigateToNext();
-        }
-      }
-    }
-  }
-
-  function performSearch(query: string) {
-    if (!query?.trim() || !transcriptSegments?.length) {
-      searchMatches = [];
-      totalMatches = 0;
-      currentMatch = 0;
-      return;
-    }
-
+  function computeMatches(query: string): SearchMatch[] {
     const normalizedQuery = query.toLowerCase().trim();
-    const matches: SearchMatch[] = [];
+    if (!normalizedQuery || !transcriptSegments?.length) return [];
 
-    // Create speaker name mapping for consistent search
-    const speakerMapping = new Map();
+    const speakerMapping = new Map<string, string>();
     speakerList.forEach((speaker: any) => {
       speakerMapping.set(speaker.name, translateSpeakerLabel(speaker.display_name || speaker.name));
     });
 
+    const matches: SearchMatch[] = [];
     transcriptSegments.forEach((segment, segmentIndex) => {
       if (!segment || typeof segment.text !== 'string') return;
 
-      // Search in transcript text
       const text = segment.text.toLowerCase();
       let textIndex = 0;
       while ((textIndex = text.indexOf(normalizedQuery, textIndex)) !== -1) {
-        matches.push({
-          segmentIndex,
-          start: textIndex,
-          length: normalizedQuery.length,
-          type: 'text'
-        });
+        matches.push({ segmentIndex, start: textIndex, length: normalizedQuery.length, type: 'text' });
         textIndex += normalizedQuery.length;
       }
 
-      // Search in speaker names (both original and display names)
       const speakerLabel = segment.speaker_label || segment.speaker?.name || '';
       const displayName = speakerMapping.get(speakerLabel) || segment.speaker?.display_name || speakerLabel;
-
-      // Search original speaker label
       if (speakerLabel.toLowerCase().includes(normalizedQuery)) {
-        matches.push({
-          segmentIndex,
-          start: 0,
-          length: speakerLabel.length,
-          type: 'speaker'
-        });
+        matches.push({ segmentIndex, start: 0, length: speakerLabel.length, type: 'speaker' });
       }
-
-      // Search display name if different from original
       if (displayName !== speakerLabel && displayName.toLowerCase().includes(normalizedQuery)) {
-        matches.push({
-          segmentIndex,
-          start: 0,
-          length: displayName.length,
-          type: 'speaker'
-        });
+        matches.push({ segmentIndex, start: 0, length: displayName.length, type: 'speaker' });
       }
     });
+    return matches;
+  }
 
-    searchMatches = matches;
-    totalMatches = matches.length;
-    currentMatch = totalMatches > 0 ? 1 : 0;
-
-    // Dispatch search results
+  function emitResults() {
     dispatch('searchResults', {
       matches: searchMatches,
       currentMatch,
       totalMatches,
-      query: normalizedQuery
+      query: searchQuery.toLowerCase().trim(),
     });
+  }
 
-    // Navigate to first match
-    if (totalMatches > 0) {
-      navigateToMatch(0);
+  function performLocalSearch(query: string) {
+    searchMatches = computeMatches(query);
+    totalMatches = searchMatches.length;
+    lastSegmentCount = transcriptSegments.length;
+    currentMatch = totalMatches > 0 ? 1 : 0;
+    emitResults();
+    if (totalMatches > 0) navigateToMatch(0);
+  }
+
+  // Recompute over a grown segment set WITHOUT resetting the user's position.
+  function reindexLocal() {
+    const prevTotal = totalMatches;
+    searchMatches = computeMatches(searchQuery);
+    totalMatches = searchMatches.length;
+    lastSegmentCount = transcriptSegments.length;
+    if (currentMatch > totalMatches) currentMatch = totalMatches;
+    emitResults();
+    return prevTotal;
+  }
+
+  function onSearch(query: string) {
+    searchQuery = query;
+    if (!query.trim()) {
+      clearSearch();
+      return;
     }
+    performLocalSearch(query); // instant, literal
+    backendLoading = true; // show progress until the probe resolves
+    backendDebounced.trigger(); // whole-transcript completeness (debounced)
   }
 
   function clearSearch() {
+    backendDebounced.cleanup();
+    backendController?.abort();
+    reqSeq++;
     searchMatches = [];
     totalMatches = 0;
     currentMatch = 0;
-    isSearching = false;
-    lastSearchQuery = '';
-    previouslyHadResults = false;
-    dispatch('searchResults', {
-      matches: [],
-      currentMatch: 0,
-      totalMatches: 0,
-      query: ''
-    });
+    backendTotal = null;
+    backendLoading = false;
+    pendingAdvance = false;
+    advanceLoads = 0;
+    emitResults();
+  }
+
+  // ---- Whole-transcript completeness probe (backend) ------------------------
+
+  async function probeBackend(query: string) {
+    if (!query.trim() || !fileUuid) {
+      backendTotal = null;
+      backendLoading = false;
+      return;
+    }
+    backendController?.abort();
+    const controller = new AbortController();
+    backendController = controller;
+    const seq = ++reqSeq;
+    backendLoading = true;
+    try {
+      // Lightweight count endpoint (size=0, no snippets/embeddings) — fast + concurrent.
+      const resp = await axiosInstance.get('/search/count', {
+        params: { q: query, file_uuid: fileUuid },
+        signal: controller.signal,
+      });
+      if (seq !== reqSeq) return; // stale — a newer query superseded this one
+      backendTotal = typeof resp.data?.total === 'number' ? resp.data.total : 0;
+    } catch (err) {
+      if (isRequestCancelled(err)) return;
+      // Degrade gracefully to loaded-window-only search.
+      if (seq === reqSeq) backendTotal = null;
+    } finally {
+      if (seq === reqSeq) backendLoading = false;
+    }
+  }
+
+  // ---- Navigation (with progressive load-more into unloaded segments) --------
+
+  function moreMatchesMayExist(): boolean {
+    // The count endpoint returns matching *chunks* across the whole file; when the
+    // term is present anywhere and unloaded segments remain, more matches may lie
+    // beyond the loaded window. Progressive loading stops once a page yields no new
+    // matches (see the reactive block) or the transcript is fully loaded.
+    return hasMoreSegments && (backendTotal ?? 0) > 0;
+  }
+
+  function requestMoreSegments() {
+    if (!loadingMoreSegments && hasMoreSegments) dispatch('loadMore');
   }
 
   function navigateToNext() {
-    if (totalMatches === 0) return;
-
-    const nextMatch = currentMatch < totalMatches ? currentMatch + 1 : 1;
-    currentMatch = nextMatch;
-    navigateToMatch(currentMatch - 1);
+    if (totalMatches > 0 && currentMatch < totalMatches) {
+      currentMatch += 1;
+      navigateToMatch(currentMatch - 1);
+      emitResults();
+      return;
+    }
+    // At/after the last loaded match: pull in more of the transcript if matches remain.
+    if (moreMatchesMayExist() && advanceLoads < MAX_ADVANCE_LOADS) {
+      pendingAdvance = true;
+      advanceLoads += 1;
+      requestMoreSegments();
+      return;
+    }
+    if (totalMatches > 0) {
+      currentMatch = 1; // wrap
+      navigateToMatch(0);
+      emitResults();
+    }
   }
 
   function navigateToPrevious() {
     if (totalMatches === 0) return;
-
-    const prevMatch = currentMatch > 1 ? currentMatch - 1 : totalMatches;
-    currentMatch = prevMatch;
+    currentMatch = currentMatch > 1 ? currentMatch - 1 : totalMatches;
     navigateToMatch(currentMatch - 1);
+    emitResults();
   }
 
   function navigateToMatch(matchIndex: number, autoSeek: boolean = false) {
-    if (matchIndex < 0 || matchIndex >= searchMatches.length || !searchMatches.length) return;
-
+    if (matchIndex < 0 || matchIndex >= searchMatches.length) return;
     const match = searchMatches[matchIndex];
     if (!match || match.segmentIndex < 0 || match.segmentIndex >= transcriptSegments.length) return;
-
     const segment = transcriptSegments[match.segmentIndex];
     if (!segment) return;
 
-    // Dispatch navigation event with autoSeek parameter
-    dispatch('navigateToMatch', {
-      match,
-      segment,
-      segmentIndex: match.segmentIndex,
-      autoSeek
+    dispatch('navigateToMatch', { match, segment, segmentIndex: match.segmentIndex, autoSeek });
+
+    // Scroll to the segment (defer a frame so freshly loaded rows are in the DOM).
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-segment-id="${segment.uuid}"]`);
+      if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      el.classList.add('search-current-match');
+      setTimeout(() => el.classList.remove('search-current-match'), 2000);
     });
-
-    // Scroll to the segment
-    const segmentElement = document.querySelector(`[data-segment-id="${segment.uuid}"]`);
-    if (segmentElement) {
-      segmentElement.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'nearest'
-      });
-
-      // Add temporary highlight to the segment
-      segmentElement.classList.add('search-current-match');
-      setTimeout(() => {
-        segmentElement.classList.remove('search-current-match');
-      }, 2000);
-    }
   }
 
   function seekToCurrentMatch() {
     if (totalMatches === 0 || currentMatch < 1) return;
-
     const match = searchMatches[currentMatch - 1];
     const segment = transcriptSegments[match.segmentIndex];
+    dispatch('navigateToMatch', { match, segment, segmentIndex: match.segmentIndex, autoSeek: true });
+  }
 
-    // Dispatch with autoSeek enabled
-    dispatch('navigateToMatch', {
-      match,
-      segment,
-      segmentIndex: match.segmentIndex,
-      autoSeek: true
-    });
+  // When the page appends newly loaded segments, re-index and (if the user pressed
+  // "next" past the loaded window) advance to the first newly revealed match.
+  $: if (isVisible && searchQuery.trim() && transcriptSegments.length !== lastSegmentCount) {
+    const prevTotal = reindexLocal();
+    if (pendingAdvance) {
+      if (totalMatches > prevTotal) {
+        pendingAdvance = false;
+        advanceLoads = 0;
+        currentMatch = prevTotal + 1;
+        navigateToMatch(currentMatch - 1);
+        emitResults();
+      } else if (moreMatchesMayExist() && advanceLoads < MAX_ADVANCE_LOADS) {
+        advanceLoads += 1;
+        requestMoreSegments(); // keep pulling pages until a new match appears
+      } else {
+        pendingAdvance = false;
+        advanceLoads = 0;
+      }
+    }
+  }
+
+  // ---- Counter / status presentation ----------------------------------------
+
+  $: moreAvailable = hasMoreSegments && (backendTotal ?? 0) > 0;
+  $: counterText = (() => {
+    if (totalMatches > 0) {
+      const base = $t('transcriptSearch.matchCounter', { current: currentMatch, total: totalMatches });
+      return moreAvailable ? `${base}+` : base;
+    }
+    if (searchQuery.trim() && !backendLoading) {
+      // Nothing in the loaded window; matches may still live in unloaded segments.
+      if (moreAvailable) return $t('transcriptSearch.moreInTranscript');
+      return '';
+    }
+    return '';
+  })();
+  $: noResults =
+    !!searchQuery.trim() && totalMatches === 0 && !backendLoading && !(backendTotal && backendTotal > 0);
+  $: statusText = backendLoading ? $t('transcriptSearch.searchingAll') : '';
+
+  // ---- Ctrl+F open / Escape close -------------------------------------------
+
+  function handleGlobalKeydown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+      event.preventDefault();
+      openSearch();
+    } else if (event.key === 'Escape' && isVisible) {
+      // Close from anywhere while the find bar is open (focus may be on a nav button).
+      closeSearch();
+    }
   }
 
   function openSearch() {
     isVisible = true;
-    // Focus the search input after a small delay to ensure it's rendered
-    setTimeout(() => {
-      if (searchInput) {
-        searchInput.focus();
-        searchInput.select();
-      }
-    }, 50);
+    setTimeout(() => searchBar?.focus(), 50);
   }
 
   function closeSearch() {
     isVisible = false;
     searchQuery = '';
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
     clearSearch();
   }
 
-  function handleSearchInput() {
-    // The reactive statement will handle the search
+  function handleBarKeydown(event: CustomEvent<KeyboardEvent>) {
+    if (event.detail.key === 'Escape' && isVisible) closeSearch();
   }
 
   onMount(() => {
-    if (typeof window !== 'undefined') {
-      window.addEventListener('keydown', handleGlobalKeydown);
-    }
+    if (typeof window !== 'undefined') window.addEventListener('keydown', handleGlobalKeydown);
   });
 
   onDestroy(() => {
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('keydown', handleGlobalKeydown);
-    }
-    if (searchTimeout) {
-      clearTimeout(searchTimeout);
-    }
+    if (typeof window !== 'undefined') window.removeEventListener('keydown', handleGlobalKeydown);
+    backendDebounced.cleanup();
+    backendController?.abort();
   });
 </script>
 
 {#if isVisible}
-  <div class="search-container" class:disabled>
-    <div class="search-input-wrapper">
-      <div class="search-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="M21 21l-4.35-4.35"></path>
-        </svg>
-      </div>
-
-      <input
-        bind:this={searchInput}
-        bind:value={searchQuery}
-        on:input={handleSearchInput}
-        on:keydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleSearchInput(); } }}
-        type="text"
-        placeholder={$t('transcriptSearch.placeholder')}
-        class="search-input"
-        {disabled}
-        aria-label={$t('transcriptSearch.ariaLabel')}
-        aria-describedby={totalMatches > 0 ? "search-results-info" : undefined}
-      />
-
-      {#if isSearching && previouslyHadResults}
-        <!-- Maintain navigation controls layout during search to prevent flicker -->
-        <div class="search-results-info" id="search-results-info">
-          <span class="results-count searching">{$t('transcriptSearch.searching')}</span>
-          <div class="navigation-controls">
-            <div class="navigation-buttons">
-              <button
-                class="nav-button"
-                disabled={true}
-                title={$t('transcriptSearch.previousMatchTitle')}
-                aria-label={$t('transcriptSearch.previousMatchAriaLabel')}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="15,18 9,12 15,6"></polyline>
-                </svg>
-              </button>
-              <button
-                class="nav-button"
-                disabled={true}
-                title={$t('transcriptSearch.nextMatchTitle')}
-                aria-label={$t('transcriptSearch.nextMatchAriaLabel')}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="9,6 15,12 9,18"></polyline>
-                </svg>
-              </button>
-            </div>
-            <button
-              class="jump-button"
-              disabled={true}
-              title={$t('transcriptSearch.jumpToMatchTitle')}
-              aria-label={$t('transcriptSearch.jumpToMatchAriaLabel')}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polygon points="5 3 19 12 5 21 5 3"></polygon>
-              </svg>
-            </button>
-          </div>
-        </div>
-      {:else if isSearching}
-        <!-- Simple searching state for first search -->
-        <div class="search-results-info" id="search-results-info">
-          <span class="results-count searching">{$t('transcriptSearch.searching')}</span>
-        </div>
-      {:else if totalMatches > 0}
-        <div class="search-results-info" id="search-results-info">
-          <span class="results-count" aria-live="polite">{$t('transcriptSearch.matchCounter', { current: currentMatch, total: totalMatches })}</span>
-          <div class="navigation-controls">
-            <div class="navigation-buttons">
-              <button
-                class="nav-button"
-                on:click={navigateToPrevious}
-                disabled={totalMatches === 0}
-                title={$t('transcriptSearch.previousMatchTitle')}
-                aria-label={$t('transcriptSearch.previousMatchAriaLabel')}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="15,18 9,12 15,6"></polyline>
-                </svg>
-              </button>
-              <button
-                class="nav-button"
-                on:click={navigateToNext}
-                disabled={totalMatches === 0}
-                title={$t('transcriptSearch.nextMatchTitle')}
-                aria-label={$t('transcriptSearch.nextMatchAriaLabel')}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="9,6 15,12 9,18"></polyline>
-                </svg>
-              </button>
-            </div>
-            <button
-              class="jump-button"
-              on:click={seekToCurrentMatch}
-              disabled={totalMatches === 0}
-              title={$t('transcriptSearch.jumpToMatchTitle')}
-              aria-label={$t('transcriptSearch.jumpToMatchAriaLabel')}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polygon points="5 3 19 12 5 21 5 3"></polygon>
-              </svg>
-            </button>
-          </div>
-        </div>
-      {:else if searchQuery.trim() && !isSearching}
-        <div class="search-results-info">
-          <span class="results-count no-results">{$t('transcriptSearch.noMatches')}</span>
-        </div>
-      {/if}
-
-      <button
-        class="close-button"
-        on:click={closeSearch}
-        title={$t('transcriptSearch.closeSearchTitle')}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M18 6L6 18M6 6l12 12"/>
-        </svg>
-      </button>
-    </div>
+  <div class="transcript-search" class:disabled>
+    <SearchBar
+      bind:this={searchBar}
+      bind:value={searchQuery}
+      {disabled}
+      size="sm"
+      debounceMs={0}
+      showNav
+      navDisabled={totalMatches === 0}
+      loading={backendLoading}
+      {counterText}
+      {statusText}
+      {noResults}
+      placeholder={$t('transcriptSearch.placeholder')}
+      ariaLabel={$t('transcriptSearch.ariaLabel')}
+      clearLabel={$t('transcriptSearch.closeSearchTitle')}
+      nextLabel={$t('transcriptSearch.nextMatchTitle')}
+      previousLabel={$t('transcriptSearch.previousMatchTitle')}
+      on:search={({ detail }) => onSearch(detail.value)}
+      on:clear={closeSearch}
+      on:next={navigateToNext}
+      on:previous={navigateToPrevious}
+      on:keydown={handleBarKeydown}
+    />
+    <button
+      class="jump-button"
+      on:click={seekToCurrentMatch}
+      disabled={totalMatches === 0}
+      title={$t('transcriptSearch.jumpToMatchTitle')}
+      aria-label={$t('transcriptSearch.jumpToMatchAriaLabel')}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polygon points="5 3 19 12 5 21 5 3"></polygon>
+      </svg>
+    </button>
+    <button class="close-button" on:click={closeSearch} title={$t('transcriptSearch.closeSearchTitle')} aria-label={$t('transcriptSearch.closeSearchTitle')}>
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 6L6 18M6 6l12 12" />
+      </svg>
+    </button>
   </div>
 {:else}
   <div class="search-trigger">
-    <button
-      class="search-trigger-button"
-      on:click={openSearch}
-      title={$t('transcriptSearch.searchButtonTitle')}
-      {disabled}
-    >
+    <button class="search-trigger-button" on:click={openSearch} title={$t('transcriptSearch.searchButtonTitle')} {disabled}>
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="11" cy="11" r="8"></circle>
         <path d="M21 21l-4.35-4.35"></path>
@@ -419,152 +363,38 @@
 {/if}
 
 <style>
-  .search-container {
-    margin: 0 0 6px 0;
-    padding: 0;
-    background: var(--surface-color);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s ease-out;
+  .transcript-search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
     width: 100%;
-    height: 40px;
+    margin: 0 0 6px 0;
   }
 
-  .search-container.disabled {
+  .transcript-search.disabled {
     opacity: 0.6;
     pointer-events: none;
-  }
-
-  .search-input-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    position: relative;
-    width: 100%;
-    height: 100%;
-    padding: 0 8px;
-  }
-
-  .search-icon {
-    color: var(--text-secondary);
-    display: flex;
-    align-items: center;
-  }
-
-  .search-icon svg {
-    flex-shrink: 0;
-    color: inherit;
-  }
-
-  .search-input {
-    flex: 1;
-    padding: 4px 6px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--background-color);
-    color: var(--text-primary);
-    font-size: 13px;
-    outline: none;
-    height: 24px;
-  }
-
-  .search-input:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
-  }
-
-  .search-input::placeholder {
-    font-size: 12px;
-  }
-
-  .search-results-info {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    color: var(--text-secondary);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .results-count {
-    font-weight: 500;
-  }
-
-  .results-count.no-results {
-    color: var(--error-color);
-  }
-
-  .results-count.searching {
-    color: var(--text-secondary);
-    font-style: italic;
-  }
-
-  .navigation-controls {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .navigation-buttons {
-    display: flex;
-    gap: 2px;
-  }
-
-  .nav-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    background: none;
-    border: 1px solid var(--border-color);
-    border-radius: 3px;
-    color: var(--text-secondary);
-    cursor: pointer;
-    transition: all 0.2s ease;
-  }
-
-  .nav-button svg {
-    flex-shrink: 0;
-    color: inherit;
-  }
-
-  .nav-button:hover:not(:disabled) {
-    background: var(--surface-hover);
-    border-color: var(--border-hover);
-    color: var(--text-primary);
-  }
-
-  .nav-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .nav-button:disabled svg {
-    color: var(--text-secondary);
   }
 
   .jump-button {
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 24px;
-    padding: 0 6px;
-    background: #3b82f6;
+    height: 32px;
+    padding: 0 8px;
+    background: var(--primary-color);
     border: 1px solid var(--primary-color);
-    border-radius: 3px;
+    border-radius: 4px;
     color: white;
     cursor: pointer;
-    font-size: 10px;
-    font-weight: 500;
-    transition: all 0.2s ease;
+    transition:
+      background 0.15s ease,
+      opacity 0.15s ease;
+    flex-shrink: 0;
   }
 
   .jump-button:hover:not(:disabled) {
-    background: #2563eb;
-    border-color: var(--primary-hover);
+    background: var(--primary-hover);
   }
 
   .jump-button:disabled {
@@ -576,36 +406,31 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 32px;
+    height: 32px;
     background: none;
-    border: none;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
     color: var(--text-secondary);
     cursor: pointer;
-    border-radius: 3px;
-    transition: all 0.2s ease;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
     flex-shrink: 0;
-  }
-
-  .close-button svg {
-    flex-shrink: 0;
-    color: inherit;
   }
 
   .close-button:hover {
-    background: var(--surface-hover);
-    color: var(--text-primary);
+    background: var(--button-hover, var(--hover-color));
+    color: var(--text-color);
   }
 
   .search-trigger {
     margin: 0 0 6px 0;
-    padding: 0;
     background: var(--surface-color);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     display: flex;
     align-items: center;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     height: 40px;
     width: fit-content;
     min-width: 120px;
@@ -622,66 +447,21 @@
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    transition: all 0.2s ease;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
     border-radius: 6px;
-    justify-content: flex-start;
-    height: 100%;
     width: 100%;
-  }
-
-  .search-trigger-button svg {
-    flex-shrink: 0;
-    color: inherit;
+    height: 100%;
   }
 
   .search-trigger-button:hover:not(:disabled) {
-    background: var(--hover-bg);
-    border: 1px solid var(--primary-color);
-    color: var(--text-primary);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    background: var(--hover-color);
+    color: var(--text-color);
   }
 
   .search-trigger-button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
-  }
-
-  /* Global styles for search highlighting */
-  :global(.search-current-match) {
-    background-color: rgba(59, 130, 246, 0.2) !important;
-    border: 2px solid var(--primary-color) !important;
-    animation: pulse 1s ease-in-out;
-  }
-
-  @keyframes pulse {
-    0%, 100% {
-      box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
-    }
-    50% {
-      box-shadow: 0 0 0 8px rgba(59, 130, 246, 0);
-    }
-  }
-
-  /* Highlight text matches - consistent with SearchTranscriptModal */
-  :global(.transcript-search-highlight) {
-    background-color: rgba(250, 204, 21, 0.4);
-    padding: 0.05em 0.15em;
-    border-radius: 2px;
-  }
-
-  :global(.transcript-search-highlight.current) {
-    background-color: rgba(250, 204, 21, 0.6);
-    border: 1px solid rgba(250, 204, 21, 0.8);
-  }
-
-  /* Dark mode highlighting */
-  :global([data-theme='dark']) :global(.transcript-search-highlight) {
-    background-color: rgba(250, 204, 21, 0.3);
-    color: var(--text-primary);
-  }
-
-  :global([data-theme='dark']) :global(.transcript-search-highlight.current) {
-    background-color: rgba(250, 204, 21, 0.5);
-    border: 1px solid rgba(250, 204, 21, 0.7);
   }
 </style>

--- a/frontend/src/components/settings/SettingsSearch.svelte
+++ b/frontend/src/components/settings/SettingsSearch.svelte
@@ -1,0 +1,179 @@
+<!--
+  SettingsSearch.svelte — macOS-style search over settings.
+
+  Rendered at the top of the settings sidebar (and above the mobile section select).
+  Receives a prebuilt fuzzy index (SettingsModal owns index construction so desktop
+  + mobile instances share the corpus). When the query is non-empty it renders a flat,
+  ranked, highlighted results list and dispatches `navigate` on selection; the parent
+  hides the normal grouped nav while `active`.
+-->
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { t } from '$stores/locale';
+  import type { FuzzyIndex } from '$lib/search/fuzzyMatcher';
+  import type { SettingsSearchItem } from '$lib/search/settingsSearchIndex';
+  import { highlightText } from '$lib/utils/searchHighlight';
+  import { sanitizeHighlightHtml } from '$lib/utils/sanitizeHtml';
+  import SearchBar from '$components/ui/SearchBar.svelte';
+  import EmptyState from '$components/ui/EmptyState.svelte';
+
+  export let index: FuzzyIndex<SettingsSearchItem> | null = null;
+  /** Bound out: true while a query is active (parent hides the grouped nav). */
+  export let active = false;
+  /** Unique suffix so desktop + mobile instances don't share DOM ids. */
+  export let idPrefix = 'settings-search';
+
+  const MAX_RESULTS = 8;
+
+  const dispatch = createEventDispatcher<{
+    navigate: { sectionId: SettingsSearchItem['sectionId']; anchorText: string };
+  }>();
+
+  let query = '';
+  let activeIndex = 0;
+
+  $: trimmed = query.trim();
+  $: active = trimmed.length > 0;
+  $: results = trimmed && index ? index.search(trimmed, MAX_RESULTS) : [];
+  // Reset the active row whenever the query changes so Enter never hits a stale row.
+  $: resetActiveRow(query);
+  function resetActiveRow(_query: string) {
+    activeIndex = 0;
+  }
+  $: listId = `${idPrefix}-results`;
+  $: countLabel = results.length
+    ? $t('settingsSearch.resultsCount', { count: results.length })
+    : '';
+
+  function selectResult(i: number) {
+    const result = results[i];
+    if (!result) return;
+    dispatch('navigate', {
+      sectionId: result.item.sectionId,
+      anchorText: result.item.anchorText,
+    });
+    query = '';
+  }
+
+  function handleKeydown(event: CustomEvent<KeyboardEvent>) {
+    const ev = event.detail;
+    if (ev.key === 'Escape') {
+      if (trimmed) {
+        // Clear the query first; stop the modal's document Escape handler from closing.
+        ev.preventDefault();
+        ev.stopPropagation();
+        query = '';
+      }
+      return;
+    }
+    if (!results.length) return;
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      activeIndex = (activeIndex + 1) % results.length;
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      activeIndex = (activeIndex - 1 + results.length) % results.length;
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      selectResult(activeIndex);
+    }
+  }
+</script>
+
+<div class="settings-search">
+  <SearchBar
+    bind:value={query}
+    size="sm"
+    debounceMs={0}
+    role="combobox"
+    inputId={`${idPrefix}-input`}
+    ariaControls={listId}
+    ariaExpanded={active}
+    ariaActivedescendant={active && results.length ? `${idPrefix}-result-${activeIndex}` : undefined}
+    placeholder={$t('settingsSearch.placeholder')}
+    ariaLabel={$t('settingsSearch.ariaLabel')}
+    counterText={countLabel}
+    on:keydown={handleKeydown}
+  />
+
+  {#if active}
+    <div class="settings-search-results">
+      {#if results.length}
+        <ul id={listId} class="results-list" role="listbox" aria-label={$t('settingsSearch.ariaLabel')}>
+          {#each results as result, i (result.item.sectionId + '|' + result.item.label + '|' + i)}
+            <!-- Combobox/listbox pattern: keyboard interaction (Arrow keys + Enter) is
+                 handled on the search input via aria-activedescendant, so the options
+                 themselves are pointer-only by design. -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <li
+              id={`${idPrefix}-result-${i}`}
+              class="result-item"
+              class:active={i === activeIndex}
+              role="option"
+              aria-selected={i === activeIndex}
+              on:mouseenter={() => (activeIndex = i)}
+              on:click={() => selectResult(i)}
+            >
+              <span class="result-label">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                {@html sanitizeHighlightHtml(highlightText(result.item.label, trimmed))}
+              </span>
+              <span class="result-section">{result.item.sectionLabel}</span>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <EmptyState
+          title={$t('settingsSearch.noResultsTitle')}
+          description={$t('settingsSearch.noResults', { query: trimmed })}
+          padding="24px 16px"
+        />
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .settings-search {
+    margin-bottom: 12px;
+  }
+
+  .settings-search-results {
+    margin-top: 8px;
+  }
+
+  .results-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .result-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid transparent;
+  }
+
+  .result-item.active {
+    background: var(--hover-color, var(--surface-color));
+    border-color: var(--border-color);
+  }
+
+  .result-label {
+    font-size: 0.875rem;
+    color: var(--text-color);
+    line-height: 1.3;
+  }
+
+  .result-section {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+  }
+</style>

--- a/frontend/src/components/transcript/TranscriptSegmentList.svelte
+++ b/frontend/src/components/transcript/TranscriptSegmentList.svelte
@@ -104,8 +104,23 @@
     infiniteScrollObserver.observe(infiniteScrollSentinel);
   }
 
+  // Map segment uuid -> its index in file.transcript_segments. Search matches are
+  // keyed by that flat index; when segments come from the backend `grouped_segments`
+  // payload they are DIFFERENT object refs than `transcript_segments`, so a plain
+  // `indexOf` returns -1 and highlights silently vanish. Look up by uuid instead.
+  $: segmentIndexByUuid = (() => {
+    const map = new Map<string | number, number>();
+    (file?.transcript_segments || []).forEach((s: any, i: number) => {
+      if (s?.uuid != null) map.set(s.uuid, i);
+    });
+    return map;
+  })();
+
   // Helper to get original segment index for search highlighting
   function getOriginalSegmentIndex(segment: any): number {
+    if (segment?.uuid != null && segmentIndexByUuid.has(segment.uuid)) {
+      return segmentIndexByUuid.get(segment.uuid) as number;
+    }
     return file?.transcript_segments?.indexOf(segment) ?? -1;
   }
 

--- a/frontend/src/components/ui/SearchBar.svelte
+++ b/frontend/src/components/ui/SearchBar.svelte
@@ -1,0 +1,386 @@
+<!--
+  SearchBar.svelte — shared search input primitive.
+
+  One styled, accessible, theme-aware search field used across the app (settings
+  search, transcript find, summary find) so every surface looks and behaves the
+  same. Presentational only: the parent owns the actual matching and passes back a
+  counter / loading state.
+
+  Modes:
+  - Plain filter (settings): bind:value, listen to `search` (debounced) + forwarded
+    `keydown` for arrow navigation of an external results list.
+  - Find-in-document (transcript/summary): set `showNav`, feed `counterText`
+    ("2 of 17"), `loading`, `statusText`; listen to `next`/`previous`.
+-->
+<script lang="ts">
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { createDebouncedHandler } from '$lib/utils/debounce';
+  import Spinner from '$components/ui/Spinner.svelte';
+
+  export let value = '';
+  export let placeholder = '';
+  export let ariaLabel = '';
+  export let disabled = false;
+  /** Show an inline spinner + status (two-phase search in progress). */
+  export let loading = false;
+  /** Show prev/next match navigation buttons (find-in-document mode). */
+  export let showNav = false;
+  /** Visible match counter, e.g. "2 of 17" or "2 in view". */
+  export let counterText = '';
+  /** Human status announced politely to assistive tech, e.g. "searching entire transcript…". */
+  export let statusText = '';
+  /** Style the counter as a "no results" state. */
+  export let noResults = false;
+  /** Disable prev/next (no matches to move between). */
+  export let navDisabled = false;
+  export let autofocus = false;
+  export let size: 'sm' | 'md' = 'md';
+  /** Debounce (ms) before emitting `search`; 0 = immediate. */
+  export let debounceMs = 200;
+  /** Accessible labels — pass i18n strings; English fallbacks keep the primitive usable standalone. */
+  export let clearLabel = 'Clear search';
+  export let nextLabel = 'Next match';
+  export let previousLabel = 'Previous match';
+  /** Optional combobox wiring for consumers with a results listbox. */
+  export let inputId: string | undefined = undefined;
+  export let role: string | undefined = undefined;
+  export let ariaControls: string | undefined = undefined;
+  export let ariaExpanded: boolean | undefined = undefined;
+  export let ariaActivedescendant: string | undefined = undefined;
+
+  const dispatch = createEventDispatcher<{
+    search: { value: string };
+    input: { value: string };
+    clear: void;
+    next: void;
+    previous: void;
+    escape: void;
+    keydown: KeyboardEvent;
+    focus: FocusEvent;
+    blur: FocusEvent;
+  }>();
+
+  let inputEl: HTMLInputElement;
+
+  const debounced = createDebouncedHandler(() => {
+    dispatch('search', { value });
+  }, debounceMs);
+
+  function handleInput(event: Event) {
+    value = (event.target as HTMLInputElement).value;
+    dispatch('input', { value });
+    if (debounceMs > 0) {
+      debounced.trigger();
+    } else {
+      dispatch('search', { value });
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      dispatch('escape');
+    } else if (event.key === 'Enter' && showNav) {
+      event.preventDefault();
+      if (event.shiftKey) dispatch('previous');
+      else dispatch('next');
+    }
+    // Always forward so consumers can handle Arrow/Enter for external result lists.
+    dispatch('keydown', event);
+  }
+
+  export function focus() {
+    inputEl?.focus();
+  }
+
+  export function selectAll() {
+    inputEl?.select();
+  }
+
+  function clear() {
+    value = '';
+    debounced.cleanup();
+    dispatch('input', { value: '' });
+    dispatch('clear');
+    inputEl?.focus();
+  }
+
+  onMount(() => {
+    if (autofocus) inputEl?.focus();
+  });
+
+  onDestroy(() => debounced.cleanup());
+</script>
+
+<div class="search-bar search-bar-{size}" class:disabled>
+  <span class="search-bar-icon" aria-hidden="true">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="M21 21l-4.35-4.35" />
+    </svg>
+  </span>
+
+  <input
+    bind:this={inputEl}
+    {value}
+    id={inputId}
+    type="text"
+    class="search-bar-input"
+    {placeholder}
+    {disabled}
+    {role}
+    aria-label={ariaLabel || placeholder}
+    aria-controls={ariaControls}
+    aria-expanded={ariaExpanded}
+    aria-activedescendant={ariaActivedescendant}
+    aria-autocomplete={role === 'combobox' ? 'list' : undefined}
+    autocomplete="off"
+    autocorrect="off"
+    autocapitalize="off"
+    spellcheck="false"
+    on:input={handleInput}
+    on:keydown={handleKeydown}
+    on:focus={(e) => dispatch('focus', e)}
+    on:blur={(e) => dispatch('blur', e)}
+  />
+
+  <div class="search-bar-status" aria-live="polite">
+    {#if loading}
+      <!-- Two-phase: show the provisional (loaded-window) counter next to the spinner
+           so progress is visible without hiding what's already found. -->
+      <span class="search-bar-loading">
+        {#if counterText}<span class="search-bar-counter">{counterText}</span>{/if}
+        <Spinner size="small" />
+        {#if statusText}<span class="search-bar-counter search-bar-status-text">{statusText}</span>{/if}
+      </span>
+    {:else if counterText}
+      <span class="search-bar-counter" class:no-results={noResults}>{counterText}</span>
+    {/if}
+  </div>
+
+  {#if showNav}
+    <div class="search-bar-nav">
+      <button
+        type="button"
+        class="search-bar-btn"
+        on:click={() => dispatch('previous')}
+        disabled={disabled || navDisabled}
+        aria-label={previousLabel}
+        title={previousLabel}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="15,18 9,12 15,6" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="search-bar-btn"
+        on:click={() => dispatch('next')}
+        disabled={disabled || navDisabled}
+        aria-label={nextLabel}
+        title={nextLabel}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="9,6 15,12 9,18" />
+        </svg>
+      </button>
+    </div>
+  {/if}
+
+  {#if value}
+    <button
+      type="button"
+      class="search-bar-clear"
+      on:click={clear}
+      {disabled}
+      aria-label={clearLabel}
+      title={clearLabel}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M18 6L6 18M6 6l12 12" />
+      </svg>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .search-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 0 8px;
+    background: var(--input-background, var(--surface-color));
+    border: 1px solid var(--input-border, var(--border-color));
+    border-radius: 6px;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .search-bar-md {
+    height: 40px;
+  }
+
+  .search-bar-sm {
+    height: 32px;
+  }
+
+  /* Google-style: soft elevation on focus, not a hard colored ring. */
+  .search-bar:focus-within {
+    border-color: var(--border-color);
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+  }
+
+  .search-bar.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  .search-bar-icon {
+    display: flex;
+    align-items: center;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+  }
+
+  .search-bar-input {
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-color);
+    font-size: 0.9rem;
+    outline: none;
+    box-shadow: none;
+  }
+
+  /* The container owns the focus treatment — the inner input must stay flat, so it
+     doesn't inherit the global input:focus ring (which looks like a box-in-a-box). */
+  .search-bar-input:focus,
+  .search-bar-input:focus-visible {
+    border: none;
+    outline: none;
+    box-shadow: none;
+  }
+
+  .search-bar-input::placeholder {
+    color: var(--text-secondary);
+  }
+
+  .search-bar-status {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .search-bar-loading {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .search-bar-status-text {
+    font-style: italic;
+    opacity: 0.85;
+  }
+
+  .search-bar-counter {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  .search-bar-counter.no-results {
+    color: var(--error-color, #ef4444);
+  }
+
+  .search-bar-nav {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  .search-bar-btn,
+  .search-bar-clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+    flex-shrink: 0;
+  }
+
+  .search-bar-btn {
+    border: 1px solid var(--border-color);
+  }
+
+  .search-bar-btn:hover:not(:disabled),
+  .search-bar-clear:hover:not(:disabled) {
+    background: var(--button-hover, var(--hover-color));
+    color: var(--text-color);
+  }
+
+  .search-bar-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .search-bar-btn:focus-visible,
+  .search-bar-clear:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 1px;
+  }
+</style>

--- a/frontend/src/components/ui/SearchBar.test.ts
+++ b/frontend/src/components/ui/SearchBar.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SearchBar from './SearchBar.svelte';
+
+// Svelte 5 removed component.$on(...); these assert observable DOM/state, which is
+// this repo's component-testing convention (see ui/CLAUDE.md). Event wiring is
+// exercised by the consuming components' integration + manual verification.
+
+describe('SearchBar', () => {
+  it('renders an input with the placeholder and aria-label', () => {
+    render(SearchBar, { props: { placeholder: 'Search settings', ariaLabel: 'Search settings' } });
+    const input = screen.getByRole('textbox', { name: 'Search settings' });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'Search settings');
+  });
+
+  it('shows the clear button only when there is text, and clearing empties the input', async () => {
+    render(SearchBar, { props: { value: '', debounceMs: 0 } });
+    expect(screen.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'hello' } });
+    const clearBtn = screen.getByRole('button', { name: 'Clear search' });
+    await fireEvent.click(clearBtn);
+    expect(input.value).toBe('');
+  });
+
+  it('renders the counter and prev/next navigation in find mode', () => {
+    render(SearchBar, { props: { showNav: true, counterText: '2 of 17', value: 'the' } });
+    expect(screen.getByText('2 of 17')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next match/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /previous match/i })).toBeInTheDocument();
+  });
+
+  it('disables navigation when navDisabled is set', () => {
+    render(SearchBar, { props: { showNav: true, navDisabled: true, value: 'x' } });
+    expect(screen.getByRole('button', { name: /next match/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /previous match/i })).toBeDisabled();
+  });
+
+  it('styles the counter as no-results and shows a loading status', () => {
+    const { rerender } = render(SearchBar, {
+      props: { counterText: 'No matches', noResults: true, value: 'zzz' },
+    });
+    const counter = screen.getByText('No matches');
+    expect(counter).toHaveClass('no-results');
+
+    rerender({ loading: true, statusText: 'searching entire transcript…', value: 'zzz' });
+    expect(screen.getByText('searching entire transcript…')).toBeInTheDocument();
+  });
+
+  it('exposes combobox wiring when role="combobox"', () => {
+    render(SearchBar, {
+      props: {
+        role: 'combobox',
+        ariaControls: 'results-list',
+        ariaExpanded: true,
+        inputId: 'settings-search-input',
+      },
+    });
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-controls', 'results-list');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    expect(input).toHaveAttribute('id', 'settings-search-input');
+  });
+});

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Den ursprünglichen, unzensierten Text anzeigen (nur Eigentümer und Administratoren; vom Administrator erzwungene Kategorien bleiben maskiert)",
   "settings.contentRedaction.showRedactedTooltip": "Zurück zur zensierten Ansicht mit maskierten sensiblen Inhalten",
   "settings.sections.billingTeam": "Abrechnung & Team",
-  "settings.orgContext.cloudTitle": "Transkript-Kontext"
+  "settings.orgContext.cloudTitle": "Transkript-Kontext",
+  "settingsSearch.placeholder": "Einstellungen durchsuchen",
+  "settingsSearch.ariaLabel": "Einstellungen durchsuchen",
+  "settingsSearch.resultsCount": "{{count}} Ergebnisse",
+  "settingsSearch.noResultsTitle": "Keine Ergebnisse",
+  "settingsSearch.noResults": "Keine Einstellungen für „{{query}}“ gefunden",
+  "transcriptSearch.searchingAll": "Gesamtes Transkript wird durchsucht…",
+  "transcriptSearch.moreInTranscript": "Weitere Treffer im nicht geladenen Transkript"
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Reveal the original unredacted text (owners and admins only; admin-forced categories stay masked)",
   "settings.contentRedaction.showRedactedTooltip": "Switch back to the redacted view with sensitive content masked",
   "settings.sections.billingTeam": "Billing & Team",
-  "settings.orgContext.cloudTitle": "Transcript Context"
+  "settings.orgContext.cloudTitle": "Transcript Context",
+  "settingsSearch.placeholder": "Search settings",
+  "settingsSearch.ariaLabel": "Search settings",
+  "settingsSearch.resultsCount": "{{count}} results",
+  "settingsSearch.noResultsTitle": "No results",
+  "settingsSearch.noResults": "No settings found for \"{{query}}\"",
+  "transcriptSearch.searchingAll": "Searching entire transcript…",
+  "transcriptSearch.moreInTranscript": "More matches in unloaded transcript"
 }

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Mostrar el texto original sin censura (solo propietarios y administradores; las categorías forzadas por el administrador permanecen ocultas)",
   "settings.contentRedaction.showRedactedTooltip": "Volver a la vista censurada con el contenido sensible oculto",
   "settings.sections.billingTeam": "Facturación y equipo",
-  "settings.orgContext.cloudTitle": "Contexto de la transcripción"
+  "settings.orgContext.cloudTitle": "Contexto de la transcripción",
+  "settingsSearch.placeholder": "Buscar ajustes",
+  "settingsSearch.ariaLabel": "Buscar ajustes",
+  "settingsSearch.resultsCount": "{{count}} resultados",
+  "settingsSearch.noResultsTitle": "Sin resultados",
+  "settingsSearch.noResults": "No se encontraron ajustes para «{{query}}»",
+  "transcriptSearch.searchingAll": "Buscando en toda la transcripción…",
+  "transcriptSearch.moreInTranscript": "Más coincidencias en la transcripción no cargada"
 }

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Afficher le texte original non expurgé (propriétaires et administrateurs uniquement ; les catégories imposées par l'administrateur restent masquées)",
   "settings.contentRedaction.showRedactedTooltip": "Revenir à la vue expurgée avec le contenu sensible masqué",
   "settings.sections.billingTeam": "Facturation et équipe",
-  "settings.orgContext.cloudTitle": "Contexte de transcription"
+  "settings.orgContext.cloudTitle": "Contexte de transcription",
+  "settingsSearch.placeholder": "Rechercher dans les réglages",
+  "settingsSearch.ariaLabel": "Rechercher dans les réglages",
+  "settingsSearch.resultsCount": "{{count}} résultats",
+  "settingsSearch.noResultsTitle": "Aucun résultat",
+  "settingsSearch.noResults": "Aucun réglage trouvé pour « {{query}} »",
+  "transcriptSearch.searchingAll": "Recherche dans toute la transcription…",
+  "transcriptSearch.moreInTranscript": "Autres résultats dans la transcription non chargée"
 }

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "編集されていない元のテキストを表示（所有者と管理者のみ。管理者が強制したカテゴリはマスクされたままです）",
   "settings.contentRedaction.showRedactedTooltip": "機密コンテンツがマスクされた編集済みビューに戻す",
   "settings.sections.billingTeam": "請求とチーム",
-  "settings.orgContext.cloudTitle": "文字起こしコンテキスト"
+  "settings.orgContext.cloudTitle": "文字起こしコンテキスト",
+  "settingsSearch.placeholder": "設定を検索",
+  "settingsSearch.ariaLabel": "設定を検索",
+  "settingsSearch.resultsCount": "{{count}} 件の結果",
+  "settingsSearch.noResultsTitle": "結果なし",
+  "settingsSearch.noResults": "「{{query}}」に一致する設定が見つかりません",
+  "transcriptSearch.searchingAll": "文字起こし全体を検索中…",
+  "transcriptSearch.moreInTranscript": "未読み込みの文字起こしにさらに一致があります"
 }

--- a/frontend/src/lib/i18n/locales/pt.json
+++ b/frontend/src/lib/i18n/locales/pt.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Mostrar o texto original sem censura (apenas proprietários e administradores; categorias impostas pelo administrador permanecem ocultas)",
   "settings.contentRedaction.showRedactedTooltip": "Voltar à visualização censurada com o conteúdo sensível oculto",
   "settings.sections.billingTeam": "Faturação e equipa",
-  "settings.orgContext.cloudTitle": "Contexto da transcrição"
+  "settings.orgContext.cloudTitle": "Contexto da transcrição",
+  "settingsSearch.placeholder": "Pesquisar configurações",
+  "settingsSearch.ariaLabel": "Pesquisar configurações",
+  "settingsSearch.resultsCount": "{{count}} resultados",
+  "settingsSearch.noResultsTitle": "Sem resultados",
+  "settingsSearch.noResults": "Nenhuma configuração encontrada para \"{{query}}\"",
+  "transcriptSearch.searchingAll": "Pesquisando toda a transcrição…",
+  "transcriptSearch.moreInTranscript": "Mais correspondências na transcrição não carregada"
 }

--- a/frontend/src/lib/i18n/locales/ru.json
+++ b/frontend/src/lib/i18n/locales/ru.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "Показать исходный текст без цензуры (только для владельцев и администраторов; категории, заданные администратором, остаются скрытыми)",
   "settings.contentRedaction.showRedactedTooltip": "Вернуться к отредактированному виду со скрытым конфиденциальным содержимым",
   "settings.sections.billingTeam": "Оплата и команда",
-  "settings.orgContext.cloudTitle": "Контекст транскрипции"
+  "settings.orgContext.cloudTitle": "Контекст транскрипции",
+  "settingsSearch.placeholder": "Поиск настроек",
+  "settingsSearch.ariaLabel": "Поиск настроек",
+  "settingsSearch.resultsCount": "{{count}} результатов",
+  "settingsSearch.noResultsTitle": "Нет результатов",
+  "settingsSearch.noResults": "Настройки по запросу «{{query}}» не найдены",
+  "transcriptSearch.searchingAll": "Поиск по всей расшифровке…",
+  "transcriptSearch.moreInTranscript": "Ещё совпадения в незагруженной части расшифровки"
 }

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -3825,5 +3825,12 @@
   "settings.contentRedaction.showOriginalTooltip": "显示未经编校的原始文本（仅限所有者和管理员；管理员强制的类别仍保持遮蔽）",
   "settings.contentRedaction.showRedactedTooltip": "切换回已编校视图，敏感内容将被遮蔽",
   "settings.sections.billingTeam": "账单与团队",
-  "settings.orgContext.cloudTitle": "转录上下文"
+  "settings.orgContext.cloudTitle": "转录上下文",
+  "settingsSearch.placeholder": "搜索设置",
+  "settingsSearch.ariaLabel": "搜索设置",
+  "settingsSearch.resultsCount": "{{count}} 个结果",
+  "settingsSearch.noResultsTitle": "无结果",
+  "settingsSearch.noResults": "未找到与“{{query}}”相关的设置",
+  "transcriptSearch.searchingAll": "正在搜索整个转录文本…",
+  "transcriptSearch.moreInTranscript": "未加载的转录文本中还有更多匹配项"
 }

--- a/frontend/src/lib/search/findInText.test.ts
+++ b/frontend/src/lib/search/findInText.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findOccurrences,
+  createFindState,
+  nextIndex,
+  previousIndex,
+  type TextBlock,
+} from './findInText';
+
+const blocks: TextBlock[] = [
+  { id: 'a', text: 'The quick brown fox' },
+  { id: 'b', text: 'jumps over the lazy dog' },
+  { id: 'c', text: 'THE END the the' },
+];
+
+describe('findOccurrences', () => {
+  it('returns nothing for an empty query', () => {
+    expect(findOccurrences(blocks, '')).toEqual([]);
+    expect(findOccurrences(blocks, '   ')).toEqual([]);
+  });
+
+  it('finds case-insensitive matches in document order with positions', () => {
+    const occ = findOccurrences(blocks, 'the');
+    // "The"(a) + "the"(b) + "THE","the","the"(c) = 5
+    expect(occ.length).toBe(5);
+    expect(occ[0]).toMatchObject({ blockIndex: 0, blockId: 'a', start: 0, length: 3 });
+    expect(occ[1].blockId).toBe('b');
+    expect(occ[2].blockId).toBe('c');
+    // last block has three "the" occurrences at distinct offsets
+    const inC = occ.filter((o) => o.blockId === 'c');
+    expect(inC.map((o) => o.start)).toEqual([0, 8, 12]);
+  });
+
+  it('skips blocks with non-string text', () => {
+    const dirty = [
+      { id: 1, text: 'ok' },
+      { id: 2, text: null as unknown as string },
+    ];
+    expect(findOccurrences(dirty, 'ok').length).toBe(1);
+  });
+});
+
+describe('createFindState', () => {
+  it('sets a query and starts at the first match', () => {
+    const state = createFindState();
+    const snap = state.setQuery(blocks, 'fox');
+    expect(snap.total).toBe(1);
+    expect(snap.current).toBe(0);
+    expect(snap.currentOccurrence?.blockId).toBe('a');
+  });
+
+  it('wraps forward and backward', () => {
+    const state = createFindState();
+    state.setQuery(blocks, 'the'); // 5 matches, current = 0
+    expect(state.next().current).toBe(1);
+    expect(state.previous().current).toBe(0);
+    expect(state.previous().current).toBe(4); // wrap to last
+    expect(state.next().current).toBe(0); // wrap to first
+  });
+
+  it('clears to an empty state', () => {
+    const state = createFindState();
+    state.setQuery(blocks, 'the');
+    const snap = state.clear();
+    expect(snap.total).toBe(0);
+    expect(snap.current).toBe(-1);
+    expect(snap.currentOccurrence).toBeNull();
+  });
+
+  it('handles no matches', () => {
+    const state = createFindState();
+    const snap = state.setQuery(blocks, 'zzz');
+    expect(snap.total).toBe(0);
+    expect(snap.current).toBe(-1);
+    expect(state.next().current).toBe(-1);
+  });
+});
+
+describe('nextIndex / previousIndex', () => {
+  it('wraps around', () => {
+    expect(nextIndex(2, 3)).toBe(0);
+    expect(nextIndex(0, 3)).toBe(1);
+    expect(previousIndex(0, 3)).toBe(2);
+    expect(previousIndex(1, 3)).toBe(0);
+  });
+
+  it('returns -1 when empty', () => {
+    expect(nextIndex(0, 0)).toBe(-1);
+    expect(previousIndex(0, 0)).toBe(-1);
+  });
+});

--- a/frontend/src/lib/search/findInText.ts
+++ b/frontend/src/lib/search/findInText.ts
@@ -1,0 +1,124 @@
+/**
+ * findInText — reusable literal (Ctrl+F-style) in-document find.
+ *
+ * Extracted from the matching loop that lived inline in TranscriptSearch, so the
+ * summary find, the transcript find, and any future in-document search share one
+ * tested implementation. Matching is literal case-insensitive substring — the
+ * correct behavior for a "find in document" bar (browsers, editors, macOS all do
+ * this) and the only kind that can be highlighted contiguously.
+ *
+ * This module is pure/side-effect free: components own their scroll/seek/highlight
+ * side effects and drive them from the returned occurrences.
+ */
+
+export interface TextBlock {
+  /** Stable id for the block (e.g. a segment uuid) used to scroll to a match. */
+  id: string | number;
+  /** The searchable text of the block. */
+  text: string;
+}
+
+export interface TextOccurrence {
+  /** Index of the block within the input array. */
+  blockIndex: number;
+  /** The block's stable id. */
+  blockId: string | number;
+  /** Character offset of the match within the block text. */
+  start: number;
+  /** Length of the matched substring (== query length). */
+  length: number;
+}
+
+/**
+ * Find every case-insensitive occurrence of `query` across `blocks`, in document
+ * order. Returns an empty array for an empty/whitespace query.
+ */
+export function findOccurrences(blocks: TextBlock[], query: string): TextOccurrence[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle || !blocks?.length) return [];
+
+  const occurrences: TextOccurrence[] = [];
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const block = blocks[blockIndex];
+    if (!block || typeof block.text !== 'string') continue;
+    const haystack = block.text.toLowerCase();
+
+    let from = 0;
+    let at = haystack.indexOf(needle, from);
+    while (at !== -1) {
+      occurrences.push({
+        blockIndex,
+        blockId: block.id,
+        start: at,
+        length: needle.length,
+      });
+      from = at + needle.length;
+      at = haystack.indexOf(needle, from);
+    }
+  }
+  return occurrences;
+}
+
+export interface FindSnapshot {
+  occurrences: TextOccurrence[];
+  /** 0-based index of the active match, or -1 when there are none. */
+  current: number;
+  total: number;
+  /** The active occurrence, or null. */
+  currentOccurrence: TextOccurrence | null;
+}
+
+/**
+ * Small framework-agnostic state machine wrapping `findOccurrences` with
+ * wrap-around next/previous navigation. Each mutator returns a fresh snapshot so
+ * Svelte components can assign it reactively.
+ */
+export function createFindState() {
+  let occurrences: TextOccurrence[] = [];
+  let current = -1;
+
+  function snapshot(): FindSnapshot {
+    return {
+      occurrences,
+      current,
+      total: occurrences.length,
+      currentOccurrence: current >= 0 ? occurrences[current] : null,
+    };
+  }
+
+  return {
+    snapshot,
+    setQuery(blocks: TextBlock[], query: string): FindSnapshot {
+      occurrences = findOccurrences(blocks, query);
+      current = occurrences.length ? 0 : -1;
+      return snapshot();
+    },
+    next(): FindSnapshot {
+      if (occurrences.length) current = (current + 1) % occurrences.length;
+      return snapshot();
+    },
+    previous(): FindSnapshot {
+      if (occurrences.length) {
+        current = (current - 1 + occurrences.length) % occurrences.length;
+      }
+      return snapshot();
+    },
+    clear(): FindSnapshot {
+      occurrences = [];
+      current = -1;
+      return snapshot();
+    },
+  };
+}
+
+/** Next index with wrap-around (pure helper for consumers that manage their own state). */
+export function nextIndex(current: number, total: number): number {
+  if (total <= 0) return -1;
+  return (current + 1) % total;
+}
+
+/** Previous index with wrap-around. */
+export function previousIndex(current: number, total: number): number {
+  if (total <= 0) return -1;
+  return (current - 1 + total) % total;
+}

--- a/frontend/src/lib/search/fuzzyMatcher.test.ts
+++ b/frontend/src/lib/search/fuzzyMatcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { createFuzzyIndex, normalizeText } from './fuzzyMatcher';
+
+interface Item {
+  label: string;
+  description?: string;
+  keywords?: string[];
+}
+
+const items: Item[] = [
+  { label: 'Transcription', description: 'source language and speaker counts' },
+  { label: 'Content Redaction', description: 'mask PII and profanity' },
+  { label: 'Backup', description: 'scheduled database backups', keywords: ['speaker export'] },
+  { label: 'Speaker Attributes', description: 'per-speaker configuration' },
+  { label: 'Vídeo Ajustes', description: 'opciones de vídeo' },
+];
+
+function makeIndex() {
+  return createFuzzyIndex(items, {
+    keys: [
+      { name: 'label', weight: 3 },
+      { name: 'description', weight: 1 },
+      { name: 'keywords', weight: 1 },
+    ],
+  });
+}
+
+describe('normalizeText', () => {
+  it('case-folds and strips diacritics', () => {
+    expect(normalizeText('Vídeo')).toBe('video');
+    expect(normalizeText('ÀÉÎÕÜ')).toBe('aeiou');
+  });
+});
+
+describe('createFuzzyIndex', () => {
+  it('returns nothing for an empty/whitespace query', () => {
+    expect(makeIndex().search('')).toEqual([]);
+    expect(makeIndex().search('   ')).toEqual([]);
+  });
+
+  it('ranks an exact label match first', () => {
+    const results = makeIndex().search('transcription');
+    expect(results[0].item.label).toBe('Transcription');
+  });
+
+  it('tolerates typos', () => {
+    const results = makeIndex().search('transcibe');
+    expect(results.map((r) => r.item.label)).toContain('Transcription');
+  });
+
+  it('weights label matches above description matches', () => {
+    const results = makeIndex().search('speaker');
+    const labels = results.map((r) => r.item.label);
+    // "Speaker Attributes" (label hit) should outrank items that only mention
+    // "speaker" in description/keywords.
+    expect(labels[0]).toBe('Speaker Attributes');
+  });
+
+  it('folds diacritics so an unaccented query matches accented text', () => {
+    const results = makeIndex().search('video');
+    expect(results.map((r) => r.item.label)).toContain('Vídeo Ajustes');
+  });
+
+  it('honors an explicit result limit', () => {
+    const results = makeIndex().search('a', 2); // broad query
+    expect(results.length).toBeLessThanOrEqual(2);
+  });
+
+  it('refreshes its collection via setCollection', () => {
+    const index = createFuzzyIndex<Item>([], { keys: ['label'] });
+    expect(index.search('backup')).toEqual([]);
+    index.setCollection(items);
+    expect(index.search('backup').map((r) => r.item.label)).toContain('Backup');
+  });
+});

--- a/frontend/src/lib/search/fuzzyMatcher.ts
+++ b/frontend/src/lib/search/fuzzyMatcher.ts
@@ -1,0 +1,115 @@
+/**
+ * fuzzyMatcher — a thin, opinionated wrapper around fuse.js.
+ *
+ * This is NOT a custom matching algorithm: fuse.js does all the work. The wrapper
+ * only (a) centralizes one set of sensible defaults so every fuzzy surface in the
+ * app behaves consistently, and (b) folds diacritics/case so accented locales
+ * (es/fr/pt/de …) match regardless of how the user types the query.
+ *
+ * Highlighting is intentionally NOT derived from fuse's match ranges — those are
+ * computed against the normalized text and would misalign with the original label.
+ * Consumers highlight the display string separately (see `$lib/utils/searchHighlight`).
+ */
+import Fuse, { type IFuseOptions } from 'fuse.js';
+
+/**
+ * Case-fold and strip combining diacritical marks so "vídeo" ⇄ "video".
+ * Uses Unicode NFD decomposition then removes the combining-marks block.
+ */
+export function normalizeText(value: string): string {
+  return value.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
+}
+
+export interface FuzzyKey {
+  /** Dotted path into the item, e.g. `"label"` or `"keywords"`. */
+  name: string;
+  /** Relative weight; higher = more influential. Default 1. */
+  weight?: number;
+}
+
+export interface FuzzyIndexOptions {
+  /** Searchable fields (string paths or weighted key objects). */
+  keys: Array<string | FuzzyKey>;
+  /** 0 = exact only, 1 = match anything. Default 0.4. */
+  threshold?: number;
+  /** Minimum query length that can produce a match. Default 2. */
+  minMatchCharLength?: number;
+  /** Default cap on results per search. */
+  limit?: number;
+}
+
+export interface FuzzyResult<T> {
+  item: T;
+  /** fuse score: 0 = perfect, 1 = worst. */
+  score: number;
+  /** Index of the item in the source collection. */
+  refIndex: number;
+}
+
+export interface FuzzyIndex<T> {
+  search(query: string, limit?: number): FuzzyResult<T>[];
+  setCollection(items: T[]): void;
+}
+
+function resolvePath(obj: unknown, segments: string[]): unknown {
+  let current: unknown = obj;
+  for (const segment of segments) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/**
+ * fuse.js value extractor that normalizes every indexed string. Because indexing
+ * happens through this, the stored tokens are accent-folded; we normalize the
+ * query the same way in `search()` so both sides line up.
+ */
+function normalizingGetFn(obj: unknown, path: string | string[]): string | string[] {
+  const segments = Array.isArray(path) ? path : String(path).split('.');
+  const value = resolvePath(obj, segments);
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.map((entry) => normalizeText(String(entry)));
+  return normalizeText(String(value));
+}
+
+/**
+ * Build a reusable fuzzy index over `items`. The returned object is cheap to hold
+ * and can be refreshed in place via `setCollection` (e.g. on locale change).
+ */
+export function createFuzzyIndex<T>(items: T[], options: FuzzyIndexOptions): FuzzyIndex<T> {
+  const defaultLimit = options.limit;
+  const fuseOptions: IFuseOptions<T> = {
+    keys: options.keys as IFuseOptions<T>['keys'],
+    threshold: options.threshold ?? 0.4,
+    minMatchCharLength: options.minMatchCharLength ?? 2,
+    ignoreLocation: true,
+    includeScore: true,
+    shouldSort: true,
+    // fuse's typing for getFn is stricter than our normalize helper; the runtime
+    // contract (return string | string[]) is satisfied.
+    getFn: normalizingGetFn as unknown as IFuseOptions<T>['getFn'],
+  };
+
+  const fuse = new Fuse(items, fuseOptions);
+
+  return {
+    search(query: string, limit?: number): FuzzyResult<T>[] {
+      const normalized = normalizeText(query.trim());
+      if (!normalized) return [];
+      const effectiveLimit = limit ?? defaultLimit;
+      const raw = fuse.search(
+        normalized,
+        effectiveLimit != null ? { limit: effectiveLimit } : undefined
+      );
+      return raw.map((result) => ({
+        item: result.item,
+        score: result.score ?? 0,
+        refIndex: result.refIndex,
+      }));
+    },
+    setCollection(next: T[]): void {
+      fuse.setCollection(next);
+    },
+  };
+}

--- a/frontend/src/lib/search/settingsSearchIndex.test.ts
+++ b/frontend/src/lib/search/settingsSearchIndex.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSettingsSearchItems,
+  createSettingsFuzzyIndex,
+  type VisibleSection,
+} from './settingsSearchIndex';
+
+const dict: Record<string, string> = {
+  // engine-settings namespace
+  'settings.engineSettings.title': 'Engine Configuration',
+  'settings.engineSettings.transcriberBackend': 'Transcriber backend',
+  'settings.engineSettings.transcriberBackendHelp': 'Choose the ASR engine to use',
+  'settings.engineSettings.save': 'Save', // chrome — excluded
+  'settings.engineSettings.saveFailed': 'Save failed', // chrome — excluded
+  'settings.engineSettings.toast.saved': 'Saved!', // toast — excluded
+  // authentication sub-panel (settings.ldap folds into authentication)
+  'settings.authentication.title': 'Authentication',
+  'settings.ldap.serverUrl': 'LDAP server URL',
+  // content-redaction with an enumerated option label (dynamic key in components)
+  'settings.contentRedaction.title': 'Content Redaction',
+  'settings.contentRedaction.category.pii': 'Personal information',
+  // a section NOT in the visible set — must be excluded
+  'settings.backup.title': 'Backups',
+  'settings.backup.retentionDays': 'Retention days',
+};
+
+const visible: VisibleSection[] = [
+  { id: 'engine-settings', label: 'Engine Configuration' },
+  { id: 'authentication', label: 'Authentication' },
+  { id: 'content-redaction', label: 'Content Redaction' },
+  // backup intentionally omitted (user can't see it)
+];
+
+describe('buildSettingsSearchItems', () => {
+  const items = buildSettingsSearchItems(dict, visible);
+
+  it('includes a section-title row for each visible section', () => {
+    const titles = items.filter((i) => i.isSectionTitle).map((i) => i.label);
+    expect(titles).toEqual(
+      expect.arrayContaining(['Engine Configuration', 'Authentication', 'Content Redaction'])
+    );
+  });
+
+  it('indexes real setting labels', () => {
+    expect(items.find((i) => i.label === 'Transcriber backend')).toBeTruthy();
+    expect(items.find((i) => i.label === 'LDAP server URL')).toBeTruthy();
+  });
+
+  it('folds settings.ldap.* into the authentication section', () => {
+    const ldap = items.find((i) => i.label === 'LDAP server URL');
+    expect(ldap?.sectionId).toBe('authentication');
+  });
+
+  it('excludes chrome leaves (save/saveFailed/toast)', () => {
+    expect(items.find((i) => i.label === 'Save')).toBeFalsy();
+    expect(items.find((i) => i.label === 'Save failed')).toBeFalsy();
+    expect(items.find((i) => i.label === 'Saved!')).toBeFalsy();
+  });
+
+  it('folds Help text into its base setting as keywords, not a separate row', () => {
+    const rows = items.filter((i) => i.label === 'Choose the ASR engine to use');
+    expect(rows.length).toBe(0);
+    const backend = items.find((i) => i.label === 'Transcriber backend');
+    expect(backend?.keywords).toContain('Choose the ASR engine to use');
+  });
+
+  it('includes enumerated option labels sourced from the key tree', () => {
+    expect(items.find((i) => i.label === 'Personal information')).toBeTruthy();
+  });
+
+  it('respects capability gating — hidden sections are not indexed', () => {
+    expect(items.find((i) => i.sectionId === 'backup')).toBeFalsy();
+    expect(items.find((i) => i.label === 'Retention days')).toBeFalsy();
+  });
+
+  it('is empty for an empty dictionary', () => {
+    expect(buildSettingsSearchItems({}, visible).some((i) => !i.isSectionTitle)).toBe(false);
+  });
+});
+
+describe('createSettingsFuzzyIndex', () => {
+  const items = buildSettingsSearchItems(dict, visible);
+  const index = createSettingsFuzzyIndex(items);
+
+  it('finds a setting and points at the right section', () => {
+    const results = index.search('transcriber backend');
+    expect(results[0].item.sectionId).toBe('engine-settings');
+  });
+
+  it('finds a setting via its help text (keywords)', () => {
+    const results = index.search('ASR engine');
+    expect(results.map((r) => r.item.sectionId)).toContain('engine-settings');
+  });
+
+  it('tolerates a typo', () => {
+    const results = index.search('redaction');
+    expect(results.map((r) => r.item.sectionId)).toContain('content-redaction');
+  });
+});

--- a/frontend/src/lib/search/settingsSearchIndex.ts
+++ b/frontend/src/lib/search/settingsSearchIndex.ts
@@ -1,0 +1,274 @@
+/**
+ * settingsSearchIndex — build a searchable index of settings from the i18n tree.
+ *
+ * The settings panels are 100% translated via flat dot-notation i18n keys, so the
+ * localized text is the natural search corpus: sourcing from the key tree means
+ * search works in all 8 locales for free and automatically covers enumerated
+ * option labels built with template-literal keys (which a component grep misses).
+ *
+ * This module is pure/testable. The caller supplies:
+ *   - `dict`: the flat locale dictionary (i18next.getResourceBundle(lng,'translation'))
+ *   - `visibleSections`: the sections the current user can actually open (already
+ *     capability/edition-filtered by SettingsModal) with their resolved labels.
+ * so the index never surfaces a section the user can't navigate to.
+ */
+import type { SettingsSection } from '$stores/settingsModalStore';
+import { createFuzzyIndex, type FuzzyIndex } from './fuzzyMatcher';
+
+export interface SettingsSearchItem {
+  /** Section to navigate to when this result is chosen. */
+  sectionId: SettingsSection;
+  /** Parent section name (shown under the result, macOS style). */
+  sectionLabel: string;
+  /** The matched setting's display text. */
+  label: string;
+  /** Searchable text (label + any paired help/description). */
+  keywords: string;
+  /** Text used to locate + flash the control in the DOM after navigation. */
+  anchorText: string;
+  /** True for the row that represents the section itself. */
+  isSectionTitle: boolean;
+}
+
+/**
+ * i18n namespaces (full key prefixes) whose leaves belong to each section. Sub-panel
+ * namespaces are folded into their parent section so their settings are findable and
+ * navigation lands somewhere the user can actually reach. Seeded from SettingsModal's
+ * `sidebarSections`; keep in sync when sections/panels are added.
+ */
+const SECTION_NAMESPACES: Partial<Record<SettingsSection, string[]>> = {
+  'system-statistics': ['settings.statistics'],
+  billing: ['billing'],
+  usage: ['usage'],
+  team: ['team'],
+  'audit-logs': ['settings.auditLog'],
+  authentication: [
+    'settings.authentication',
+    'settings.ldap',
+    'settings.keycloak',
+    'settings.pki',
+    'settings.localAuth',
+    'settings.session',
+  ],
+  'admin-users': ['settings.users', 'settings.accountStatus'],
+  'data-integrity': ['settings.dataIntegrity'],
+  retention: ['settings.retention', 'settings.cache'],
+  backup: ['settings.backup'],
+  'search-indexing': ['settings.searchIndexing', 'settings.search'],
+  'embedding-migration': ['settings.embeddingMigration', 'settings.embeddingConsistency'],
+  'admin-task-health': ['settings.taskHealth', 'settings.retry'],
+  groups: ['groups'],
+  profile: ['settings.profile', 'settings.security', 'settings.certificate', 'settings.language'],
+  'ai-prompts': ['settings.aiPrompts', 'prompts'],
+  'asr-provider': ['settings.asrProvider'],
+  'engine-settings': ['settings.engineSettings'],
+  'redaction-policy': ['settings.redactionPolicy'],
+  'auto-labeling': ['autoLabel'],
+  'custom-vocabulary': ['settings.customVocabulary', 'settings.vocabulary'],
+  'content-redaction': ['settings.contentRedaction'],
+  'llm-provider': ['settings.llmProvider', 'llm'],
+  'organization-context': ['settings.orgContext'],
+  'speaker-attributes': ['settings.speakerAttributes'],
+  transcription: ['settings.transcription'],
+  'audio-extraction': ['settings.audioExtraction'],
+  'media-sources': ['settings.mediaSources'],
+  'watch-sources': ['settings.watchSources', 'settings.emailNotifications'],
+  recording: ['settings.recording'],
+  download: ['settings.download'],
+};
+
+/**
+ * Leaf tokens that are UI chrome (buttons/toasts/status), not real settings. The
+ * last dotted segment of a key is checked against this set. Descriptions/help/hints
+ * are intentionally NOT excluded — they are wanted in the index.
+ */
+const STOP_LEAVES = new Set(
+  [
+    'save',
+    'saving',
+    'saved',
+    'saveFailed',
+    'saveError',
+    'saveSuccess',
+    'saveChanges',
+    'cancel',
+    'close',
+    'confirm',
+    'confirming',
+    'delete',
+    'deleting',
+    'deleted',
+    'remove',
+    'removing',
+    'removed',
+    'edit',
+    'editing',
+    'add',
+    'adding',
+    'added',
+    'back',
+    'retry',
+    'retrying',
+    'refresh',
+    'refreshing',
+    'reset',
+    'resetting',
+    'apply',
+    'applying',
+    'loading',
+    'loadFailed',
+    'loadError',
+    'updating',
+    'updated',
+    'success',
+    'error',
+    'errorTitle',
+    'testing',
+    'testConnection',
+    'testSuccess',
+    'testFailed',
+    'dismiss',
+    'discard',
+    'saveButton',
+    'cancelButton',
+  ].map((s) => s.toLowerCase())
+);
+
+/** Secondary text suffixes: these leaves are folded into their base setting as keywords. */
+const SECONDARY_SUFFIX = /(Help|Hint|Description|Desc|Note|Tooltip|Subtitle|Caption|Placeholder)$/;
+
+function cleanText(value: string): string {
+  return value
+    .replace(/\{\{[^}]*\}\}/g, '') // strip i18n interpolation placeholders
+    .replace(/<[^>]*>/g, ' ') // strip any stray html
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function lastSegment(key: string): string {
+  const idx = key.lastIndexOf('.');
+  return idx === -1 ? key : key.slice(idx + 1);
+}
+
+function isStopLeaf(leaf: string): boolean {
+  return STOP_LEAVES.has(leaf.toLowerCase());
+}
+
+export interface VisibleSection {
+  id: SettingsSection;
+  label: string;
+}
+
+/**
+ * Build the flat list of searchable settings items for the given locale dictionary,
+ * limited to the sections the user can open.
+ */
+export function buildSettingsSearchItems(
+  dict: Record<string, string>,
+  visibleSections: VisibleSection[]
+): SettingsSearchItem[] {
+  const items: SettingsSearchItem[] = [];
+  if (!dict) return items;
+
+  for (const section of visibleSections) {
+    const sectionLabel = cleanText(section.label || '');
+    const seen = new Set<string>();
+
+    // The section itself is always findable by its own name.
+    if (sectionLabel) {
+      const key = sectionLabel.toLowerCase();
+      seen.add(key);
+      items.push({
+        sectionId: section.id,
+        sectionLabel,
+        label: sectionLabel,
+        keywords: sectionLabel,
+        anchorText: sectionLabel,
+        isSectionTitle: true,
+      });
+    }
+
+    const namespaces = SECTION_NAMESPACES[section.id];
+    if (!namespaces) continue;
+
+    // Two passes so secondary (help/hint) text can attach to its base setting.
+    const primaries = new Map<string, SettingsSearchItem>();
+    const orphanSecondaries: Array<{ base: string; value: string }> = [];
+
+    for (const ns of namespaces) {
+      const prefix = `${ns}.`;
+      for (const fullKey of Object.keys(dict)) {
+        if (!fullKey.startsWith(prefix)) continue;
+        if (fullKey.includes('.toast.') || fullKey.includes('.errors.')) continue;
+
+        const leaf = lastSegment(fullKey);
+        if (leaf === 'title' || leaf === 'description') {
+          // Section-level title/description handled by the section-title row / kept minimal.
+          // (A section's own title duplicates the section row; skip to avoid noise.)
+          continue;
+        }
+        if (isStopLeaf(leaf)) continue;
+
+        const value = cleanText(dict[fullKey] ?? '');
+        if (!value || !/\p{L}/u.test(value)) continue;
+
+        const relative = fullKey.slice(prefix.length);
+        if (SECONDARY_SUFFIX.test(leaf)) {
+          orphanSecondaries.push({ base: relative.replace(SECONDARY_SUFFIX, ''), value });
+          continue;
+        }
+
+        const dedupeKey = value.toLowerCase();
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        const item: SettingsSearchItem = {
+          sectionId: section.id,
+          sectionLabel,
+          label: value,
+          keywords: value,
+          anchorText: value,
+          isSectionTitle: false,
+        };
+        primaries.set(relative, item);
+        items.push(item);
+      }
+    }
+
+    // Attach secondary text to its base setting as extra keywords, or index it standalone.
+    for (const secondary of orphanSecondaries) {
+      const base = primaries.get(secondary.base);
+      if (base) {
+        base.keywords = `${base.keywords} ${secondary.value}`;
+      } else {
+        const dedupeKey = secondary.value.toLowerCase();
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        items.push({
+          sectionId: section.id,
+          sectionLabel,
+          label: secondary.value,
+          keywords: secondary.value,
+          anchorText: secondary.value,
+          isSectionTitle: false,
+        });
+      }
+    }
+  }
+
+  return items;
+}
+
+/** fuse.js field weights: a section's own name ranks highest, then the label, then help text. */
+export function createSettingsFuzzyIndex(
+  items: SettingsSearchItem[]
+): FuzzyIndex<SettingsSearchItem> {
+  return createFuzzyIndex(items, {
+    keys: [
+      { name: 'label', weight: 3 },
+      { name: 'sectionLabel', weight: 2 },
+      { name: 'keywords', weight: 1 },
+    ],
+    threshold: 0.4,
+    minMatchCharLength: 2,
+  });
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import "../styles/form-elements.css";
   import "../styles/tables.css";
   import "../styles/animations.css";
+  import "../styles/search.css";
 
   // Import auth store
   import { authStore, isAuthenticated, initAuth, authReady, getAuthMethods } from "$stores/auth";

--- a/frontend/src/styles/search.css
+++ b/frontend/src/styles/search.css
@@ -1,0 +1,64 @@
+/*
+ * search.css — shared search-highlight + flash styles.
+ *
+ * Promoted out of TranscriptSearch.svelte so every search surface (transcript
+ * find, summary find, settings search) highlights identically in light and dark.
+ * Class names are load-bearing: `.transcript-search-highlight` is emitted by
+ * `$lib/utils/searchHighlight.ts` and consumed by TranscriptDisplay and
+ * TranscriptSegmentList — do not rename.
+ */
+
+/* Inline text-match highlight (the yellow marker on matched words). */
+.transcript-search-highlight {
+  background-color: rgba(250, 204, 21, 0.4);
+  padding: 0.05em 0.15em;
+  border-radius: 2px;
+}
+
+.transcript-search-highlight.current {
+  background-color: rgba(250, 204, 21, 0.6);
+  border: 1px solid rgba(250, 204, 21, 0.8);
+}
+
+[data-theme='dark'] .transcript-search-highlight {
+  background-color: rgba(250, 204, 21, 0.3);
+  color: var(--text-primary);
+}
+
+[data-theme='dark'] .transcript-search-highlight.current {
+  background-color: rgba(250, 204, 21, 0.5);
+  border: 1px solid rgba(250, 204, 21, 0.7);
+}
+
+/* Whole-element "current match" pulse — used when scrolling a container (e.g. a
+   transcript segment) into view. */
+.search-current-match {
+  background-color: rgba(var(--primary-color-rgb), 0.2) !important;
+  border: 2px solid var(--primary-color) !important;
+  animation: search-pulse 1s ease-in-out;
+}
+
+/* Settings search: flash the control the user jumped to. */
+.settings-search-flash {
+  animation: search-pulse 1.6s ease-in-out;
+  border-radius: 6px;
+}
+
+@keyframes search-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--primary-color-rgb), 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(var(--primary-color-rgb), 0);
+  }
+}
+
+/* Respect reduced-motion: keep a static ring instead of the pulse. */
+@media (prefers-reduced-motion: reduce) {
+  .search-current-match,
+  .settings-search-flash {
+    animation: none;
+    box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb), 0.35);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **macOS System Settings–style search** to the Settings modal and unifies search UX across the app on a shared, library-first foundation. Typing in the box above the sidebar tabs shows ranked, highlighted results; selecting one **jumps to the section and flashes the matched control**.

Built on `fuse.js` (the established fuzzy library — no custom matching algorithm) plus a shared `SearchBar` primitive now used by settings, transcript, and summary search.

## What's included

**Shared foundation** — `$lib/search/{fuzzyMatcher,findInText}` + `ui/SearchBar.svelte` + `styles/search.css`. One accessible, themed input (counter, prev/next, two-phase spinner, i18n labels, Google-style soft-focus).

**Settings search** — index built from the i18n key tree (all 8 locales; capability/edition-gated; sub-panels folded into their parent; chrome stop-listed). Combobox/listbox a11y, arrow-key nav, Escape-clears-then-closes, mobile parity. Field-flash is a central DOM scan (bounded retry for async panels) — **no edits to the 45 settings panels**.

**Transcript search (backend-backed for completeness)** — transcripts paginate at 500 segments, so a pure client find misses unloaded matches. The find bar now:
- highlights local literal matches instantly, then resolves a debounced, race-guarded **completeness probe** (`GET /search/count`, file-scoped);
- shows a spinner + provisional counter and an `N of M+` indicator when matches may exist beyond the loaded window;
- progressively loads more segments to reach them. Ctrl+F / Escape / seek preserved.

**Summary search** — reduced to a thin `SearchBar` wrapper (whole summary already in memory).

**Backend (minimal + optimized)**
- `file_uuid` scope filter on the existing `GET /search` (reuses the OpenSearch index; no schema/migration/Celery).
- New **`GET /search/count`** (`size=0`, no embeddings/RRF/snippets) — **~20 ms warm** vs ~85 ms full search; concurrent via FastAPI threadpool + OpenSearch.

## Bug fixes (pre-existing)
- **Inline transcript highlighting was broken** for files using the backend `grouped_segments` payload (the default): `getOriginalSegmentIndex` did `indexOf` on a different object array → -1 → zero highlights (the segment pulse masked it). Fixed via a uuid→index map.
- **npm audit**: the pre-existing high-severity `form-data`/`undici` advisories fixed → **0 vulnerabilities**.

## Testing
- **Unit (Vitest)**: 110/110 (≈45 new — fuzzy matcher, find-in-text, settings index, SearchBar).
- **Backend (pytest)**: file-scope filter unit tests; ruff + mypy clean.
- **E2E (Playwright)**: `TestSettingsSearch` (6) + `TestTranscriptSearch` (5) — read-only, no dev-data mutation. All pass against the live stack.
- svelte-check 0/0, `npm run build` ✓, i18n parity ✓ (all 8 locales), pre-commit green.

## Notes
- Summary search couldn't be exercised with live data (no summarized files in dev without triggering LLM/GPU work) — it's a low-risk presentational swap to the proven `SearchBar`.
- The `/suggestions` 404 in console is expected/handled (optional LLM feature) — not a regression.
