### PR TITLE
fix: fail closed on redaction masking errors + declare 70 missing CSS variables

### DIFF
--- a/backend/app/utils/transcript_builders.py
+++ b/backend/app/utils/transcript_builders.py
@@ -27,8 +27,17 @@ def _seg_text(segment, redaction_cfg=None) -> str:
             text, segment.redactions or [], segment.words, redaction_cfg, set()
         )
         return masked
-    except Exception:  # noqa: BLE001
-        return text
+    except Exception:
+        # FAIL CLOSED. This previously returned the raw text, which is the exact
+        # outcome the function exists to prevent: redaction is enabled, so this
+        # string is about to be put in a prompt for an EXTERNAL LLM provider, and
+        # a masking failure would have sent the unredacted PII off-site.
+        # Dropping the segment loses context; leaking it is unrecoverable.
+        logger.exception(
+            "Redaction masking failed for a segment; withholding its text rather than "
+            "sending unmasked content to an external provider"
+        )
+        return "[redacted — masking unavailable]"
 
 
 def get_speaker_name(segment) -> str:

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -8,6 +8,13 @@
   /* Default Light Theme */
   --primary-color: #3b82f6; /* Original blue color */
   --primary-color-rgb: 59, 130, 246; /* RGB values for primary color */
+  /* RGB channel triplets for the status colours below, so components can tint
+     with rgba(..., alpha). Without these the inline fallback always won, so the
+     tint stayed light-mode in dark mode and, for success, did not even match its
+     own text colour (#22c55e vs #10b981). Keep in sync with the hexes. */
+  --success-color-rgb: 16, 185, 129; /* #10b981 */
+  --error-color-rgb: 239, 68, 68; /* #ef4444 */
+  --warning-color-rgb: 245, 158, 11; /* #f59e0b */
   --primary-hover: #2563eb;
   --primary-light: #dbeafe; /* Light blue for button backgrounds */
   --primary-dark: #1d4ed8; /* Darker blue for button text */
@@ -74,12 +81,117 @@
   --surface-secondary: #f1f5f9;
   --surface-hover: rgba(0, 0, 0, 0.04);
   --background-secondary: #f1f5f9;
+
+  /* ---------------------------------------------------------------------
+     Compatibility aliases.
+
+     Every name below was referenced by at least one component but declared
+     nowhere. `var(--card-bg)` with no fallback makes the whole declaration
+     invalid at computed-value time, so 15 call sites were painting no
+     background at all; the references that did carry an inline fallback were
+     pinned to that one literal in BOTH themes.
+
+     Declared once here rather than in both blocks: `data-theme` is set on
+     <html> (stores/theme.js), the same element :root matches, so an alias
+     pointing at a canonical variable already resolves to the active theme's
+     value. Only names whose light/dark values are not derivable from a
+     canonical variable are repeated in the dark block.
+     --------------------------------------------------------------------- */
+
+  /* Primary / accent */
+  --accent: var(--primary-color);
+  --accent-color: var(--primary-color);
+  --accent-light: var(--primary-light);
+  --secondary-color: var(--text-secondary);
+  --primary-bg: var(--primary-light);
+  --primary-border: var(--primary-color);
+  --primary-color-alpha: var(--color-primary-alpha);
+  --primary-color-dark: var(--primary-dark);
+  --primary-color-hover: var(--primary-hover);
+  --primary-color-light: var(--primary-light);
+
+  /* Surfaces / backgrounds */
+  --bg-color: var(--background-color);
+  --color-background: var(--background-color);
+  --background-main: var(--background-color);
+  --background-alt: var(--background-secondary);
+  --bg-secondary: var(--background-secondary);
+  --bg-tertiary: var(--color-bg-tertiary);
+  --card-bg: var(--card-background);
+  --bg-hover: var(--hover-color);
+  --hover-bg: var(--hover-color);
+  --color-bg-hover: var(--hover-color);
+  --card-hover: var(--hover-color);
+  --skeleton-base: var(--color-bg-secondary);
+  --disabled-background: var(--color-bg-secondary);
+  --disabled-color: var(--text-secondary);
+
+  /* Text */
+  --text-color-secondary: var(--text-secondary);
+  --text-secondary-color: var(--text-secondary);
+  --text-tertiary: var(--color-text-tertiary);
+
+  /* Buttons */
+  --button-secondary-bg: var(--surface-color);
+  --button-secondary-bg-hover: var(--hover-color);
+  --button-secondary-border: var(--border-color);
+
+  /* Tags */
+  --tag-bg: rgba(var(--primary-color-rgb), 0.1);
+  --tag-border: rgba(var(--primary-color-rgb), 0.3);
+  --tag-color: var(--primary-dark);
+
+  /* Status tints, derived from the RGB triplets so they track the theme */
+  --danger-color: var(--error-color);
+  --danger-bg: rgba(var(--error-color-rgb), 0.1);
+  --error-background: rgba(var(--error-color-rgb), 0.1);
+  --error-light: rgba(var(--error-color-rgb), 0.1);
+  --error-color-light: rgba(var(--error-color-rgb), 0.1);
+  --error-border: rgba(var(--error-color-rgb), 0.3);
+  --success-bg: rgba(var(--success-color-rgb), 0.1);
+  --color-success-bg: rgba(var(--success-color-rgb), 0.1);
+  --success-color-light: rgba(var(--success-color-rgb), 0.1);
+  --success-border: rgba(var(--success-color-rgb), 0.3);
+  --warning-bg: rgba(var(--warning-color-rgb), 0.1);
+  --warning-background: rgba(var(--warning-color-rgb), 0.1);
+  --warning-light: rgba(var(--warning-color-rgb), 0.1);
+  --warning-border: rgba(var(--warning-color-rgb), 0.3);
+  --warning-text: var(--color-warning-text);
+  --info-light: rgba(var(--primary-color-rgb), 0.1);
+
+  /* Emphasis shades — no canonical source, so light values here, dark below */
+  --border-hover: #cbd5e1;
+  --border-color-hover: #cbd5e1;
+  --border-light: #f1f5f9;
+  --border-color-soft: #eef2f6;
+  --error-dark: #b91c1c;
+  --error-hover: #dc2626;
+  --success-hover: #059669;
+  --color-success-text: #047857;
+  --warning-dark: #b45309;
+  --info-dark: #1d4ed8;
+  --color-info-text: #1d4ed8;
+
+  /* Named for dark mode and used inside already-dark-scoped rules, so these
+     intentionally hold the same dark value in both themes. */
+  --dark-border: #334155;
+  --dark-input-bg: #334155;
+  --dark-text: #f8fafc;
+
+  /* Font stacks */
+  --font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-family-sans: var(--font-family);
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
 }
 
 /* Dark Theme */
 [data-theme='dark'] {
   --primary-color: #60a5fa; /* Lighter blue for dark mode */
   --primary-color-rgb: 96, 165, 250; /* RGB values for primary color in dark mode */
+  --success-color-rgb: 52, 211, 153; /* #34d399 */
+  --error-color-rgb: 248, 113, 113; /* #f87171 */
+  --warning-color-rgb: 251, 191, 36; /* #fbbf24 */
   --primary-hover: #3b82f6; /* Darker on hover — same blue as light-mode base. Apple HIG: hover always darkens. */
   --primary-light: #1e3a8a; /* Deeper blue for button backgrounds in dark mode */
   --primary-dark: #93c5fd; /* Lighter blue for button text in dark mode (contrast on dark surfaces) */
@@ -141,6 +253,21 @@
   --surface-secondary: #1e293b;
   --surface-hover: rgba(255, 255, 255, 0.06);
   --background-secondary: #1e293b;
+
+  /* Compatibility aliases - dark mode. Only the names whose value is not
+     derivable from a canonical variable need repeating; the rest are declared
+     once in :root and follow the theme automatically. See the light block. */
+  --border-hover: #475569;
+  --border-color-hover: #475569;
+  --border-light: #293548;
+  --border-color-soft: #263143;
+  --error-dark: #fca5a5;
+  --error-hover: #ef4444;
+  --success-hover: #10b981;
+  --color-success-text: #6ee7b7;
+  --warning-dark: #fcd34d;
+  --info-dark: #93c5fd;
+  --color-info-text: #93c5fd;
 }
 
 /* Global styles that should adapt to theme */


### PR DESCRIPTION
Two independent silent-no-op fixes, both instances of the recurring #284 bug class: **a control that reads correct and does nothing**.

## 1. `transcript_builders._seg_text` failed open (security)

When redaction is enabled and masking raises, the function returned the **raw** segment text. That is the exact outcome it exists to prevent: the string is about to be placed in a prompt for an **external LLM provider**, so a masking failure shipped unredacted PII off-site.

Now returns a `[redacted — masking unavailable]` placeholder and logs the exception. Dropping the segment loses context; leaking it is unrecoverable.

## 2. 70 CSS custom properties referenced but never declared (frontend)

Swept every `var(--x)` reference under `frontend/src` against actual declarations. 70 names were used by components and declared nowhere.

**Mode A — no fallback (visible breakage).** `var(--card-bg)` with no second argument is invalid at computed-value time, so the entire declaration is dropped:

| variable | uses | of which no fallback |
|---|---|---|
| `--card-bg` | 15 | **15** |
| `--hover-bg` | 14 | 13 |
| `--border-hover` | 14 | 10 |
| `--text-secondary-color` | 11 | **11** |
| `--text-color-secondary` | 7 | **7** |
| `--success-bg` | 10 | 8 |

**Mode B — fallback present but theme-blind.** `rgba(var(--success-color-rgb, 34, 197, 94), .1)` always took the inline literal, so tints stayed light-mode in dark mode — and that fallback did not even match `--success-color` (`#22c55e` vs `#10b981`) in light mode.

Most names are near-synonyms of existing canonical variables, so they are declared as aliases (`--card-bg: var(--card-background)`). Aliases live once in `:root` — `data-theme` is set on `<html>`, the element `:root` matches, so the canonical lookup already resolves per-theme. Only emphasis shades with no canonical source (`--border-hover`, `--error-dark`, `--success-hover`, …) are repeated in the dark block.

`--tooltip-left`, `--tooltip-top`, `--transcript-height` are intentionally left undeclared — set at runtime via `element.style.setProperty()`.

## Verification

- `svelte-check` — 926 files, **0 errors**, 0 warnings
- `npm run build` — production build succeeds
- eslint — passes
- used-vs-declared sweep — empty apart from the three runtime-set names
- pre-commit `frontend-check` hook green

Refs #284.