### PR TITLE
perf(frontend): #284 Phase 2 (frontend half) — locale code-splitting, transcript scroll, lazy FFmpeg, upload stall watchdog

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -9,6 +9,11 @@ is frontend-specific. Folder-level `CLAUDE.md` files add detail where you're wor
   **client-side SPA** (`fallback: index.html`, no SSR, no `+page.server.ts`). Data is fetched
   client-side (`onMount`/reactive) from the FastAPI backend.
 - i18n via i18next (8 locales in `src/lib/i18n/locales`). Node pinned to 22 (`.nvmrc`).
+  Locales are **code-split, one chunk per language** — `src/lib/i18n/index.ts` globs them
+  non-eagerly and `ensureLocaleLoaded()` fetches only the active one. Never static-import a
+  locale JSON: that puts all ~2.3 MB back into the entry chunk. Only the active language is
+  loaded (not the `en` fallback), which is safe because `npm run check:i18n` enforces exact
+  key parity — keep it green.
 
 ## Commands (run in `frontend/`)
 

--- a/frontend/src/components/FileUploader.svelte
+++ b/frontend/src/components/FileUploader.svelte
@@ -18,7 +18,6 @@
   import { loadProtectedMediaAuthConfig } from '$lib/services/configService';
   import type { ExtractedAudio } from '$lib/types/audioExtraction';
   import { getAudioExtractionSettings, type AudioExtractionSettings } from '$lib/api/audioExtractionSettings';
-  import { audioExtractionService } from '$lib/services/audioExtractionService';
   import {
     getTranscriptionSettings,
     getTranscriptionSystemDefaults,
@@ -55,6 +54,20 @@
     selectedWhisperModel: string | null;
     skippedSteps: string[];  // step IDs that were skipped (e.g. ['tags', 'collections'])
     timestamp: number;
+  }
+
+  /**
+   * Load the FFmpeg.wasm wrapper on first use.
+   *
+   * A static import pulled `@ffmpeg/ffmpeg` + `@ffmpeg/util` into the home-page
+   * chunk, so every visitor downloaded the wrapper even though client-side audio
+   * extraction is an opt-in path taken only for video uploads. The dynamic
+   * `import()` moves it to its own chunk, fetched the first time a user actually
+   * extracts. The module caches itself, so repeat calls are free.
+   */
+  async function loadAudioExtractionService() {
+    const { audioExtractionService } = await import('$lib/services/audioExtractionService');
+    return audioExtractionService;
   }
 
   // ── Constants ──
@@ -551,7 +564,7 @@
     toastStore.info($t('uploader.extractingAudioFrom', { count: videoFiles.length }));
     videoFiles.forEach(async (videoFile) => {
       try {
-        const ea = await audioExtractionService.extractAudio(videoFile);
+        const ea = await (await loadAudioExtractionService()).extractAudio(videoFile);
         uploadsStore.addExtractedAudio(ea.blob, ea.filename, ea.metadata, ea.metadata.compressionRatio);
       } catch {
         toastStore.error($t('uploader.failedToExtractAudio', { filename: videoFile.name }));
@@ -609,7 +622,8 @@
       // Extraction runs in background — result is queued when done
       (async () => {
         try {
-          const extractedAudio = await audioExtractionService.extractAudio(fileToExtract);
+          const extractionService = await loadAudioExtractionService();
+          const extractedAudio = await extractionService.extractAudio(fileToExtract);
           uploadsStore.addExtractedAudio(
             extractedAudio.blob,
             extractedAudio.filename,

--- a/frontend/src/components/transcript/CLAUDE.md
+++ b/frontend/src/components/transcript/CLAUDE.md
@@ -11,7 +11,8 @@ that oversized file. They render the transcript editing/export UI and dispatch i
 - `TranscriptActionsBar.svelte` — export + download dropdowns; dispatches `export` / `download`
   (the parent owns the actual logic).
 - `TranscriptSegmentList.svelte` — the scrollable segment list: playback sync, inline text
-  edit, search highlighting, infinite-scroll pagination sentinel.
+  edit, search highlighting, infinite-scroll pagination sentinel. Two IntersectionObservers:
+  one on the pagination sentinel, one over `[data-seg-index]` for the reading-progress bar.
 
 ## Conventions / patterns
 
@@ -34,3 +35,12 @@ that oversized file. They render the transcript editing/export UI and dispatch i
   injected as HTML, so these must stay `:global`.
 - Don't relocate download/SSE or `handleSegmentSpeakerChange` into children — they belong to
   the coordinator so state stays single-sourced.
+- **The segment list is virtualized by CSS (`content-visibility: auto`), not by JS windowing.**
+  Don't swap in `$components/gallery/VirtualList.svelte`: it slices a fixed-44px row list, whereas
+  segments are variable height (wrapped text, multi-segment overlap groups, the expanded edit
+  textarea), and evicting off-screen rows breaks everything that reaches a segment through
+  `document.querySelector('[data-segment-id=…]')` — search scroll-to, seek-to-playhead,
+  `SpeakerEditorPanel`'s jump, and `.highlight-flash`.
+- **No `on:scroll` handler on `.transcript-display`.** Reading progress comes from the
+  IntersectionObserver; a scroll handler here previously ran an O(n) `querySelectorAll` plus
+  `offsetTop` reads (forced layout) on every scroll event.

--- a/frontend/src/components/transcript/TranscriptSegmentList.svelte
+++ b/frontend/src/components/transcript/TranscriptSegmentList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { createEventDispatcher, onMount, onDestroy, tick } from 'svelte';
   import ScrollbarIndicator from '$components/ScrollbarIndicator.svelte';
   import SegmentSpeakerDropdown from '$components/SegmentSpeakerDropdown.svelte';
   import Spinner from '$components/ui/Spinner.svelte';
@@ -47,34 +47,81 @@
   // Calculate loaded segments info
   $: loadedSegments = file?.transcript_segments?.length || 0;
 
-  // Handle scroll to update progress bar based on segment index (not scroll position)
-  // This ensures progress is relative to total transcript size, not just loaded segments
-  function handleTranscriptScroll(event: Event) {
-    const target = event.target as HTMLElement;
-    if (!target || totalSegments === 0) return;
+  // Reading progress is measured in SEGMENT INDEX, not scroll offset, so the bar
+  // reflects position in the whole transcript rather than in the loaded page.
+  //
+  // This used to run from an unthrottled `on:scroll` handler that, on every single
+  // scroll event, did a `querySelectorAll('[data-seg-index]')` across the entire
+  // list and then walked it reading `offsetTop` — an O(n) DOM query plus a forced
+  // synchronous layout per event, on a list that holds thousands of segments.
+  // An IntersectionObserver gets the same answer with no scroll handler, no DOM
+  // query and no layout read: the browser tells us which segments are on screen
+  // and the smallest index among them is the top one.
+  // Plain Set on purpose: nothing in the markup reads it, so making it reactive
+  // would only add invalidation churn on every intersection callback.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const visibleSegmentIndices = new Set<number>();
+  let progressObserver: IntersectionObserver | null = null;
 
-    // Find all segment elements with data-seg-index attribute
-    const segmentElements = target.querySelectorAll('[data-seg-index]');
-    if (segmentElements.length === 0) {
+  function updateScrollProgress() {
+    if (totalSegments === 0 || visibleSegmentIndices.size === 0) {
       scrollProgress = 0;
       return;
     }
+    scrollProgress = Math.round((Math.min(...visibleSegmentIndices) / totalSegments) * 100);
+  }
 
-    // Find the first visible segment (at top of viewport)
-    const viewportTop = target.scrollTop;
-    let firstVisibleSegmentIndex = 0;
-
-    for (const el of Array.from(segmentElements)) {
-      const segmentTop = (el as HTMLElement).offsetTop - target.offsetTop;
-      if (segmentTop >= viewportTop) {
-        const dataIndex = el.getAttribute('data-seg-index');
-        firstVisibleSegmentIndex = dataIndex ? parseInt(dataIndex, 10) : 0;
-        break;
+  function handleSegmentVisibility(entries: IntersectionObserverEntry[]) {
+    for (const entry of entries) {
+      const raw = (entry.target as HTMLElement).dataset.segIndex;
+      if (raw === undefined) continue;
+      const index = parseInt(raw, 10);
+      if (Number.isNaN(index)) continue;
+      if (entry.isIntersecting) {
+        visibleSegmentIndices.add(index);
+      } else {
+        visibleSegmentIndices.delete(index);
       }
     }
+    updateScrollProgress();
+  }
 
-    // Calculate progress as percentage of total segments
-    scrollProgress = Math.round((firstVisibleSegmentIndex / totalSegments) * 100);
+  // Re-target the observer when the segment set changes (pagination appends rows).
+  // O(n) once per data change instead of O(n) per scroll event.
+  async function refreshProgressObserver() {
+    if (typeof IntersectionObserver === 'undefined') return;
+    await tick();
+    if (!transcriptDisplayElement) return;
+
+    if (progressObserver) {
+      progressObserver.disconnect();
+    } else {
+      progressObserver = new IntersectionObserver(handleSegmentVisibility, {
+        root: transcriptDisplayElement,
+      });
+    }
+    visibleSegmentIndices.clear();
+    transcriptDisplayElement
+      .querySelectorAll('[data-seg-index]')
+      .forEach((el) => progressObserver?.observe(el));
+  }
+
+  $: if (transcriptDisplayElement && groupedTranscriptSegments) {
+    void refreshProgressObserver();
+  }
+
+  // A group renders as one row, so it needs a key that is stable across reorders
+  // and appends. Overlap groups are identified by their group id, plain groups by
+  // their single segment's uuid; the prefix keeps the two id spaces from colliding.
+  function groupKey(group: {
+    isOverlapGroup?: boolean;
+    overlapGroupId?: string;
+    segments?: { uuid?: string | number }[];
+    startSegmentIndex?: number;
+  }): string {
+    if (group?.isOverlapGroup && group.overlapGroupId) return `g:${group.overlapGroupId}`;
+    const uuid = group?.segments?.[0]?.uuid;
+    return uuid != null ? `s:${uuid}` : `i:${group?.startSegmentIndex}`;
   }
 
   // Set up infinite scroll observer
@@ -96,6 +143,10 @@
     if (infiniteScrollObserver) {
       infiniteScrollObserver.disconnect();
       infiniteScrollObserver = null;
+    }
+    if (progressObserver) {
+      progressObserver.disconnect();
+      progressObserver = null;
     }
   });
 
@@ -198,9 +249,8 @@
   <div
     class="transcript-display"
     bind:this={transcriptDisplayElement}
-    on:scroll={handleTranscriptScroll}
   >
-  {#each groupedTranscriptSegments as group}
+  {#each groupedTranscriptSegments as group (groupKey(group))}
     {#if group.isOverlapGroup}
       <!-- Overlap Group Container -->
       <div class="{diarizationDisabled ? '' : 'overlap-group'}" data-overlap-group-id="{group.overlapGroupId}" data-seg-index={group.startSegmentIndex}>
@@ -217,7 +267,7 @@
         </div>
         <div class="overlap-connector"></div>
         {/if}
-        {#each group.segments as segment, segIdx}
+        {#each group.segments as segment, segIdx (segment.uuid)}
           <div
             class="transcript-segment{diarizationDisabled ? '' : ' in-overlap'}"
             class:first-in-overlap={!diarizationDisabled && segIdx === 0}
@@ -527,7 +577,12 @@
        Unlike JS windowing, every segment stays in the DOM, so infinite-scroll, the
        scrollbar indicator, search-scroll-to, segment editing, and the highlight-flash
        all keep working unchanged. `auto` remembers each row's real rendered height,
-       so the intrinsic-size estimate only affects never-yet-rendered far-offscreen rows. */
+       so the intrinsic-size estimate only affects never-yet-rendered far-offscreen rows.
+       This is why $components/gallery/VirtualList.svelte is NOT reused here: it windows
+       a fixed 44px row into a spacer-padded slice, which would evict off-screen segments
+       from the DOM and break every one of those features (they all reach segments by
+       `document.querySelector('[data-segment-id=…]')`). Variable-height rows — wrapped
+       text, multi-segment overlap groups, the expanded edit textarea — rule it out too. */
     content-visibility: auto;
     contain-intrinsic-size: auto 56px;
   }

--- a/frontend/src/components/transcript/TranscriptSegmentList.test.ts
+++ b/frontend/src/components/transcript/TranscriptSegmentList.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Reading progress used to be recomputed from an unthrottled `scroll` handler
+ * that ran `querySelectorAll` + `offsetTop` over the whole list on every event.
+ * It is now derived from an IntersectionObserver. These tests pin the resulting
+ * contract: no scroll listener, every segment row observed, and progress driven
+ * by the topmost visible segment index.
+ *
+ * jsdom has no IntersectionObserver, so one is stubbed and driven by hand.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import TranscriptSegmentList from './TranscriptSegmentList.svelte';
+
+type IOCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let observers: { callback: IOCallback; targets: Element[] }[] = [];
+
+class StubIntersectionObserver {
+  private record: { callback: IOCallback; targets: Element[] };
+
+  constructor(callback: IOCallback) {
+    this.record = { callback, targets: [] };
+    observers.push(this.record);
+  }
+
+  observe(target: Element) {
+    this.record.targets.push(target);
+  }
+
+  disconnect() {
+    this.record.targets = [];
+  }
+
+  unobserve() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+/** Fire an intersection callback for the observer that watches `[data-seg-index]`. */
+function fireVisibility(entries: { target: Element; isIntersecting: boolean }[]) {
+  const observer = observers.find((o) => o.targets.length > 0);
+  observer?.callback(entries as unknown as IntersectionObserverEntry[]);
+}
+
+function segment(uuid: string, index: number) {
+  return {
+    uuid,
+    start_time: index * 5,
+    end_time: index * 5 + 5,
+    text: `Segment ${index}`,
+    speaker_label: 'SPEAKER_00',
+  };
+}
+
+function group(uuid: string, index: number) {
+  return {
+    isOverlapGroup: false,
+    startSegmentIndex: index,
+    startTime: index * 5,
+    endTime: index * 5 + 5,
+    segments: [segment(uuid, index)],
+  };
+}
+
+const groups = [group('a', 0), group('b', 1), group('c', 2), group('d', 3)];
+
+const props = {
+  file: { uuid: 'file-1', transcript_segments: groups.map((g) => g.segments[0]) },
+  groupedTranscriptSegments: groups,
+  transcriptSegments: groups.map((g) => g.segments[0]),
+  // Keeps SegmentSpeakerDropdown (which talks to the API) out of the tree.
+  diarizationDisabled: true,
+  totalSegments: 100,
+};
+
+describe('TranscriptSegmentList', () => {
+  beforeEach(() => {
+    observers = [];
+    vi.stubGlobal('IntersectionObserver', StubIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders one row per segment under a keyed each block', () => {
+    render(TranscriptSegmentList, { props });
+    // A duplicate/missing key would make Svelte throw during render.
+    expect(screen.getByText('Segment 0')).toBeInTheDocument();
+    expect(screen.getByText('Segment 3')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-segment-id]')).toHaveLength(4);
+  });
+
+  it('attaches no scroll listener to the scroll container', () => {
+    const spy = vi.spyOn(Element.prototype, 'addEventListener');
+    render(TranscriptSegmentList, { props });
+    const scrollListeners = spy.mock.calls.filter(([type]) => type === 'scroll');
+    expect(scrollListeners).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  it('observes every segment row for reading progress', async () => {
+    render(TranscriptSegmentList, { props });
+    await tick();
+    await tick();
+
+    const observed = observers.flatMap((o) => o.targets);
+    expect(observed).toHaveLength(4);
+    expect(observed.every((el) => el.hasAttribute('data-seg-index'))).toBe(true);
+  });
+
+  it('derives progress from the topmost visible segment index', async () => {
+    const { container } = render(TranscriptSegmentList, { props });
+    await tick();
+    await tick();
+
+    const rows = Array.from(container.querySelectorAll('[data-seg-index]'));
+    fireVisibility([
+      { target: rows[2], isIntersecting: true },
+      { target: rows[3], isIntersecting: true },
+    ]);
+    await tick();
+
+    // Topmost visible is index 2 of 100 total segments.
+    const fill = container.querySelector('.reading-progress-fill') as HTMLElement;
+    expect(fill.style.width).toBe('2%');
+
+    // Scrolling row 2 out leaves row 3 on top.
+    fireVisibility([{ target: rows[2], isIntersecting: false }]);
+    await tick();
+    expect(fill.style.width).toBe('3%');
+  });
+});

--- a/frontend/src/lib/i18n/index.test.ts
+++ b/frontend/src/lib/i18n/index.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Locale strings are code-split (one chunk per language) — see index.ts. These
+ * tests lock the two properties that make that safe: exactly one bundle is
+ * registered up front, and any other language can be pulled in on demand.
+ *
+ * Tests share the i18next singleton, so they run in declaration order.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import i18next from 'i18next';
+import { initI18n, ensureLocaleLoaded } from './index';
+
+describe('i18n lazy locale loading', () => {
+  beforeAll(async () => {
+    await initI18n('es');
+  });
+
+  it('registers only the active locale', () => {
+    expect(i18next.resolvedLanguage).toBe('es');
+    expect(i18next.hasResourceBundle('es', 'translation')).toBe(true);
+    expect(i18next.hasResourceBundle('fr', 'translation')).toBe(false);
+    expect(i18next.hasResourceBundle('ru', 'translation')).toBe(false);
+  });
+
+  it('resolves real strings from the lazily loaded bundle', () => {
+    // A raw dot-notation key coming back means the bundle never landed.
+    expect(i18next.t('common.save')).not.toBe('common.save');
+  });
+
+  it('loads another locale on demand and collapses BCP-47 tags', async () => {
+    expect(await ensureLocaleLoaded('fr-CA')).toBe('fr');
+    expect(i18next.hasResourceBundle('fr', 'translation')).toBe(true);
+  });
+
+  it('falls back to the default language for unsupported codes', async () => {
+    expect(await ensureLocaleLoaded('xx')).toBe('en');
+    expect(i18next.hasResourceBundle('en', 'translation')).toBe(true);
+  });
+
+  it('is idempotent for an already-loaded locale', async () => {
+    expect(await ensureLocaleLoaded('fr')).toBe('fr');
+    expect(await ensureLocaleLoaded('fr')).toBe('fr');
+  });
+
+  it('locale.set() fetches the chunk before switching i18next', async () => {
+    const { locale } = await import('$stores/locale');
+    expect(i18next.hasResourceBundle('de', 'translation')).toBe(false);
+
+    locale.set('de');
+
+    await vi.waitFor(() => expect(i18next.language).toBe('de'));
+    // If the switch had raced ahead of the fetch, the UI would render raw keys.
+    expect(i18next.hasResourceBundle('de', 'translation')).toBe(true);
+    expect(i18next.t('common.save')).not.toBe('common.save');
+  });
+});

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -1,47 +1,96 @@
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './languages';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, isValidLanguageCode } from './languages';
 
-import en from './locales/en.json';
-import es from './locales/es.json';
-import fr from './locales/fr.json';
-import de from './locales/de.json';
-import pt from './locales/pt.json';
-import zh from './locales/zh.json';
-import ja from './locales/ja.json';
-import ru from './locales/ru.json';
-
-const resources: Record<string, { translation: Record<string, string> }> = {
-  en: { translation: en },
-  es: { translation: es },
-  fr: { translation: fr },
-  de: { translation: de },
-  pt: { translation: pt },
-  zh: { translation: zh },
-  ja: { translation: ja },
-  ru: { translation: ru },
-};
+// Per-locale loaders — deliberately NON-eager. Statically importing all eight
+// locale JSONs put ~2.3 MB of translations (every language, for every visitor)
+// into a single entry chunk, of which one language is ever read. Without
+// `eager`, `import.meta.glob` compiles to one `import()` per file, so Rollup
+// emits one chunk per locale and the browser fetches exactly the one in use.
+const localeLoaders = import.meta.glob('./locales/*.json', {
+  import: 'default',
+}) as Record<string, () => Promise<Record<string, string>>>;
 
 // Managed-edition string packs: the commercial overlay drops per-locale flat
 // JSON files into $lib/cloud/locales/ at image-build time; the community build
 // has none, so this glob is empty and the merge is a no-op. Locale files are
-// flat dot-notation key maps, so a shallow spread is a correct merge.
+// flat dot-notation key maps, so a shallow spread is a correct merge. These stay
+// eager: the community glob resolves to zero files, and an edition pack is a
+// small delta over the base locale, not a second full translation.
 const editionPacks = import.meta.glob('../cloud/locales/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, Record<string, string>>;
+
+const editionPackByLanguage: Record<string, Record<string, string>> = {};
 for (const [path, pack] of Object.entries(editionPacks)) {
-  const lng = path.replace(/^.*\/([a-z]{2})\.json$/, '$1');
-  if (resources[lng]) {
-    resources[lng].translation = { ...resources[lng].translation, ...pack };
+  editionPackByLanguage[path.replace(/^.*\/([a-z]{2})\.json$/, '$1')] = pack;
+}
+
+/** Collapse a BCP-47 tag ("en-US") to a supported base code, or the default. */
+function normalizeLanguage(lng?: string | null): string {
+  const base = (lng || '').split('-')[0].toLowerCase();
+  return isValidLanguageCode(base) ? base : DEFAULT_LANGUAGE;
+}
+
+const loadedLanguages = new Set<string>();
+const inFlightLoads = new Map<string, Promise<void>>();
+
+async function loadLanguage(lng: string): Promise<void> {
+  const loader = localeLoaders[`./locales/${lng}.json`];
+  if (!loader) return;
+
+  const translation = await loader();
+  const pack = editionPackByLanguage[lng];
+  i18next.addResourceBundle(
+    lng,
+    'translation',
+    pack ? { ...translation, ...pack } : translation,
+    true,
+    true
+  );
+  loadedLanguages.add(lng);
+}
+
+/**
+ * Fetch and register one locale's strings, once. Safe to call repeatedly and
+ * concurrently — the first call owns the fetch, later callers await the same
+ * promise. Callers MUST await this before switching i18next to `lng`, otherwise
+ * the UI renders raw dot-notation keys until the chunk lands.
+ *
+ * Only the active language is ever loaded — not the `en` fallback. That is safe
+ * because `npm run check:i18n` gates every locale on exact key parity with
+ * en.json, so there is nothing for the fallback chain to resolve.
+ *
+ * @param lng - Language code (BCP-47 tags are collapsed to their base code).
+ * @returns The normalized language code that was loaded.
+ */
+export async function ensureLocaleLoaded(lng: string): Promise<string> {
+  const code = normalizeLanguage(lng);
+  if (loadedLanguages.has(code)) return code;
+
+  let pending = inFlightLoads.get(code);
+  if (!pending) {
+    pending = loadLanguage(code).finally(() => inFlightLoads.delete(code));
+    inFlightLoads.set(code, pending);
   }
+  await pending;
+  return code;
 }
 
 export async function initI18n(savedLanguage?: string): Promise<typeof i18next> {
   await i18next.use(LanguageDetector).init({
-    resources,
+    // Empty on purpose: the active locale is added by `ensureLocaleLoaded`
+    // below, before this promise resolves. `partialBundledLanguages` tells
+    // i18next that resources arrive incrementally so it doesn't treat the empty
+    // map as "this language has no strings".
+    resources: {},
+    partialBundledLanguages: true,
     fallbackLng: DEFAULT_LANGUAGE,
     supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
+    // Collapse "en-US" → "en" so the resolved language always matches a locale
+    // file name; otherwise the lazy loader would find no chunk to fetch.
+    load: 'languageOnly',
     detection: {
       order: ['localStorage', 'navigator'],
       lookupLocalStorage: 'locale',
@@ -53,6 +102,13 @@ export async function initI18n(savedLanguage?: string): Promise<typeof i18next> 
     },
     debug: false,
   });
+
+  // Awaited before init resolves — callers (the layout gates all rendering on
+  // it) never paint against an empty resource store, so there is no FOUC.
+  const code = await ensureLocaleLoaded(i18next.resolvedLanguage || savedLanguage || '');
+  if (i18next.resolvedLanguage !== code) {
+    await i18next.changeLanguage(code);
+  }
 
   return i18next;
 }

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -2258,6 +2258,7 @@
   "upload.unknownType": "Unbekannter Upload-Typ: {{type}}",
   "upload.uploadCompleted": "Upload abgeschlossen: {{name}}",
   "upload.uploadFailed": "Upload fehlgeschlagen: {{name}} - {{error}}",
+  "upload.stalled": "Upload angehalten: {{seconds}} Sekunden lang wurden keine Daten übertragen. Prüfen Sie Ihre Verbindung.",
   "upload.uploading": "wird hochgeladen",
   "upload.uploads": "Uploads",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -1430,6 +1430,7 @@
   "upload.fileAlreadyExists": "File already exists: {{name}}",
   "upload.uploadCompleted": "Upload completed: {{name}}",
   "upload.uploadFailed": "Upload failed: {{name}} - {{error}}",
+  "upload.stalled": "Upload stalled — no data transferred for {{seconds}} seconds. Check your connection.",
   "upload.calculatingHash": "Calculating file hash...",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",
   "fileDetail.unknownFile": "Unknown File",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -2258,6 +2258,7 @@
   "upload.unknownType": "Tipo de carga desconocido: {{type}}",
   "upload.uploadCompleted": "Carga completada: {{name}}",
   "upload.uploadFailed": "Carga fallida: {{name}} - {{error}}",
+  "upload.stalled": "Subida detenida: no se transfirieron datos durante {{seconds}} segundos. Comprueba tu conexión.",
   "upload.uploading": "subiendo",
   "upload.uploads": "subidas",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -2258,6 +2258,7 @@
   "upload.unknownType": "Type de téléchargement inconnu : {{type}}",
   "upload.uploadCompleted": "Téléchargement terminé : {{name}}",
   "upload.uploadFailed": "Échec du téléchargement : {{name}} - {{error}}",
+  "upload.stalled": "Téléversement bloqué : aucune donnée transférée pendant {{seconds}} secondes. Vérifiez votre connexion.",
   "upload.uploading": "en cours",
   "upload.uploads": "téléversements",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -1429,6 +1429,7 @@
   "upload.fileAlreadyExists": "ファイルは既に存在します：{{name}}",
   "upload.uploadCompleted": "アップロード完了：{{name}}",
   "upload.uploadFailed": "アップロード失敗：{{name}} - {{error}}",
+  "upload.stalled": "アップロードが停止しました: {{seconds}} 秒間データが転送されませんでした。接続を確認してください。",
   "upload.calculatingHash": "ファイルハッシュを計算中...",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",
   "fileDetail.unknownFile": "不明なファイル",

--- a/frontend/src/lib/i18n/locales/pt.json
+++ b/frontend/src/lib/i18n/locales/pt.json
@@ -1429,6 +1429,7 @@
   "upload.fileAlreadyExists": "Arquivo já existe: {{name}}",
   "upload.uploadCompleted": "Upload concluído: {{name}}",
   "upload.uploadFailed": "Falha no upload: {{name}} - {{error}}",
+  "upload.stalled": "Envio parado: nenhum dado transferido por {{seconds}} segundos. Verifique sua conexão.",
   "upload.calculatingHash": "Calculando hash do arquivo...",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",
   "fileDetail.unknownFile": "Arquivo Desconhecido",

--- a/frontend/src/lib/i18n/locales/ru.json
+++ b/frontend/src/lib/i18n/locales/ru.json
@@ -1419,6 +1419,7 @@
   "upload.fileAlreadyExists": "Файл уже существует: {{name}}",
   "upload.uploadCompleted": "Загрузка завершена: {{name}}",
   "upload.uploadFailed": "Загрузка не удалась: {{name}} - {{error}}",
+  "upload.stalled": "Загрузка остановлена: данные не передавались {{seconds}} секунд. Проверьте подключение.",
   "upload.calculatingHash": "Вычисление хеша файла...",
   "upload.uploadPausedBrowserClosed": "Загрузка приостановлена. Откройте приложение для продолжения.",
   "fileDetail.unknownFile": "Неизвестный файл",

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -1429,6 +1429,7 @@
   "upload.fileAlreadyExists": "文件已存在：{{name}}",
   "upload.uploadCompleted": "上传完成：{{name}}",
   "upload.uploadFailed": "上传失败：{{name}} - {{error}}",
+  "upload.stalled": "上传已停滞：{{seconds}} 秒内未传输任何数据。请检查您的网络连接。",
   "upload.calculatingHash": "正在计算文件哈希...",
   "upload.uploadPausedBrowserClosed": "Upload paused. Open the app to resume.",
   "fileDetail.unknownFile": "未知文件",

--- a/frontend/src/lib/services/CLAUDE.md
+++ b/frontend/src/lib/services/CLAUDE.md
@@ -14,13 +14,15 @@ runtime, a Web Worker, a TTL cache. Import via `$lib/services/...`.
 
 If a new module has no state and no lifecycle it belongs in `api/` or `utils/`, not here.
 Every module here exports **one shared instance** (`export const xService = …`); never construct
-a second one in a component. (`AudioExtractionService` is also exported as a class — for tests only.)
+a second one in a component. (`AudioExtractionService` is also exported as a class — for tests only.
+`stallWatchdog.ts` is the other exception: a per-request factory, not a singleton.)
 
 ## Key files
 
 - `uploadService.ts` — the upload queue singleton: max 3 concurrent, 3 retries with exponential
-  backoff, 5-min timeout, persisted to `localStorage['upload_queue']`. Tries a **presigned PUT
+  backoff, persisted to `localStorage['upload_queue']`. Tries a **presigned PUT
   straight to MinIO, then silently falls back** to the legacy multipart `POST /files`.
+- `stallWatchdog.ts` — `createStallWatchdog()`: the timeout control for file bodies. See gotchas.
 - `audioExtractionService.ts` — in-browser video→audio via FFmpeg.wasm (`-c:a copy`, no re-encode),
   core loaded from `frontend/public/ffmpeg/`; extractions run **one at a time** through an internal queue.
   **Import it with a dynamic `import()`** (see `FileUploader.svelte`) — a static import drags the
@@ -51,6 +53,15 @@ a second one in a component. (`AudioExtractionService` is also exported as a cla
   call sites now use `hashFileSHA256` directly.
 - `audioExtractionService.ts` and `configService.ts` still use relative imports (`../types/…`,
   `../../stores/…`, `../axios`). Everything else uses `$lib`/`$stores` — don't copy that.
+- **Never put a total-request `timeout` on a request whose body is the file.** That caps how long a
+  _healthy_ upload may take: the old 5-minute cap against the app's 15 GB limit failed every upload
+  slower than ~50 MB/s, then burned all 3 retries repeating it. File bodies go through
+  `uploadService.sendBody()`, which arms a `createStallWatchdog()` (abort only when no bytes have
+  moved) and passes `watchdog.signal` to axios. `CONTROL_REQUEST_TIMEOUT_MS` is for the small JSON
+  calls (`/files/prepare`, `/files/complete`, `/files/process-url`) only.
+- A watchdog abort surfaces as `UploadStalledError`, **not** an axios `CanceledError`: `axios.isCancel`
+  means "the user cancelled" throughout `uploadService` and suppresses retry. A stall must also not
+  fall through to the legacy multipart path — re-sending the body through the API container stalls too.
 - The presigned→legacy fallback swallows the error with no log; a broken presign looks like a slow
   upload. `configService` likewise swallows its fetch error and marks itself loaded, so "config
   failed" is indistinguishable from "no protected hosts".
@@ -59,4 +70,4 @@ a second one in a component. (`AudioExtractionService` is also exported as a cla
   multi-GB video), like `$lib/export/`. Don't extend the precedent to business logic.
 - `uploadService.formatTimeRemaining` is a compact `Xh Ym` ETA that returns `''` — it is on the explicit
   do-NOT-migrate list in `$lib/utils/CLAUDE.md`. Leave it alone.
-- No tests in this folder.
+- Tests here cover `sha256Hasher` and `stallWatchdog` only; the queue itself is untested.

--- a/frontend/src/lib/services/CLAUDE.md
+++ b/frontend/src/lib/services/CLAUDE.md
@@ -23,6 +23,8 @@ a second one in a component. (`AudioExtractionService` is also exported as a cla
   straight to MinIO, then silently falls back** to the legacy multipart `POST /files`.
 - `audioExtractionService.ts` — in-browser video→audio via FFmpeg.wasm (`-c:a copy`, no re-encode),
   core loaded from `frontend/public/ffmpeg/`; extractions run **one at a time** through an internal queue.
+  **Import it with a dynamic `import()`** (see `FileUploader.svelte`) — a static import drags the
+  `@ffmpeg/*` wrapper into whichever route chunk references it, and extraction is an opt-in path.
 - `sha256Hasher.ts` — client for `$lib/workers/sha256Worker`, with a main-thread `crypto.subtle` fallback.
 - `llmService.ts` — TTL-cached `/llm/status` (60 s when available, 10 s after a failure).
   `$stores/llmStatus` wraps it — components should read the store, not the service.

--- a/frontend/src/lib/services/stallWatchdog.test.ts
+++ b/frontend/src/lib/services/stallWatchdog.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The watchdog replaced a 5-minute total-request timeout that failed every
+ * upload slower than ~50 MB/s against a 15 GB limit. These tests pin the
+ * distinction that made the old control wrong: slow must not abort, silent must.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createStallWatchdog } from './stallWatchdog';
+
+describe('createStallWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not abort a slow-but-moving transfer, however long it runs', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000 });
+
+    // 60 ticks of 1 byte each, 900 ms apart: 54 s total — an order of magnitude
+    // past the stall window, but never idle for a full window.
+    for (let i = 1; i <= 60; i++) {
+      vi.advanceTimersByTime(900);
+      watchdog.notifyProgress(i, 10_000);
+    }
+
+    expect(watchdog.signal.aborted).toBe(false);
+    expect(watchdog.stalled).toBe(false);
+    watchdog.dispose();
+  });
+
+  it('aborts when no bytes move for the stall window', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000 });
+
+    watchdog.notifyProgress(500, 10_000);
+    vi.advanceTimersByTime(999);
+    expect(watchdog.stalled).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(watchdog.stalled).toBe(true);
+    expect(watchdog.signal.aborted).toBe(true);
+    watchdog.dispose();
+  });
+
+  it('aborts a connection that never delivers a first byte', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000 });
+
+    vi.advanceTimersByTime(1000);
+
+    expect(watchdog.stalled).toBe(true);
+    watchdog.dispose();
+  });
+
+  it('treats a repeated byte count as no progress', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000 });
+
+    watchdog.notifyProgress(500, 10_000);
+    vi.advanceTimersByTime(600);
+    watchdog.notifyProgress(500, 10_000);
+    vi.advanceTimersByTime(400);
+
+    expect(watchdog.stalled).toBe(true);
+    watchdog.dispose();
+  });
+
+  it('switches to the longer ceiling once the body is fully sent', () => {
+    // Progress events stop firing at 100%, so the transfer window must not apply
+    // while the object store writes and checksums a multi-GB upload.
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000, finalizeTimeoutMs: 10_000 });
+
+    watchdog.notifyProgress(10_000, 10_000);
+    vi.advanceTimersByTime(9999);
+    expect(watchdog.stalled).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(watchdog.stalled).toBe(true);
+    watchdog.dispose();
+  });
+
+  it('does not re-arm the finalize window on repeated completion ticks', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000, finalizeTimeoutMs: 10_000 });
+
+    watchdog.notifyProgress(10_000, 10_000);
+    vi.advanceTimersByTime(9000);
+    watchdog.notifyProgress(10_000, 10_000);
+    vi.advanceTimersByTime(1000);
+
+    expect(watchdog.stalled).toBe(true);
+    watchdog.dispose();
+  });
+
+  it('stops firing after dispose', () => {
+    const watchdog = createStallWatchdog({ stallTimeoutMs: 1000 });
+
+    watchdog.dispose();
+    vi.advanceTimersByTime(60_000);
+
+    expect(watchdog.stalled).toBe(false);
+    expect(watchdog.signal.aborted).toBe(false);
+  });
+});

--- a/frontend/src/lib/services/stallWatchdog.ts
+++ b/frontend/src/lib/services/stallWatchdog.ts
@@ -1,0 +1,117 @@
+/**
+ * Stall watchdog for long-running body uploads.
+ *
+ * A *total-request* timeout is the wrong control for a whole-file PUT: it is a
+ * deadline on the upload's duration, so it fails healthy uploads purely for
+ * being big. With the app's 15 GB limit and a 5-minute cap, anything slower than
+ * ~50 MB/s was guaranteed to fail (then retry and fail again). What we actually
+ * want to detect is a *dead* connection, which means: no bytes moved for a while.
+ *
+ * Two phases, because they fail differently:
+ *  - **transfer** — bytes are still being written to the socket. Every progress
+ *    tick that advances `loaded` re-arms the timer.
+ *  - **finalizing** — the whole body has been sent and we are waiting on the
+ *    server's response. No further progress events will ever fire here, so the
+ *    transfer timeout must not apply: the object store still has to write and
+ *    checksum the upload (minutes, for a multi-GB file). A separate, longer
+ *    ceiling covers a genuinely hung server.
+ *
+ * Not a singleton — one watchdog per in-flight request (see this folder's
+ * CLAUDE.md; the "one shared instance" rule covers the service objects, not this
+ * per-request factory).
+ */
+
+/** No bytes moved for this long during transfer → the connection is dead. */
+export const DEFAULT_STALL_TIMEOUT_MS = 120_000; // 2 minutes
+
+/** Body fully sent; server has this long to answer before we give up. */
+export const DEFAULT_FINALIZE_TIMEOUT_MS = 900_000; // 15 minutes
+
+export interface StallWatchdogOptions {
+  /** Idle time tolerated while bytes are still in flight. */
+  stallTimeoutMs?: number;
+  /** Idle time tolerated after the body is fully sent. */
+  finalizeTimeoutMs?: number;
+}
+
+export interface StallWatchdog {
+  /** Hand to axios/fetch as `signal`; aborts when the transfer goes quiet. */
+  readonly signal: AbortSignal;
+  /** True once this watchdog aborted the request (vs. a user cancellation). */
+  readonly stalled: boolean;
+  /** Feed on every progress tick. `total` omitted → still in the transfer phase. */
+  notifyProgress(loaded: number, total?: number): void;
+  /** Stop the timer. Always call from a `finally`. */
+  dispose(): void;
+}
+
+/**
+ * Create a watchdog that aborts a request only when its byte stream goes quiet.
+ *
+ * @param options - Phase timeouts; both default to the constants above.
+ * @returns A watchdog whose `signal` fires on stall and never on slowness alone.
+ */
+export function createStallWatchdog(options: StallWatchdogOptions = {}): StallWatchdog {
+  const stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+  const finalizeTimeoutMs = options.finalizeTimeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastLoaded = -1;
+  let finalizing = false;
+  let stalled = false;
+  let disposed = false;
+
+  function clear() {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function arm(delayMs: number) {
+    clear();
+    if (disposed) return;
+    timer = setTimeout(() => {
+      timer = null;
+      stalled = true;
+      controller.abort();
+    }, delayMs);
+  }
+
+  // Armed from the start: a connection that never delivers its first byte is
+  // stalled too.
+  arm(stallTimeoutMs);
+
+  return {
+    signal: controller.signal,
+
+    get stalled() {
+      return stalled;
+    },
+
+    notifyProgress(loaded: number, total?: number) {
+      if (disposed || stalled) return;
+
+      // Body fully sent — switch to the response-wait ceiling, once.
+      if (total !== undefined && total > 0 && loaded >= total) {
+        if (!finalizing) {
+          finalizing = true;
+          arm(finalizeTimeoutMs);
+        }
+        return;
+      }
+
+      // Only real forward movement counts; a repeated `loaded` is not progress.
+      if (loaded > lastLoaded) {
+        lastLoaded = loaded;
+        arm(stallTimeoutMs);
+      }
+    },
+
+    dispose() {
+      disposed = true;
+      clear();
+    },
+  };
+}

--- a/frontend/src/lib/services/uploadService.ts
+++ b/frontend/src/lib/services/uploadService.ts
@@ -7,6 +7,11 @@ import axios, { type AxiosProgressEvent, type CancelTokenSource } from 'axios';
 import type { ExtractedAudioMetadata } from '$lib/types/audioExtraction';
 import { generateId } from '$lib/utils/ids';
 import { hashFileSHA256 } from '$lib/services/sha256Hasher';
+import {
+  createStallWatchdog,
+  DEFAULT_STALL_TIMEOUT_MS,
+  type StallWatchdog,
+} from '$lib/services/stallWatchdog';
 
 // Upload item types
 export type UploadType = 'file' | 'url' | 'recording' | 'extracted-audio';
@@ -52,8 +57,12 @@ export interface UploadItem {
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 1000;
 const MAX_CONCURRENT_UPLOADS = 3;
-const UPLOAD_TIMEOUT_MS = 300000; // 5 minutes
 const QUEUE_PROCESS_DELAY_MS = 100;
+
+// Total-request timeout for the small JSON control-plane calls only (prepare,
+// complete, process-url). File bodies must NEVER use a total-request timeout —
+// see the note on UploadStalledError below.
+const CONTROL_REQUEST_TIMEOUT_MS = 300000; // 5 minutes
 
 // Event types for upload lifecycle
 export type UploadEventType =
@@ -75,6 +84,23 @@ export interface UploadEvent {
 interface UploadResult {
   uuid: string;
   isDuplicate: boolean;
+}
+
+/**
+ * Raised when the stall watchdog aborts a body transfer.
+ *
+ * File bodies used to carry a 5-minute *total-request* timeout while the UI
+ * advertises a 15 GB limit, so every upload slower than ~50 MB/s failed on the
+ * clock alone — then burned all 3 retries doing it again. The timeout is now a
+ * stall watchdog (abort only when no bytes have moved), and its abort surfaces
+ * as this type rather than an axios `CanceledError`, because `axios.isCancel`
+ * means "the user cancelled" everywhere else in this file and suppresses retry.
+ */
+export class UploadStalledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UploadStalledError';
+  }
 }
 
 class UploadService {
@@ -319,6 +345,55 @@ class UploadService {
     this.persistUploads();
   }
 
+  /**
+   * Run a whole-file body transfer under a stall watchdog.
+   *
+   * Replaces the total-request `timeout` that used to guard these calls: that
+   * capped how long a *healthy* upload was allowed to take, which is exactly
+   * wrong for a 15 GB limit. The watchdog aborts only when the byte stream goes
+   * quiet, and its abort is rethrown as `UploadStalledError` so the caller can
+   * tell it apart from a user cancellation.
+   *
+   * @param run - Issues the request; must pass `watchdog.signal` to axios and
+   *   feed `watchdog` from `onUploadProgress`.
+   */
+  private async sendBody<T>(run: (watchdog: StallWatchdog) => Promise<T>): Promise<T> {
+    const watchdog = createStallWatchdog();
+    try {
+      return await run(watchdog);
+    } catch (err: unknown) {
+      if (watchdog.stalled) {
+        throw new UploadStalledError(
+          get(t)('upload.stalled', { seconds: Math.round(DEFAULT_STALL_TIMEOUT_MS / 1000) })
+        );
+      }
+      throw err;
+    } finally {
+      watchdog.dispose();
+    }
+  }
+
+  /**
+   * Build the axios progress callback for one upload: updates percentage + ETA
+   * and keeps the stall watchdog fed.
+   */
+  private makeProgressHandler(uploadId: string, upload: UploadItem) {
+    return (watchdog: StallWatchdog) => (progressEvent: AxiosProgressEvent) => {
+      watchdog.notifyProgress(progressEvent.loaded, progressEvent.total);
+      if (!progressEvent.total) return;
+      const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+      const progress = Math.min(percentCompleted, 99);
+      this.updateUpload(uploadId, { progress });
+      this.emit('progress', uploadId, { progress });
+      const elapsed = Date.now() - (upload.startTime || Date.now());
+      if (elapsed > 0) {
+        const rate = progressEvent.loaded / elapsed;
+        const remaining = (progressEvent.total - progressEvent.loaded) / rate;
+        this.updateUpload(uploadId, { estimatedTime: this.formatTimeRemaining(remaining) });
+      }
+    };
+  }
+
   private async uploadFile(uploadId: string, file: File | Blob): Promise<UploadResult> {
     const upload = this.uploads.get(uploadId)!;
 
@@ -376,34 +451,24 @@ class UploadService {
       estimatedTime: 'Uploading...',
     });
 
-    const progressHandler = (progressEvent: AxiosProgressEvent) => {
-      if (!progressEvent.total) return;
-      const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
-      const progress = Math.min(percentCompleted, 99);
-      this.updateUpload(uploadId, { progress });
-      this.emit('progress', uploadId, { progress });
-      const elapsed = Date.now() - (upload.startTime || Date.now());
-      if (elapsed > 0) {
-        const rate = progressEvent.loaded / elapsed;
-        const remaining = (progressEvent.total - progressEvent.loaded) / rate;
-        this.updateUpload(uploadId, { estimatedTime: this.formatTimeRemaining(remaining) });
-      }
-    };
+    const progressHandler = this.makeProgressHandler(uploadId, upload);
 
     // --- Presigned flow ---------------------------------------------------
     if (uploadUrl && uploadMethod === 'PUT' && taskId) {
       try {
         const clientPutStartMs = Date.now();
-        await axios.put(uploadUrl, file, {
-          headers: {
-            'Content-Type': file instanceof File ? file.type : 'audio/webm',
-          },
-          timeout: UPLOAD_TIMEOUT_MS,
-          maxContentLength: Infinity,
-          maxBodyLength: Infinity,
-          cancelToken: cancelToken.token,
-          onUploadProgress: progressHandler,
-        });
+        await this.sendBody((watchdog) =>
+          axios.put(uploadUrl, file, {
+            headers: {
+              'Content-Type': file instanceof File ? file.type : 'audio/webm',
+            },
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
+            cancelToken: cancelToken.token,
+            signal: watchdog.signal,
+            onUploadProgress: progressHandler(watchdog),
+          })
+        );
         const clientPutEndMs = Date.now();
 
         await axiosInstance.post('/files/complete', {
@@ -422,7 +487,10 @@ class UploadService {
 
         return { uuid: fileId, isDuplicate: false };
       } catch (err: unknown) {
-        if (axios.isCancel(err)) {
+        // A stalled connection is a network fault, not "the server can't do
+        // presigned uploads" — re-sending the whole body through the API
+        // container would stall too. Let the queue retry the presigned path.
+        if (axios.isCancel(err) || err instanceof UploadStalledError) {
           throw err;
         }
         // Fall through to the legacy flow below.
@@ -449,14 +517,16 @@ class UploadService {
       headers['X-Num-Speakers'] = upload.numSpeakers.toString();
     }
 
-    await axiosInstance.post('/files', formData, {
-      headers,
-      timeout: UPLOAD_TIMEOUT_MS,
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      cancelToken: cancelToken.token,
-      onUploadProgress: progressHandler,
-    });
+    await this.sendBody((watchdog) =>
+      axiosInstance.post('/files', formData, {
+        headers,
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+        cancelToken: cancelToken.token,
+        signal: watchdog.signal,
+        onUploadProgress: progressHandler(watchdog),
+      })
+    );
 
     return { uuid: fileId, isDuplicate: false };
   }
@@ -509,32 +579,22 @@ class UploadService {
       estimatedTime: 'Uploading extracted audio...',
     });
 
-    const progressHandler = (progressEvent: AxiosProgressEvent) => {
-      if (!progressEvent.total) return;
-      const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
-      const progress = Math.min(percentCompleted, 99);
-      this.updateUpload(uploadId, { progress });
-      this.emit('progress', uploadId, { progress });
-      const elapsed = Date.now() - (upload.startTime || Date.now());
-      if (elapsed > 0) {
-        const rate = progressEvent.loaded / elapsed;
-        const remaining = (progressEvent.total - progressEvent.loaded) / rate;
-        this.updateUpload(uploadId, { estimatedTime: this.formatTimeRemaining(remaining) });
-      }
-    };
+    const progressHandler = this.makeProgressHandler(uploadId, upload);
 
     // --- Presigned flow: PUT the audio blob straight to MinIO, then finalize.
     if (uploadUrl && uploadMethod === 'PUT' && taskId) {
       try {
         const clientPutStartMs = Date.now();
-        await axios.put(uploadUrl, audioBlob, {
-          headers: { 'Content-Type': contentType },
-          timeout: UPLOAD_TIMEOUT_MS,
-          maxContentLength: Infinity,
-          maxBodyLength: Infinity,
-          cancelToken: cancelToken.token,
-          onUploadProgress: progressHandler,
-        });
+        await this.sendBody((watchdog) =>
+          axios.put(uploadUrl, audioBlob, {
+            headers: { 'Content-Type': contentType },
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
+            cancelToken: cancelToken.token,
+            signal: watchdog.signal,
+            onUploadProgress: progressHandler(watchdog),
+          })
+        );
         const clientPutEndMs = Date.now();
 
         await axiosInstance.post('/files/complete', {
@@ -551,7 +611,9 @@ class UploadService {
 
         return { uuid: fileId, isDuplicate: false };
       } catch (err: unknown) {
-        if (axios.isCancel(err)) {
+        // See uploadFile(): a stall must not silently re-send the body through
+        // the API container.
+        if (axios.isCancel(err) || err instanceof UploadStalledError) {
           throw err;
         }
         // Fall through to the legacy flow below.
@@ -562,18 +624,20 @@ class UploadService {
     const formData = new FormData();
     formData.append('file', audioBlob, upload.name);
 
-    await axiosInstance.post('/files', formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-        'X-File-ID': fileId,
-        'X-File-Hash': originalFileHash || '',
-      },
-      timeout: UPLOAD_TIMEOUT_MS,
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      cancelToken: cancelToken.token,
-      onUploadProgress: progressHandler,
-    });
+    await this.sendBody((watchdog) =>
+      axiosInstance.post('/files', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          'X-File-ID': fileId,
+          'X-File-Hash': originalFileHash || '',
+        },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+        cancelToken: cancelToken.token,
+        signal: watchdog.signal,
+        onUploadProgress: progressHandler(watchdog),
+      })
+    );
 
     return { uuid: fileId, isDuplicate: false };
   }
@@ -596,7 +660,7 @@ class UploadService {
         tag_names: upload.tagNames || undefined,
       },
       {
-        timeout: UPLOAD_TIMEOUT_MS,
+        timeout: CONTROL_REQUEST_TIMEOUT_MS,
         cancelToken: cancelToken.token,
         onUploadProgress: (progressEvent: AxiosProgressEvent) => {
           if (progressEvent.total) {

--- a/frontend/src/stores/locale.ts
+++ b/frontend/src/stores/locale.ts
@@ -32,6 +32,20 @@ if (typeof window !== 'undefined') {
 }
 
 // Create the locale store
+/**
+ * Switch i18next to `newLocale`, fetching that locale's chunk first.
+ *
+ * Locale strings are code-split (one chunk per language), so `changeLanguage`
+ * must not run before the chunk lands or every `$t(...)` renders its raw
+ * dot-notation key. The UI keeps showing the previous language for the duration
+ * of the fetch instead of flashing keys.
+ */
+const applyLanguage = async (newLocale: string): Promise<void> => {
+  const { ensureLocaleLoaded } = await import('$lib/i18n');
+  await ensureLocaleLoaded(newLocale);
+  await i18next.changeLanguage(newLocale);
+};
+
 const createLocaleStore = () => {
   const { subscribe, set, update } = writable<string>(getInitialLocale());
 
@@ -47,9 +61,9 @@ const createLocaleStore = () => {
           localStorage.setItem('locale', newLocale);
         }
 
-        // Update i18next language
+        // Update i18next language (loads the locale chunk first)
         if (i18next.isInitialized) {
-          i18next.changeLanguage(newLocale);
+          void applyLanguage(newLocale);
         }
 
         // Update document lang attribute for accessibility


### PR DESCRIPTION
# Pull Request

## Description

Frontend half of **#284 Phase 2** — the performance items that live entirely in
`frontend/`. No backend files are touched.

Covers **A2.1**, **A2.2**, **A2.3**, and **A2.9** (the presigned-upload timeout, which is a
launch blocker rather than a performance nit). Backend Phase 2 items (A2.4–A2.8) are out of
scope for this PR.

Four commits, one per item; each commit message explains the root cause.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) — A2.9
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement — A2.1, A2.2, A2.3

## Changes made

### A2.1 — Locale eager-bundling (the big one)

`i18n/index.ts` static-imported all eight locale JSONs, so Rollup emitted one **2,192,042 B**
chunk containing every translation, sitting in the entry graph — every visitor downloaded all
eight languages to read one.

Locales are now code-split: `import.meta.glob` without `eager` gives one chunk per language,
and `ensureLocaleLoaded()` fetches exactly the active one. i18next initializes with an empty
resource map + `partialBundledLanguages`, and the bundle is registered via `addResourceBundle`
**before `initI18n` resolves**.

**No FOUC.** The layout already awaits `locale.initialize()` before flipping `authReady`, which
gates all rendering — nothing paints against an empty resource store. `locale.set()` likewise
awaits the chunk before `changeLanguage`, so switching language shows the *previous* language
during the fetch rather than a flash of raw `dot.notation` keys.

Only the active language is loaded — **not** the `en` fallback. That is safe because
`npm run check:i18n` gates every locale on exact key parity with `en.json`; the fallback chain
has nothing left to resolve. `load: 'languageOnly'` collapses `en-US` → `en` so the resolved
language always names a locale file.

**Bundle sizes** — static-import closure of the entry + layout + home route (i.e. what the
browser fetches before first paint), measured from the same script on both builds:

| | raw | gzip |
|---|---:|---:|
| before | 4,283,527 B | 1,120,007 B |
| after | 2,089,254 B | 591,848 B |
| **delta** | **−2,194,273 B (−51.2%)** | **−528,159 B (−47.2%)** |

Plus one lazily fetched locale chunk. Per language, raw / gzip:

| en | zh | es | ja | de | fr | pt | ru |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 241,922 / 59,240 | 231,323 / 62,182 | 265,840 / 65,723 | 290,791 / 66,848 | 266,557 / 66,069 | 273,688 / 66,566 | 262,399 / 64,560 | 352,970 / 75,349 |

Net first load for an English visitor: **2,320,577 B raw / 654,030 B gzip**, vs 4,283,527 /
1,120,007 before — **−45.8% raw, −41.6% gzip**. Total bytes emitted are unchanged (4.29 MB);
the win is entirely in what any one visitor downloads.

### A2.2 — Transcript segment list

- Removed the unthrottled `on:scroll` handler. It ran
  `querySelectorAll('[data-seg-index]')` across the whole list and then walked the result
  reading `offsetTop` — an O(n) DOM query plus a forced synchronous layout, **per scroll
  event**, on a list that paginates to thousands of segments. Reading progress now comes from
  an `IntersectionObserver` over the same rows: no scroll listener, no DOM query, no layout
  read. Re-targeting is O(n) but happens once per data change (pagination append), not per frame.
- Both `{#each}` blocks are keyed (groups by overlap-group id or their segment uuid, inner
  segments by `segment.uuid`).

### A2.3 — FFmpeg wrapper out of the home bundle

`FileUploader.svelte` static-imported `audioExtractionService`, folding `@ffmpeg/ffmpeg` +
`@ffmpeg/util` into the home-route chunk. Now a dynamic `import()` behind
`loadAudioExtractionService()`; the wrapper moves to its own **13,034 B** chunk fetched at
first extraction.

### A2.9 — Presigned upload hard-failed after 5 minutes (launch blocker)

Every file body — presigned PUT to MinIO and the legacy multipart POST, for both regular
uploads and extracted audio — carried `timeout: 300000`. axios' `timeout` is a **total
request** deadline, not an idle one: it capped how long a *healthy* upload was allowed to take.
Against the 15 GB limit the UI advertises, anything slower than ~50 MB/s was guaranteed to fail
— a 2 GB upload on a 50 Mbit link needs ~5.5 min and died at 5. The queue then retried 3× with
backoff, re-hashing and re-sending from byte zero, failing identically each time.

Bodies now run through `sendBody()`, which arms a stall watchdog
(`$lib/services/stallWatchdog.ts`) and hands axios its `AbortSignal`: abort **only** when no
bytes have moved for 120 s. Slowness never fails; a dead connection still does.

Two things worth reviewer attention:

1. **Second phase.** Progress events stop firing at 100% while the object store writes and
   checksums a multi-GB object. A naive stall watchdog would abort *successful* large uploads
   there. Once the body is fully sent the watchdog re-arms with a 15-minute response ceiling
   instead of the 2-minute transfer window.
2. **Error type.** A watchdog abort surfaces as `UploadStalledError`, deliberately *not* an
   axios `CanceledError` — `axios.isCancel` means "the user cancelled" everywhere else in
   `uploadService` and suppresses retry. For the same reason a stall is rethrown out of the
   presigned block rather than falling through to the legacy multipart path: re-sending the
   whole body through the API container would stall too.

`UPLOAD_TIMEOUT_MS` → `CONTROL_REQUEST_TIMEOUT_MS`, now scoped to the small JSON calls
(`/files/prepare`, `/files/complete`, `/files/process-url`) where a total deadline is correct.

New i18n key `upload.stalled` added to all 8 locales.

## Where the issue text was wrong

Flagging these rather than quietly working around them:

1. **"no virtualization / every segment mounted" (A2.2) is not accurate.** The segment list is
   already virtualized — by `content-visibility: auto` + `contain-intrinsic-size`, with a
   comment in `TranscriptSegmentList.svelte` explaining the deliberate choice. The browser skips
   layout and paint for off-screen rows.

   **I did not apply `$components/gallery/VirtualList.svelte`**, and I think doing so would be a
   regression:
   - It windows a **fixed 44 px row** into a spacer-padded slice. Transcript segments are
     variable height — wrapped text, multi-segment overlap groups, and an edit mode that swaps
     the row for a 3-row `<textarea>`.
   - It **removes off-screen rows from the DOM**. Four separate features reach segments via
     `document.querySelector('[data-segment-id=…]')` and would silently break for anything not
     currently on screen: search scroll-to (`TranscriptSearch.svelte`), seek-to-playhead
     (`routes/files/[id]/+page.svelte`), `SpeakerEditorPanel`'s jump-to-segment, and the
     `.highlight-flash` playback animation. The infinite-scroll sentinel and `ScrollbarIndicator`
     geometry also assume a full-height container.

   The real O(n)-per-frame cost the issue points at was the **scroll handler**, and that is
   fixed. I've recorded the reasoning in `components/transcript/CLAUDE.md` and in the CSS
   comment so this doesn't get "fixed" later.

2. **A2.3 is worth ~13 KB, not more.** The issue rates it Low and that's right — the FFmpeg
   *core* was never bundled (it's fetched at runtime from `frontend/public/ffmpeg/`), so the
   13,034 B wrapper is the entirety of what was in the home bundle.

3. **A2.9 is not in the issue body.** #284 as published has no A2.9; the numbering came with the
   task. Filing it here under that label for traceability — it is a real launch blocker and the
   most user-visible bug in this set.

## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests for my changes
- [x] All existing tests pass
- [ ] I have tested with different audio/video formats (if applicable)

```
npm run check       # svelte-check: 926 files, 0 errors, 0 warnings
npm run lint        # 0 errors (619 pre-existing warnings, none new)
npm run test        # 27 files, 146 tests, all pass
npm run check:i18n  # parity OK across all 8 locales
npm run build       # succeeds
backend/venv/bin/pre-commit run --files <changed>   # all hooks pass
```

New tests (16):
- `stallWatchdog.test.ts` (7) — slow-but-moving never aborts; silent does; never-first-byte
  aborts; repeated byte count is not progress; the finalize window applies after 100% and does
  not re-arm; `dispose()` stops it.
- `TranscriptSegmentList.test.ts` (4) — keyed each renders every row; **no scroll listener is
  attached** (verified this test actually fails when the handler is put back); every row is
  observed; progress tracks the topmost visible index.
- `i18n/index.test.ts` (5) — only the active locale is registered; strings resolve; another
  locale loads on demand with BCP-47 collapse; unsupported codes fall back; `locale.set()`
  fetches the chunk before switching.

Browser verification (production build served from `dist/`, headless Chromium): `/login`
renders fully translated in `en`, and in `es` after switching, in **both light and dark mode**,
with **zero console errors**. The dev stack's backend was unreachable during this session, so
the transcript page was verified at the component level (see above) rather than end-to-end.

## Frontend changes (if applicable)
- [x] Changes work in light and dark mode
- [x] Changes are responsive on mobile devices (no layout changes; only the removed scroll
      handler and keyed each blocks touch the segment list, and its media queries are untouched)
- [x] No console errors or warnings

## Backend changes (if applicable)
None — this PR touches no file under `backend/`.

## Documentation
- [ ] I have updated the README if needed
- [x] I have updated relevant documentation
- [x] Code is properly commented

`frontend/CLAUDE.md` (never static-import a locale JSON), `components/transcript/CLAUDE.md`
(why not `VirtualList`, no `on:scroll`), `lib/services/CLAUDE.md` (never put a total-request
timeout on a file body; dynamic-import the extraction service).

## Additional notes

**Follow-up, deliberately out of scope:** A2.9 stops uploads dying on the clock, but a failed
15 GB upload still restarts from byte zero. The real fix is S3/MinIO **multipart upload with
resumable parts**, which needs a backend counterpart and pairs naturally with A1.11
("multipart upload for files >5 GB").

Two behaviours reviewers should sanity-check against expectations:
- Switching UI language now costs one chunk fetch (~60–75 KB gzip) before the strings change.
- First paint adds one locale round-trip on the critical path, in exchange for ~1.9 MB less to
  download. It could be shaved further with a `modulepreload` hint if that trade looks wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
