### PR TITLE
security(#284 A3.3): fail-closed exception handling — 11 fail-open controls fixed, S110 exemption removed

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -366,7 +366,7 @@ alembic downgrade -1               # Roll back one migration
 ### Task System
 - **Celery** with Redis broker (three worker types: GPU worker, CPU worker, embedding worker)
 - **Flower** monitoring at http://localhost:5175/flower
-- **3-stage transcription pipeline**: `preprocess_task` → `gpu_transcription_task` → `postprocess_task`
+- **3-stage transcription pipeline**: `preprocess_for_transcription` → `transcribe_gpu_task` → `finalize_transcription`
 - Async enrichment decoupling — postprocess no longer blocks GPU for enrichment
 
 ### Worker Types

--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -102,7 +102,7 @@ def get_system_uptime():
         else:
             return f"{int(hours)}h {int(minutes)}m {int(seconds)}s"
     except Exception as e:
-        logger.error(f"Error getting system uptime: {e}")
+        logger.exception(f"Error getting system uptime: {e}")
         return "Unknown"
 
 
@@ -120,7 +120,7 @@ def get_memory_usage():
             "percent": f"{memory.percent}%",
         }
     except Exception as e:
-        logger.error(f"Error getting memory usage: {e}")
+        logger.exception(f"Error getting memory usage: {e}")
         return {
             "total": "Unknown",
             "available": "Unknown",
@@ -149,7 +149,7 @@ def get_cpu_usage():
             "physical_cores": physical_cores,
         }
     except Exception as e:
-        logger.error(f"Error getting CPU usage: {e}")
+        logger.exception(f"Error getting CPU usage: {e}")
         return {
             "total_percent": "Unknown",
             "per_cpu": [],
@@ -176,7 +176,7 @@ def get_disk_usage():
             "percent": f"{disk.percent}%",
         }
     except Exception as e:
-        logger.error(f"Error getting disk usage: {e}")
+        logger.exception(f"Error getting disk usage: {e}")
         return {
             "total": "Unknown",
             "used": "Unknown",
@@ -271,7 +271,7 @@ def get_gpu_usage():
             }
         ]
     except Exception as e:
-        logger.error(f"Error getting GPU usage from Redis: {e}")
+        logger.exception(f"Error getting GPU usage from Redis: {e}")
         return [
             {
                 "available": False,
@@ -503,7 +503,7 @@ async def get_admin_stats(
         try:
             system_stats = await asyncio.to_thread(_collect_system_stats)
         except Exception as e:
-            logger.error(f"Error getting system stats: {e}")
+            logger.exception(f"Error getting system stats: {e}")
             system_stats = {
                 "cpu": {
                     "total_percent": "Unknown",
@@ -721,7 +721,7 @@ def delete_admin_user(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"User deletion failed, all changes rolled back: {e}")
+        logger.exception(f"User deletion failed, all changes rolled back: {e}")
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1814,7 +1814,8 @@ async def get_gpu_profiles(
                 profiles.append(json.loads(raw))
         return profiles
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to read GPU profiles: {e}") from e
+        logger.exception("Failed to read GPU profiles from Redis")
+        raise HTTPException(status_code=500, detail="Failed to read GPU profiles.") from e
 
 
 @router.post("/embedding-consistency/stop")

--- a/backend/app/api/endpoints/asr_settings.py
+++ b/backend/app/api/endpoints/asr_settings.py
@@ -1048,10 +1048,10 @@ def restart_gpu_worker(
         try:
             celery_app.control.broadcast("shutdown")
         except Exception as exc:
-            logger.error("Failed to broadcast shutdown: %s", exc)
+            logger.exception("Failed to broadcast shutdown")
             raise HTTPException(
                 status_code=500,
-                detail=f"Failed to signal worker restart: {exc}",
+                detail="Failed to signal worker restart.",
             ) from exc
         return {
             "status": "restart_signaled",
@@ -1061,10 +1061,12 @@ def restart_gpu_worker(
             "they may already be restarting.",
         }
 
-    # Check for active GPU tasks
+    # Check for active GPU tasks. Best-effort: this only produces an advisory
+    # count in the response, so a broker hiccup must not block the restart.
     try:
         active_result = inspector.active() or {}
     except Exception:
+        logger.exception("Failed to inspect active GPU tasks; reporting 0")
         active_result = {}
 
     active_gpu_tasks = 0
@@ -1076,10 +1078,10 @@ def restart_gpu_worker(
     try:
         celery_app.control.broadcast("shutdown", destination=gpu_workers)
     except Exception as exc:
-        logger.error("Failed to send shutdown to GPU workers: %s", exc)
+        logger.exception("Failed to send shutdown to GPU workers")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to signal worker restart: {exc}",
+            detail="Failed to signal worker restart.",
         ) from exc
 
     logger.info(

--- a/backend/app/api/endpoints/auth/dependencies.py
+++ b/backend/app/api/endpoints/auth/dependencies.py
@@ -191,6 +191,16 @@ def get_current_user(
         request.state.user_id = user.id
         request.state.org_id = getattr(user, "external_org_id", None)
         return user  # type: ignore[no-any-return]
+    except HTTPException:
+        # FAIL CLOSED. `credentials_exception` (401, unknown user) and the 400
+        # "Inactive user" raised above are *authorization decisions*, not
+        # infrastructure errors — but they are HTTPExceptions, so the broad
+        # handler below caught them and, under TESTING, replaced the denial with
+        # a FABRICATED authenticated user. That made "unknown user" and
+        # "deactivated user" both resolve to a valid session. Re-raise instead:
+        # the mock-user shortcut now only covers what it was written for, an
+        # unavailable database.
+        raise
     except Exception as e:
         # Handle database connection errors or other issues
         logger.error(f"Error retrieving user: {e}")

--- a/backend/app/api/endpoints/auth/mfa_tokens.py
+++ b/backend/app/api/endpoints/auth/mfa_tokens.py
@@ -114,7 +114,7 @@ def _blacklist_mfa_token(jti: str, expires_seconds: int) -> bool:
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to blacklist MFA token JTI: {e}")
+        logger.exception(f"Failed to blacklist MFA token JTI: {e}")
         if settings.MFA_REQUIRE_REDIS:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -149,7 +149,7 @@ def _is_mfa_token_blacklisted(jti: str) -> bool:
                 logger.warning("Redis not available for MFA token blacklist check")
                 return False
     except Exception as e:
-        logger.error(f"Failed to check MFA token blacklist: {e}")
+        logger.exception(f"Failed to check MFA token blacklist: {e}")
         # Fail-secure when Redis required (deny access), fail-open otherwise
         return bool(settings.MFA_REQUIRE_REDIS)
 

--- a/backend/app/api/endpoints/auth_config.py
+++ b/backend/app/api/endpoints/auth_config.py
@@ -448,7 +448,7 @@ async def _test_ldap_connection(config: dict[str, Any]) -> AuthMethodTestRespons
             message="LDAP library (ldap3) is not installed",
         )
     except Exception as e:
-        logger.error(f"LDAP connection test error: {e}")
+        logger.exception(f"LDAP connection test error: {e}")
         return AuthMethodTestResponse(
             success=False,
             message="LDAP connection failed due to an unexpected error. Check server logs for details.",
@@ -530,7 +530,7 @@ async def _test_keycloak_connection(config: dict[str, Any]) -> AuthMethodTestRes
             message="Connection to Keycloak server timed out",
         )
     except Exception as e:
-        logger.error(f"Keycloak connection test error: {e}")
+        logger.exception(f"Keycloak connection test error: {e}")
         return AuthMethodTestResponse(
             success=False,
             message="Keycloak connection failed due to an unexpected error. Check server logs for details.",

--- a/backend/app/api/endpoints/embedding_migration.py
+++ b/backend/app/api/endpoints/embedding_migration.py
@@ -122,6 +122,9 @@ async def get_migration_status(
 
             status["consistency_status"] = get_embedding_consistency_status()
         except Exception:
+            # Optional Redis-backed enrichment of an otherwise complete status
+            # payload — a missing sub-field must not fail the whole endpoint.
+            logger.exception("Could not read embedding consistency status")
             status["consistency_status"] = None
 
         return status

--- a/backend/app/api/endpoints/files/__init__.py
+++ b/backend/app/api/endpoints/files/__init__.py
@@ -598,7 +598,7 @@ def get_media_file_stream_url(
             "is_public": getattr(db_file, "is_public", False),
         }
     except Exception as e:
-        logger.error(f"Error generating presigned URL for file {file_uuid}: {e}")
+        logger.exception(f"Error generating presigned URL for file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error generating streaming URL: {str(e)}",
@@ -692,7 +692,10 @@ def _ensure_prepare_enqueued(db_file: MediaFile, user_id: int, mode: str) -> Non
     try:
         first = get_redis().set(guard_key, "1", nx=True, ex=900)
     except Exception:
-        first = True  # Redis hiccup → don't block the download
+        # The Redis key is only a duplicate-dispatch guard; losing it costs one
+        # redundant prepare task, whereas failing here would block the download.
+        logger.exception("Download-prepare dedup guard unavailable; dispatching anyway")
+        first = True
     if first:
         prepare_media_download_task.delay(file_id=db_file.id, user_id=user_id, mode=mode)
 
@@ -1021,7 +1024,7 @@ def clear_video_cache(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error clearing video cache for file {file_id}: {e}")
+        logger.exception(f"Error clearing video cache for file {file_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error clearing video cache",
@@ -1084,7 +1087,7 @@ def refresh_analytics(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error refreshing analytics for file {file_id}: {e}")
+        logger.exception(f"Error refreshing analytics for file {file_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error refreshing analytics",

--- a/backend/app/api/endpoints/files/cancel_upload.py
+++ b/backend/app/api/endpoints/files/cancel_upload.py
@@ -85,7 +85,7 @@ def cancel_upload(
                 delete_file(str(db_file.storage_path))
                 logger.info(f"Deleted partial upload: {db_file.storage_path}")
             except Exception as e:
-                logger.error(f"Error deleting file {db_file.storage_path}: {e}")
+                logger.exception(f"Error deleting file {db_file.storage_path}: {e}")
                 # Continue with cleanup even if file deletion fails
 
         # Delete the database record
@@ -95,7 +95,7 @@ def cancel_upload(
 
     except Exception as e:
         db.rollback()
-        logger.error(f"Error cancelling upload {file_id}: {e}")
+        logger.exception(f"Error cancelling upload {file_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to cancel upload",

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -439,14 +439,26 @@ def _resolve_redaction_for_request(
 
     The owner (and admins, audited) may set ``redact=false`` to reveal NON-forced
     categories; admin-forced categories stay masked. Non-owners never reveal.
+
+    Raises:
+        HTTPException: 503 when the redaction policy cannot be resolved.
     """
     try:
         from app.services.redaction.config import resolve_effective_config
 
         cfg = resolve_effective_config(db, current_user.id)
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"Failed to resolve redaction config: {e}")
-        return None, set()
+    except Exception as e:
+        # FAIL CLOSED. Returning (None, set()) told every downstream reader that
+        # redaction was off: `_apply_redaction` short-circuits on a None config
+        # and returned every segment raw, `_redaction_pending` stopped withholding
+        # transcripts mid-detection, and no `transcript.view_unredacted` audit
+        # event fired because `reveal` was empty — an unredacted read with no
+        # compliance trail, including admin-forced categories. Refuse the read.
+        logger.exception("Failed to resolve redaction config; refusing the transcript read")
+        raise HTTPException(
+            status_code=503,
+            detail="Redaction policy is temporarily unavailable; transcript withheld.",
+        ) from e
 
     can_reveal = bool(db_file.user_id == current_user.id) or bool(is_admin)
     reveal = cfg.reveal_categories(requested=(redact is False), is_owner=can_reveal)

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -109,7 +109,7 @@ def get_file_tags(db: Session, file_id: int) -> list[str]:
         tags = db.query(Tag.name).join(FileTag).filter(FileTag.media_file_id == file_id).all()
         return [tag[0] for tag in tags]
     except Exception as tag_error:
-        logger.error(f"Error getting tags: {tag_error}")
+        logger.exception(f"Error getting tags: {tag_error}")
         db.rollback()
         return []
 
@@ -139,7 +139,7 @@ def get_file_collections(db: Session, file_id: int, user_id: int) -> list[dict]:
             for col in collection_objs
         ]
     except Exception as collection_error:
-        logger.error(f"Error getting collections: {collection_error}")
+        logger.exception(f"Error getting collections: {collection_error}")
         db.rollback()
         return []
 
@@ -733,7 +733,7 @@ def get_media_file_detail(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error in get_media_file_detail: {e}")
+        logger.exception(f"Error in get_media_file_detail: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error retrieving media file: {str(e)}",

--- a/backend/app/api/endpoints/files/filtering.py
+++ b/backend/app/api/endpoints/files/filtering.py
@@ -304,7 +304,7 @@ def apply_transcript_search_filter(
             query = query.filter(MediaFile.uuid.in_(file_uuids))
 
     except Exception as e:
-        logger.error(f"OpenSearch transcript search failed: {e}")
+        logger.exception(f"OpenSearch transcript search failed: {e}")
         # Degrade gracefully — skip filter rather than error the whole request
 
     return query

--- a/backend/app/api/endpoints/files/management.py
+++ b/backend/app/api/endpoints/files/management.py
@@ -166,7 +166,7 @@ def get_file_status_detail(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting file status detail for {file_uuid}: {e}")
+        logger.exception(f"Error getting file status detail for {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error retrieving file status details",
@@ -212,7 +212,7 @@ def cancel_file_processing(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error cancelling file {file_uuid}: {e}")
+        logger.exception(f"Error cancelling file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error cancelling file processing",
@@ -293,7 +293,7 @@ def retry_file_processing(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error retrying file {file_uuid}: {e}")
+        logger.exception(f"Error retrying file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error retrying file processing",
@@ -335,7 +335,7 @@ def recover_file(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error recovering file {file_uuid}: {e}")
+        logger.exception(f"Error recovering file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error recovering file",
@@ -363,7 +363,7 @@ def force_delete_file(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error force deleting file {file_uuid}: {e}")
+        logger.exception(f"Error force deleting file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error force deleting file",
@@ -416,7 +416,7 @@ def get_stuck_files(
         }
 
     except Exception as e:
-        logger.error(f"Error getting stuck files: {e}")
+        logger.exception(f"Error getting stuck files: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error retrieving stuck files",
@@ -585,6 +585,9 @@ def _handle_summarize_action(
             )
         llm_service.close()
     except Exception:
+        # Bulk actions report per-file outcomes instead of aborting the batch,
+        # so an unconstructable LLM client becomes this file's failure result.
+        logger.exception(f"Could not construct an LLM client for file {file_uuid}")
         return BulkActionResult(
             file_uuid=file_uuid,
             success=False,
@@ -741,7 +744,7 @@ def bulk_file_action(
                     )
                 )
             except Exception as e:
-                logger.error(f"Error processing bulk action for file {file_uuid}: {e}")
+                logger.exception(f"Error processing bulk action for file {file_uuid}: {e}")
                 results.append(
                     BulkActionResult(
                         file_uuid=file_uuid,
@@ -754,7 +757,7 @@ def bulk_file_action(
         return results
 
     except Exception as e:
-        logger.error(f"Error in bulk file action: {e}")
+        logger.exception(f"Error in bulk file action: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error performing bulk file action",
@@ -799,6 +802,9 @@ def cleanup_orphaned_files(
                         if isinstance(errors_list, list):
                             errors_list.append(f"Failed to recover file {file_id}")
                 except Exception as e:
+                    # Per-file failure is recorded and the sweep continues; the
+                    # caller reads cleanup_results["errors"].
+                    logger.exception(f"Orphan cleanup failed for file {file_id}")
                     errors_list = cleanup_results["errors"]
                     if isinstance(errors_list, list):
                         errors_list.append(f"Error processing file {file_id}: {str(e)}")
@@ -806,7 +812,7 @@ def cleanup_orphaned_files(
         return cleanup_results
 
     except Exception as e:
-        logger.error(f"Error in cleanup orphaned files: {e}")
+        logger.exception(f"Error in cleanup orphaned files: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error cleaning up orphaned files",

--- a/backend/app/api/endpoints/files/prepare_upload.py
+++ b/backend/app/api/endpoints/files/prepare_upload.py
@@ -375,7 +375,7 @@ async def prepare_upload(
         # duplicate) — don't bury them in a generic 500.
         raise
     except Exception as e:
-        logger.error(f"Error preparing upload: {str(e)}")
+        logger.exception(f"Error preparing upload: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error preparing upload: {str(e)}",

--- a/backend/app/api/endpoints/files/reprocess.py
+++ b/backend/app/api/endpoints/files/reprocess.py
@@ -113,7 +113,7 @@ def clear_existing_transcription_data(db: Session, media_file: MediaFile) -> Non
                 logger.warning(f"OpenSearch speaker cleanup failed (non-fatal): {os_err}")
 
     except Exception as e:
-        logger.error(f"Error clearing transcription data for file {media_file.id}: {e}")
+        logger.exception(f"Error clearing transcription data for file {media_file.id}: {e}")
         db.rollback()
         raise
 
@@ -243,7 +243,7 @@ def clear_selective_data(db: Session, media_file: MediaFile, stages: list[str]) 
         db.commit()
         logger.info(f"Cleared selective data for stages {stages} on file {media_file.id}")
     except Exception as e:
-        logger.error(f"Error clearing selective data for file {media_file.id}: {e}")
+        logger.exception(f"Error clearing selective data for file {media_file.id}: {e}")
         db.rollback()
         raise
 
@@ -534,7 +534,7 @@ def process_file_reprocess(
         # Re-raise HTTP exceptions
         raise
     except Exception as e:
-        logger.error(f"Error processing reprocess request for file {file_uuid}: {e}")
+        logger.exception(f"Error processing reprocess request for file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error processing reprocess request",

--- a/backend/app/api/endpoints/files/streaming.py
+++ b/backend/app/api/endpoints/files/streaming.py
@@ -105,7 +105,7 @@ def get_thumbnail_streaming_response(db_file: MediaFile) -> StreamingResponse:
             detail="Thumbnail not found in storage",
         ) from e
     except Exception as e:
-        logger.error(f"Error retrieving thumbnail: {e}")
+        logger.exception(f"Error retrieving thumbnail: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error retrieving thumbnail: {str(e)}",

--- a/backend/app/api/endpoints/files/subtitles.py
+++ b/backend/app/api/endpoints/files/subtitles.py
@@ -128,12 +128,16 @@ async def get_subtitles(
             },
         )
 
+    except HTTPException:
+        # The 404 raised above for an empty transcript is a deliberate status;
+        # the broad handler below turned it into a 500 whose detail embedded the
+        # 404's message.
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to generate subtitles: {str(e)}"
-        ) from e
+        logger.exception(f"Failed to generate {subtitle_format} subtitles for file {file_uuid}")
+        raise HTTPException(status_code=500, detail="Failed to generate subtitles.") from e
 
 
 @router.get("/{file_uuid}/subtitles/validate", response_model=SubtitleValidationResult)
@@ -185,10 +189,11 @@ async def validate_subtitles(
             total_duration=float(total_duration),
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to validate subtitles: {str(e)}"
-        ) from e
+        logger.exception(f"Failed to validate subtitles for file {file_uuid}")
+        raise HTTPException(status_code=500, detail="Failed to validate subtitles.") from e
 
 
 class BulkExportPrepareRequest(BaseModel):

--- a/backend/app/api/endpoints/files/subtitles.py
+++ b/backend/app/api/endpoints/files/subtitles.py
@@ -32,14 +32,25 @@ def _resolve_subtitle_redaction(db, media_file, current_user, redact: bool):
 
     Honors the admin forced-export lock: when ``export_locked`` is set, the original
     can never be exported regardless of the ``redact`` flag.
+
+    Raises:
+        HTTPException: 503 when the redaction policy cannot be resolved.
     """
     try:
         from app.services.redaction.config import resolve_effective_config
 
         cfg = resolve_effective_config(db, current_user.id)
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"Failed to resolve redaction config for subtitles: {e}")
-        return None, set()
+    except Exception as e:
+        # FAIL CLOSED. Returning None skipped the `export_locked` branch three
+        # lines below and handed SubtitleService a None config, whose masking
+        # step early-returns — so the user downloaded a fully unredacted
+        # SRT/VTT/TXT even under the admin `force_export_redacted` floor.
+        # An export is unrecoverable once written to disk; refuse it instead.
+        logger.exception("Failed to resolve redaction config; refusing the subtitle export")
+        raise HTTPException(
+            status_code=503,
+            detail="Redaction policy is temporarily unavailable; export withheld.",
+        ) from e
 
     if getattr(cfg, "export_locked", False):
         return cfg, set()  # forced — never reveal on export

--- a/backend/app/api/endpoints/files/summary_status.py
+++ b/backend/app/api/endpoints/files/summary_status.py
@@ -133,7 +133,7 @@ async def retry_summary(
     try:
         llm_available = await is_llm_available(user_id=current_user.id)
     except Exception as e:
-        logger.error(f"Failed to check LLM availability for retry of file {file_id}: {e}")
+        logger.exception(f"Failed to check LLM availability for retry of file {file_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to verify LLM service availability. Please try again later.",

--- a/backend/app/api/endpoints/files/upload.py
+++ b/backend/app/api/endpoints/files/upload.py
@@ -170,7 +170,7 @@ def create_media_file_record(
         return db_file
 
     except Exception as e:
-        logger.error(f"Error creating MediaFile: {e}")
+        logger.exception(f"Error creating MediaFile: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error creating media file record: {str(e)}",

--- a/backend/app/api/endpoints/files/url_processing.py
+++ b/backend/app/api/endpoints/files/url_processing.py
@@ -287,7 +287,7 @@ def _handle_playlist_processing(
         )
 
     except Exception as e:
-        logger.error(f"Failed to dispatch YouTube playlist processing task: {e}")
+        logger.exception(f"Failed to dispatch YouTube playlist processing task: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to start playlist processing. Please try again.",
@@ -327,7 +327,7 @@ def _extract_video_info(
         # Re-raise HTTPExceptions (they already have proper error messages)
         raise
     except Exception as e:
-        logger.error(f"Error extracting video info from {normalized_url}: {e}")
+        logger.exception(f"Error extracting video info from {normalized_url}: {e}")
         # Create user-friendly error message
         user_friendly_error = create_user_friendly_error(str(e), normalized_url)
         raise HTTPException(
@@ -552,7 +552,7 @@ def _dispatch_video_task(
 
         files_uploaded_total.labels(source="url").inc()
     except Exception as e:
-        logger.error(f"Failed to dispatch media processing task: {e}")
+        logger.exception(f"Failed to dispatch media processing task: {e}")
         db.delete(media_file)
         db.commit()
         raise HTTPException(

--- a/backend/app/api/endpoints/files/waveform.py
+++ b/backend/app/api/endpoints/files/waveform.py
@@ -387,7 +387,7 @@ def generate_waveform_for_file(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error triggering waveform generation for file {file_uuid}: {e}")
+        logger.exception(f"Error triggering waveform generation for file {file_uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to start waveform generation: {str(e)}",
@@ -450,7 +450,7 @@ def generate_waveforms_for_files(
         }
 
     except Exception as e:
-        logger.error(f"Error triggering waveform generation: {e}")
+        logger.exception(f"Error triggering waveform generation: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to start waveform generation: {str(e)}",
@@ -513,7 +513,7 @@ def get_waveform_status(
         }
 
     except Exception as e:
-        logger.error(f"Error getting waveform status: {e}")
+        logger.exception(f"Error getting waveform status: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to get waveform status: {str(e)}",

--- a/backend/app/api/endpoints/llm_settings.py
+++ b/backend/app/api/endpoints/llm_settings.py
@@ -697,7 +697,7 @@ async def test_llm_connection(
 
     except Exception as e:
         response_time = int((time.time() - start_time) * 1000)
-        logger.error(f"LLM connection test failed: {e}")
+        logger.exception(f"LLM connection test failed: {e}")
 
         return schemas.ConnectionTestResponse(
             success=False,
@@ -924,7 +924,7 @@ async def get_ollama_models(
             "message": f"Connection error: {str(e)}",
         }
     except Exception as e:
-        logger.error(f"Error fetching Ollama models from {base_url}: {e}")
+        logger.exception(f"Error fetching Ollama models from {base_url}: {e}")
         return {
             "success": False,
             "models": [],

--- a/backend/app/api/endpoints/llm_status.py
+++ b/backend/app/api/endpoints/llm_status.py
@@ -78,7 +78,7 @@ async def get_llm_status(
         return status_info
 
     except Exception as e:
-        logger.error(f"Error checking LLM status: {e}")
+        logger.exception(f"Error checking LLM status: {e}")
         return {
             "available": False,
             "user_id": current_user.id,
@@ -120,7 +120,7 @@ async def test_llm_connection(
         }
 
     except Exception as e:
-        logger.error(f"Error testing LLM connection: {e}")
+        logger.exception(f"Error testing LLM connection: {e}")
         return {
             "success": False,
             "message": "Connection test failed due to an unexpected error. Check server logs for details.",

--- a/backend/app/api/endpoints/search.py
+++ b/backend/app/api/endpoints/search.py
@@ -415,7 +415,7 @@ def trigger_reindex(
                     )
                     indexed_uuids = {b["key"] for b in buckets}
             except Exception as e:
-                logger.error(f"Error querying indexed files: {e}")
+                logger.exception(f"Error querying indexed files: {e}")
 
         # Compute the difference: files that need indexing
         pending_uuids = list(all_uuids - indexed_uuids)
@@ -568,7 +568,7 @@ def reindex_status(
             indexed_files = aggs.get("unique_files", {}).get("value", 0)
             last_indexed_at = aggs.get("last_indexed", {}).get("value_as_string")
         except Exception as e:
-            logger.error(f"Error checking index status: {e}")
+            logger.exception(f"Error checking index status: {e}")
 
     # Check if a reindex task is actively running for this user
     in_progress = _check_reindex_task_active(current_user.id)
@@ -729,7 +729,7 @@ def repair_indices(
                     else:
                         results[idx] = "failed"
                 except Exception as e:
-                    logger.error(f"Failed to rebuild speakers index: {e}")
+                    logger.exception(f"Failed to rebuild speakers index: {e}")
                     results[idx] = "failed"
             else:
                 repaired = _repair_index(idx)

--- a/backend/app/api/endpoints/speaker_clusters.py
+++ b/backend/app/api/endpoints/speaker_clusters.py
@@ -75,7 +75,7 @@ def list_clusters(
             search=search,
         )
     except Exception as e:
-        logger.error("Error listing clusters: %s", e)
+        logger.exception("Error listing clusters: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
@@ -115,7 +115,7 @@ def trigger_recluster(
             "message": "Re-clustering started in background",
         }
     except Exception as e:
-        logger.error("Error triggering recluster: %s", e)
+        logger.exception("Error triggering recluster: %s", e)
         raise HTTPException(status_code=500, detail="Failed to start re-clustering") from e
 
 
@@ -344,7 +344,7 @@ def update_cluster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error updating cluster: %s", e)
+        logger.exception("Error updating cluster: %s", e)
         db.rollback()
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
@@ -386,7 +386,7 @@ def delete_cluster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error deleting cluster: %s", e)
+        logger.exception("Error deleting cluster: %s", e)
         db.rollback()
         raise HTTPException(status_code=500, detail="Internal server error") from e
 

--- a/backend/app/api/endpoints/speaker_profiles.py
+++ b/backend/app/api/endpoints/speaker_profiles.py
@@ -183,7 +183,7 @@ def list_speaker_profiles(
         # :65) must propagate unchanged — do not mask them as a generic 500.
         raise
     except Exception as e:
-        logger.error(f"Error listing speaker profiles: {e}")
+        logger.exception(f"Error listing speaker profiles: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -237,7 +237,7 @@ def create_speaker_profile(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating speaker profile: {e}")
+        logger.exception(f"Error creating speaker profile: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -298,7 +298,7 @@ def update_speaker_profile(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error updating speaker profile: {e}")
+        logger.exception(f"Error updating speaker profile: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -360,7 +360,7 @@ def assign_speaker_to_profile(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error assigning speaker to profile: {e}")
+        logger.exception(f"Error assigning speaker to profile: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -553,7 +553,7 @@ def get_speaker_profile_suggestions(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting speaker suggestions: {e}")
+        logger.exception(f"Error getting speaker suggestions: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -586,7 +586,7 @@ def get_speaker_profile_occurrences(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting speaker occurrences: {e}")
+        logger.exception(f"Error getting speaker occurrences: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -639,7 +639,7 @@ def delete_speaker_profile(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting speaker profile: {e}")
+        logger.exception(f"Error deleting speaker profile: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -714,7 +714,7 @@ async def upload_profile_avatar(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error uploading avatar: {e}")
+        logger.exception(f"Error uploading avatar: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -748,7 +748,7 @@ def delete_profile_avatar(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting avatar: {e}")
+        logger.exception(f"Error deleting avatar: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -841,7 +841,7 @@ def list_speaker_collections(
         return result
 
     except Exception as e:
-        logger.error(f"Error listing speaker collections: {e}")
+        logger.exception(f"Error listing speaker collections: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -894,6 +894,6 @@ def create_speaker_collection(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating speaker collection: {e}")
+        logger.exception(f"Error creating speaker collection: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e

--- a/backend/app/api/endpoints/speaker_update.py
+++ b/backend/app/api/endpoints/speaker_update.py
@@ -160,7 +160,7 @@ def auto_create_or_assign_profile(speaker: Speaker, display_name: str, db: Sessi
         return True
 
     except Exception as e:
-        logger.error(f"Error in auto profile creation/assignment: {e}")
+        logger.exception(f"Error in auto profile creation/assignment: {e}")
         return False
 
 
@@ -195,7 +195,7 @@ def _sync_speaker_to_opensearch(speaker: Speaker, db: Session) -> None:
             f"display_name='{speaker.display_name}', profile_id={speaker.profile_id}, verified={speaker.verified}"
         )
     except Exception as e:
-        logger.error(f"Failed to sync speaker {speaker.id} to OpenSearch: {e}")
+        logger.exception(f"Failed to sync speaker {speaker.id} to OpenSearch: {e}")
 
 
 def _update_profile_embedding(db: Session, speaker_id: int, profile_id: int) -> None:
@@ -299,7 +299,7 @@ def _sync_suggestion_speakers_to_opensearch(updated_speaker: Speaker, db: Sessio
         if suggestion_speakers:
             logger.info(f"Synced {len(suggestion_speakers)} speaker suggestions to OpenSearch")
     except Exception as e:
-        logger.error(f"Error during batch OpenSearch sync for suggestions: {e}")
+        logger.exception(f"Error during batch OpenSearch sync for suggestions: {e}")
 
 
 def _send_bulk_update_notification(
@@ -414,7 +414,7 @@ def trigger_retroactive_matching(updated_speaker: Speaker, db: Session) -> dict[
         return {"auto_applied_count": auto_applied_count, "suggested_count": suggested_count}
 
     except Exception as e:
-        logger.error(f"Error in retroactive matching: {e}")
+        logger.exception(f"Error in retroactive matching: {e}")
         db.rollback()
         return {"auto_applied_count": 0, "suggested_count": 0}
 

--- a/backend/app/api/endpoints/speakers.py
+++ b/backend/app/api/endpoints/speakers.py
@@ -718,7 +718,7 @@ def cleanup_orphaned_embeddings(
             "message": f"Cleaned up {deleted_count} orphaned speaker embeddings",
         }
     except Exception as e:
-        logger.error(f"Error during cleanup: {e}")
+        logger.exception(f"Error during cleanup: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -858,6 +858,9 @@ def debug_cross_media_data(
                     )
 
         except Exception as e:
+            # Diagnostic endpoint: the OpenSearch section is optional, and the
+            # error is surfaced in the payload rather than failing the report.
+            logger.exception("OpenSearch section of the speaker debug report failed")
             debug_info["opensearch_error"] = str(e)
 
         # Add summary analysis
@@ -872,7 +875,7 @@ def debug_cross_media_data(
         return debug_info
 
     except Exception as e:
-        logger.error(f"Error in debug endpoint: {e}")
+        logger.exception(f"Error in debug endpoint: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -983,7 +986,7 @@ def debug_cross_media_by_name(
         return results
 
     except Exception as e:
-        logger.error(f"Error in cross-media-by-name debug endpoint: {e}")
+        logger.exception(f"Error in cross-media-by-name debug endpoint: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -1041,7 +1044,7 @@ def get_speaker_cross_media_occurrences(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting cross-media occurrences: {e}")
+        logger.exception(f"Error getting cross-media occurrences: {e}")
         raise ErrorHandler.internal_error() from e
 
 
@@ -1083,7 +1086,7 @@ def verify_speaker_identification(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error verifying speaker: {e}")
+        logger.exception(f"Error verifying speaker: {e}")
         db.rollback()
         raise ErrorHandler.internal_error() from e
 
@@ -1302,7 +1305,7 @@ def _handle_profile_embedding_updates(
                 )
 
     except Exception as e:
-        logger.error(f"Error updating profile embeddings for speaker {speaker_id}: {e}")
+        logger.exception(f"Error updating profile embeddings for speaker {speaker_id}: {e}")
         # Don't fail the operation if embedding update fails
 
 
@@ -1311,7 +1314,7 @@ def _update_opensearch_speaker_name(speaker_uuid: str, display_name: str) -> Non
     try:
         update_speaker_display_name(speaker_uuid, display_name)
     except Exception as e:
-        logger.error(f"Failed to update speaker display name in OpenSearch: {e}")
+        logger.exception(f"Failed to update speaker display name in OpenSearch: {e}")
 
 
 def _handle_speaker_labeling_workflow(
@@ -1348,7 +1351,7 @@ def _clear_video_cache_for_speaker(db: Session, media_file_id: int) -> None:
         video_processing_service = VideoProcessingService(minio_service)
         video_processing_service.clear_cache_for_media_file(db, media_file_id)
     except Exception as e:
-        logger.error(f"Warning: Failed to clear video cache after speaker update: {e}")
+        logger.exception(f"Warning: Failed to clear video cache after speaker update: {e}")
 
 
 def _handle_update_profile_action(
@@ -1740,7 +1743,7 @@ def _accept_speaker_profile_match(
                 f"Failed to update profile {profile_id} embedding for speaker {speaker_id}"
             )
     except Exception as e:
-        logger.error(f"Error updating profile embedding: {e}")
+        logger.exception(f"Error updating profile embedding: {e}")
 
     return {
         "status": "accepted",
@@ -1778,7 +1781,7 @@ def _reject_speaker_suggestion(speaker: Speaker, speaker_id: int, db: Session) -
                     f"Failed to update profile {old_profile_id} embedding after removing speaker {speaker_id}"
                 )
         except Exception as e:
-            logger.error(f"Error updating profile embedding after rejection: {e}")
+            logger.exception(f"Error updating profile embedding after rejection: {e}")
 
     return {
         "status": "rejected",
@@ -1836,7 +1839,7 @@ def _create_new_speaker_profile(
                 f"Failed to update new profile {new_profile.id} embedding for speaker {speaker_id}"
             )
     except Exception as e:
-        logger.error(f"Error updating new profile embedding: {e}")
+        logger.exception(f"Error updating new profile embedding: {e}")
 
     return {
         "status": "created_and_assigned",
@@ -1942,7 +1945,7 @@ def _merge_speaker_embeddings(source_speaker_uuid: str, target_speaker: Speaker)
         else:
             logger.warning("Could not retrieve embeddings for speaker merge")
     except Exception as e:
-        logger.error(f"Error averaging speaker embeddings during merge: {e}")
+        logger.exception(f"Error averaging speaker embeddings during merge: {e}")
 
 
 def _clear_speaker_video_cache(db: Session, affected_media_files: set[int]) -> None:
@@ -1957,7 +1960,7 @@ def _clear_speaker_video_cache(db: Session, affected_media_files: set[int]) -> N
         for media_file_id in affected_media_files:
             video_processing_service.clear_cache_for_media_file(db, media_file_id)
     except Exception as e:
-        logger.error(f"Warning: Failed to clear video cache after speaker merge: {e}")
+        logger.exception(f"Warning: Failed to clear video cache after speaker merge: {e}")
 
 
 def _update_opensearch_speaker_merge(source_speaker_uuid: str, target_speaker_uuid: str) -> None:
@@ -1970,7 +1973,7 @@ def _update_opensearch_speaker_merge(source_speaker_uuid: str, target_speaker_uu
             f"Merged speaker embeddings in OpenSearch: {source_speaker_uuid} -> {target_speaker_uuid}"
         )
     except Exception as e:
-        logger.error(f"Error merging speaker embeddings in OpenSearch: {e}")
+        logger.exception(f"Error merging speaker embeddings in OpenSearch: {e}")
 
 
 def _refresh_analytics_after_merge(db: Session, affected_media_files: set[int]) -> None:
@@ -1986,7 +1989,7 @@ def _refresh_analytics_after_merge(db: Session, affected_media_files: set[int]) 
             else:
                 logger.warning(f"Failed to refresh analytics for media file {media_file_id}")
     except Exception as e:
-        logger.error(f"Error refreshing analytics after speaker merge: {e}")
+        logger.exception(f"Error refreshing analytics after speaker merge: {e}")
 
 
 def _update_profile_embeddings_after_merge(
@@ -2016,7 +2019,7 @@ def _update_profile_embeddings_after_merge(
             logger.info(f"Updated target profile {target_profile_id} embedding after speaker merge")
 
     except Exception as e:
-        logger.error(f"Error updating profile embeddings after speaker merge: {e}")
+        logger.exception(f"Error updating profile embeddings after speaker merge: {e}")
 
 
 # --- Helper functions for get_speaker_cross_media_occurrences ---

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -114,7 +114,7 @@ async def get_system_stats(
                 "uptime": get_system_uptime(),
             }
         except Exception as e:
-            logger.error(f"Error getting system stats: {e}")
+            logger.exception(f"Error getting system stats: {e}")
             system_stats = {
                 "cpu": {
                     "total_percent": "Unknown",
@@ -224,7 +224,7 @@ async def get_protected_media_auth(current_user: User = Depends(get_current_user
     try:
         return get_protected_media_auth_config()
     except Exception as e:
-        logger.error(f"Error getting protected media auth config: {e}")
+        logger.exception(f"Error getting protected media auth config: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Error retrieving protected media configuration",

--- a/backend/app/api/endpoints/tags.py
+++ b/backend/app/api/endpoints/tags.py
@@ -196,7 +196,7 @@ def list_tags(
 
         return tags_with_counts
     except Exception as e:
-        logger.error(f"Error in list_tags: {e}")
+        logger.exception(f"Error in list_tags: {e}")
         # If there's an error, return an empty list
         return []
 
@@ -226,7 +226,7 @@ def list_unused_tags(
 
         return unused_tags
     except Exception as e:
-        logger.error(f"Error in list_unused_tags: {e}")
+        logger.exception(f"Error in list_unused_tags: {e}")
         return []
 
 
@@ -269,7 +269,7 @@ def cleanup_unused_tags(
             "message": f"{count} unused tags deleted successfully",
         }
     except Exception as e:
-        logger.error(f"Error in cleanup_unused_tags: {e}")
+        logger.exception(f"Error in cleanup_unused_tags: {e}")
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/app/api/endpoints/tasks.py
+++ b/backend/app/api/endpoints/tasks.py
@@ -233,7 +233,7 @@ def list_tasks(
         )
 
     except Exception as e:
-        logger.error(f"Error in list_tasks: {e}")
+        logger.exception(f"Error in list_tasks: {e}")
         return PaginatedTaskResponse(
             items=[], total=0, page=1, page_size=page_size, total_pages=0, has_more=False
         )
@@ -375,7 +375,7 @@ def recover_all_stuck_tasks(
                                 f"new task ID: {task_id}"
                             )
                         except Exception as e:
-                            logger.error(f"Error retrying transcription: {e}")
+                            logger.exception(f"Error retrying transcription: {e}")
 
                     # Get UUID from the relationship
                     file_uuid = str(task.media_file.uuid) if task.media_file else None
@@ -417,7 +417,7 @@ def trigger_startup_recovery(
                 result = startup_recovery_task.delay()
                 logger.info(f"Manual startup recovery triggered: {result.id}")
             except Exception as e:
-                logger.error(f"Error in manual startup recovery: {e}")
+                logger.exception(f"Error in manual startup recovery: {e}")
 
         background_tasks.add_task(run_recovery)
 
@@ -453,7 +453,7 @@ def trigger_all_user_file_recovery(
                 result = recover_user_files_task.delay()  # No user_id means all users
                 logger.info(f"All user file recovery triggered: {result.id}")
             except Exception as e:
-                logger.error(f"Error in all user file recovery: {e}")
+                logger.exception(f"Error in all user file recovery: {e}")
 
         background_tasks.add_task(run_all_user_recovery)
 
@@ -492,7 +492,7 @@ def trigger_user_file_recovery(
                 result = recover_user_files_task.delay(user_id)
                 logger.info(f"User file recovery triggered for user {user_id}: {result.id}")
             except Exception as e:
-                logger.error(f"Error in user file recovery: {e}")
+                logger.exception(f"Error in user file recovery: {e}")
 
         background_tasks.add_task(run_user_recovery)
 
@@ -548,7 +548,7 @@ def recover_task(
                             f"Retrying transcription for file {file_uuid}, new task ID: {task_id}"
                         )
                     except Exception as e:
-                        logger.error(f"Error retrying transcription: {e}")
+                        logger.exception(f"Error retrying transcription: {e}")
 
                 background_tasks.add_task(retry_transcription)
 
@@ -705,7 +705,7 @@ def retry_file_processing(
                 task_id = dispatch_transcription_pipeline(file_uuid=file_uuid)
                 logger.info(f"Started new transcription for file {file_id}, task ID: {task_id}")
             except Exception as e:
-                logger.error(f"Error starting new transcription: {e}")
+                logger.exception(f"Error starting new transcription: {e}")
 
         background_tasks.add_task(start_new_transcription)
 

--- a/backend/app/api/endpoints/user_files.py
+++ b/backend/app/api/endpoints/user_files.py
@@ -424,7 +424,7 @@ async def request_user_recovery(
                 result = recover_user_files_task.delay(current_user.id)
                 logger.info(f"User {current_user.id} requested file recovery, task ID: {result.id}")
             except Exception as e:
-                logger.error(f"Error in user recovery request: {e}")
+                logger.exception(f"Error in user recovery request: {e}")
 
         background_tasks.add_task(run_user_recovery)
 

--- a/backend/app/api/endpoints/watch_sources.py
+++ b/backend/app/api/endpoints/watch_sources.py
@@ -574,6 +574,9 @@ def test_watch_source(
         with create_client(source) as client:
             ok, message = client.test_connection()
     except Exception as e:  # noqa: BLE001
+        # This endpoint's whole purpose is to report whether the connection
+        # works, so any failure is a successful *test* with a negative result.
+        logger.exception(f"Connection test failed for watch source {source_uuid}")
         return ConnectionTestResponse(success=False, message=str(e))
     return ConnectionTestResponse(
         success=ok, message=message, latency_ms=round((time.perf_counter() - started) * 1000, 1)

--- a/backend/app/auth/pki_auth.py
+++ b/backend/app/auth/pki_auth.py
@@ -495,9 +495,13 @@ def _verify_signature_by_key_type(
         )
         return True
 
+    # FAIL CLOSED. A key type we cannot verify with is not a verified signature.
+    # Returning True here declared an unauthenticated OCSP response authentic;
+    # the caller then accepted its GOOD status as proof of non-revocation.
+    # The supported place to accept an inconclusive revocation check is
+    # PKI_REVOCATION_SOFT_FAIL, not a silent success deep inside verification.
     logger.warning(f"Unsupported public key type for OCSP verification: {type(public_key)}")
-    # Allow verification to proceed as soft-fail for unknown key types
-    return True
+    return False
 
 
 def _verify_ocsp_signature(
@@ -535,14 +539,17 @@ def _verify_ocsp_signature(
         # Determine the hash algorithm from the signature algorithm OID
         hash_algorithm = _get_hash_algorithm_for_sig_oid(sig_alg_oid)
         if hash_algorithm is None:
+            # FAIL CLOSED — see _verify_signature_by_key_type.
             logger.warning(
                 f"Unsupported OCSP signature algorithm {sig_alg_oid} for serial {serial_str}"
             )
-            # Allow verification to proceed as soft-fail for unknown algorithms
-            return True
+            return False
 
         # Verify the signature based on key type
-        _verify_signature_by_key_type(public_key, signature, tbs_data, hash_algorithm, serial_str)
+        if not _verify_signature_by_key_type(
+            public_key, signature, tbs_data, hash_algorithm, serial_str
+        ):
+            return False
 
         logger.debug(f"OCSP response signature verified for serial {serial_str}")
         return True
@@ -550,11 +557,21 @@ def _verify_ocsp_signature(
     except InvalidSignature:
         logger.warning(f"OCSP response signature verification failed for serial {serial_str}")
         return False
-    except Exception as e:
-        logger.warning(f"Could not verify OCSP response signature for serial {serial_str}: {e}")
-        # Soft-fail: allow verification to proceed if we encounter unexpected errors
-        # This handles edge cases like unusual signature algorithms
-        return True
+    except Exception:
+        # FAIL CLOSED. This used to return True ("soft-fail"), which told the
+        # caller an *unverified* OCSP response was authentic. OCSP is fetched
+        # over plain HTTP, so a forged GOOD response — or any malformed one that
+        # made this block raise — was accepted as proof of non-revocation and
+        # cached for PKI_CRL_CACHE_SECONDS. Because a False (= not revoked) OCSP
+        # result returns immediately from _check_revocation, that also skipped
+        # the CRL cross-check and defeated PKI_REVOCATION_SOFT_FAIL=false.
+        # Returning False makes the OCSP check inconclusive, which is what the
+        # CRL fallback and the soft-fail setting exist to handle.
+        logger.exception(
+            f"Could not verify OCSP response signature for serial {serial_str}; "
+            "treating the response as unverified"
+        )
+        return False
 
 
 def _get_ocsp_url(cert: x509.Certificate) -> str | None:
@@ -843,16 +860,22 @@ def _parse_and_verify_crl(
             # Fall back to PEM format
             crl = x509.load_pem_x509_crl(crl_data, default_backend())
 
-        # Verify CRL signature before trusting its contents
-        if issuer_cert:
-            if not _verify_crl_signature(crl, issuer_cert):
-                logger.warning(f"CRL signature verification failed for {crl_url}")
-                return None
-        else:
-            logger.warning(
-                f"No issuer certificate available for CRL signature verification "
-                f"({crl_url}) - proceeding without verification"
+        # Verify CRL signature before trusting its contents. FAIL CLOSED when we
+        # cannot: a CRL is downloaded over the network and drives an
+        # authentication decision, so an unverifiable one must be treated as no
+        # CRL at all (-> inconclusive -> PKI_REVOCATION_SOFT_FAIL decides).
+        # `validate_pki_settings` already requires PKI_CA_CERT_PATH whenever
+        # PKI_VERIFY_REVOCATION is on, so a missing issuer here means the CA file
+        # is unreadable — an operator problem, not a reason to trust the CRL.
+        if issuer_cert is None:
+            logger.error(
+                f"No issuer certificate available to verify the CRL from {crl_url}; "
+                "refusing to trust it"
             )
+            return None
+        if not _verify_crl_signature(crl, issuer_cert):
+            logger.warning(f"CRL signature verification failed for {crl_url}")
+            return None
 
         return crl
     except Exception as e:

--- a/backend/app/services/formatting_service.py
+++ b/backend/app/services/formatting_service.py
@@ -344,8 +344,18 @@ class FormattingService:
                 segment_dict["toxicity"] = segment.toxicity
             else:
                 segment_dict["toxicity"] = None
-        except Exception as e:  # noqa: BLE001 — never break transcript rendering
-            logger.warning(f"Redaction masking failed for a segment: {e}")
+        except Exception:  # noqa: BLE001 — never break transcript rendering
+            # FAIL CLOSED. `segment_dict["text"]` still holds the raw DB text at
+            # this point (it is only overwritten once mask_segment returns), so
+            # the old handler shipped the unredacted segment — including
+            # admin-forced categories — straight to the client. Same bug class as
+            # utils/transcript_builders._seg_text. Withhold the text instead;
+            # rendering keeps working, which is what this handler is here for.
+            logger.exception(
+                "Redaction masking failed for a segment; withholding its text rather than "
+                "returning unmasked content"
+            )
+            segment_dict["text"] = "[redacted — masking unavailable]"
             segment_dict["redactions"] = None
             segment_dict["toxicity"] = None
 

--- a/backend/app/services/gdpr_erasure_service.py
+++ b/backend/app/services/gdpr_erasure_service.py
@@ -70,7 +70,10 @@ ERASURE_SLA_DAYS = 30
 
 
 def _erase_speaker_voiceprints(
-    *, user_id: int | None = None, organization_id: int | None = None
+    *,
+    user_id: int | None = None,
+    organization_id: int | None = None,
+    errors: list[dict[str, Any]] | None = None,
 ) -> int:
     """Delete speaker/profile embedding docs (biometric data) from OpenSearch.
 
@@ -81,11 +84,30 @@ def _erase_speaker_voiceprints(
     storage erasure (those are the legally-binding deletions; this catches
     orphaned biometric docs).
 
+    Args:
+        user_id: Scope the deletion to one user.
+        organization_id: Scope the deletion to one organization.
+        errors: The caller's ``summary["errors"]`` list. Failures are appended
+            here so the erasure is audited as PARTIAL rather than SUCCESS —
+            biometric data surviving an Art. 17 request must not be recorded as
+            a completed erasure.
+
     Returns the number of voiceprint documents deleted (0 if OpenSearch is
     unavailable).
     """
     if user_id is None and organization_id is None:
         return 0
+
+    def _record(reason: str) -> None:
+        if errors is not None:
+            errors.append(
+                {
+                    "stage": "voiceprints",
+                    "user_id": user_id,
+                    "org_id": organization_id,
+                    "error": reason,
+                }
+            )
 
     deleted = 0
     try:
@@ -96,6 +118,7 @@ def _erase_speaker_voiceprints(
 
         if opensearch_client is None:
             logger.warning("OpenSearch unavailable — skipping voiceprint erasure (orphan docs)")
+            _record("OpenSearch client unavailable")
             return 0
 
         terms = []
@@ -119,8 +142,10 @@ def _erase_speaker_voiceprints(
                 deleted += int(resp.get("deleted", 0))
             except Exception as idx_err:  # noqa: BLE001 — best-effort per index
                 logger.warning(f"Voiceprint erasure failed on index {idx}: {idx_err}")
+                _record(f"index {idx}: {idx_err}")
     except Exception as e:  # noqa: BLE001 — OpenSearch optional
         logger.warning(f"Voiceprint erasure skipped (OpenSearch error): {e}")
+        _record(str(e))
 
     if deleted:
         logger.info(
@@ -256,7 +281,9 @@ def erase_user(
     _purge_files(db, files, summary)
     _delete_owner_scoped_rows(db, user_id, summary)
 
-    summary["voiceprints_deleted"] = _erase_speaker_voiceprints(user_id=user_id)
+    summary["voiceprints_deleted"] = _erase_speaker_voiceprints(
+        user_id=user_id, errors=summary["errors"]
+    )
 
     if summary["legal_holds_skipped"]:
         logger.warning(
@@ -357,7 +384,7 @@ def erase_org_member_data(
     db.commit()
 
     summary["voiceprints_deleted"] = _erase_speaker_voiceprints(
-        user_id=user_id, organization_id=org_id
+        user_id=user_id, organization_id=org_id, errors=summary["errors"]
     )
 
     audit_logger.log(
@@ -445,7 +472,9 @@ def erase_organization(
         summary["collections_deleted"] += 1
     db.commit()
 
-    summary["voiceprints_deleted"] = _erase_speaker_voiceprints(organization_id=org_id)
+    summary["voiceprints_deleted"] = _erase_speaker_voiceprints(
+        organization_id=org_id, errors=summary["errors"]
+    )
 
     # Drop the org row (organization_membership rows CASCADE on delete).
     member_count = (

--- a/backend/app/services/opensearch_service/aliases.py
+++ b/backend/app/services/opensearch_service/aliases.py
@@ -5,7 +5,6 @@ The ``speakers`` alias points at a concrete versioned index (``speakers_v3``
 swap, and the cached lookup of whichever concrete index is currently active.
 """
 
-import contextlib
 import logging
 import time
 from typing import Any
@@ -14,6 +13,8 @@ from app.core.constants import get_speaker_index
 from app.core.constants import get_speaker_index_v3
 from app.core.constants import get_speaker_index_v4
 from app.services.opensearch_service import client as _client
+from app.services.opensearch_service.client import CLUSTER_UNAVAILABLE_ERRORS
+from app.services.opensearch_service.client import OpenSearchUnavailableError
 from app.services.opensearch_service.client import _get_alias_target
 from app.services.opensearch_service.client import _get_index_embedding_dimension
 from app.services.opensearch_service.client import _is_alias
@@ -28,14 +29,43 @@ _active_index_cache: tuple[str, float] | None = None
 _ACTIVE_INDEX_CACHE_TTL = 30.0  # seconds
 
 
+def _count_docs(index_name: str) -> int | None:
+    """Count documents in an index.
+
+    Args:
+        index_name: Index or alias to count.
+
+    Returns:
+        The document count, or **None** when the count could not be obtained.
+        None is deliberately distinct from 0: callers use a zero count to
+        authorise deleting an index, and an unanswered count must never be
+        read as "empty".
+    """
+    if not _client.opensearch_client:
+        return None
+    try:
+        return int(_client.opensearch_client.count(index=index_name)["count"])
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        logger.warning(f"Could not count docs in '{index_name}': {e}")
+        return None
+
+
 def get_active_versioned_index() -> str:
     """Get the concrete versioned index name that the 'speakers' alias points to.
 
     Returns the alias target (e.g. 'speakers_v3' or 'speakers_v4'), or
-    falls back to get_speaker_index() if aliases haven't been set up yet.
+    falls back to get_speaker_index() if aliases haven't been set up yet or
+    OpenSearch is unreachable.
     """
     alias_name = get_speaker_index()
-    target = _get_alias_target(alias_name)
+    try:
+        target = _get_alias_target(alias_name)
+    except OpenSearchUnavailableError as e:
+        # Same fallback as "alias not set up", but no longer silent: callers
+        # index and search against the returned name, so a wrong answer here
+        # is worth an operator-visible log line.
+        logger.error(f"Could not resolve the speaker alias, falling back to '{alias_name}': {e}")
+        return alias_name
     if target:
         return target
     # Fallback: alias not set up yet (pre-migration state)
@@ -72,12 +102,29 @@ def migrate_to_alias_based_indices() -> dict[str, Any]:
 
     Returns dict with migration status details.
     """
+    if not _client.opensearch_client:
+        return {"status": "skipped", "reason": "no_client"}
+
+    try:
+        return _migrate_to_alias_based_indices()
+    except OpenSearchUnavailableError as e:
+        # Fail CLOSED. Every branch of the migration decides whether to create,
+        # alias, reindex or DELETE a live index, and it decides from index-
+        # existence and document-count answers. When the cluster cannot answer,
+        # those used to read as "nothing is there" — which routes straight into
+        # the delete branch. Aborting is always the safe move: the migration is
+        # idempotent and re-runs on the next startup.
+        logger.error(f"Speaker alias migration aborted — OpenSearch unavailable: {e}")
+        return {"status": "error", "reason": "opensearch_unavailable"}
+
+
+def _migrate_to_alias_based_indices() -> dict[str, Any]:
+    """Body of :func:`migrate_to_alias_based_indices`; see it for semantics."""
     from app.core.constants import PYANNOTE_EMBEDDING_DIMENSION_V3
     from app.core.constants import PYANNOTE_EMBEDDING_DIMENSION_V4
     from app.core.constants import get_speaker_index_v3_backup
 
-    if not _client.opensearch_client:
-        return {"status": "skipped", "reason": "no_client"}
+    assert _client.opensearch_client is not None  # noqa: S101 - checked by caller
 
     alias_name = get_speaker_index()  # "speakers"
     v3_index = get_speaker_index_v3()  # "speakers_v3"
@@ -91,11 +138,7 @@ def migrate_to_alias_based_indices() -> dict[str, Any]:
         return {"status": "already_migrated", "alias_target": target}
 
     # Check if 'speakers' exists as a concrete index
-    concrete_exists = False
-    with contextlib.suppress(Exception):
-        concrete_exists = _client.opensearch_client.indices.exists(index=alias_name)
-
-    if not concrete_exists:
+    if not _safe_index_exists(alias_name):
         # Fresh install OR the index was deleted. Check for versioned indices.
         v3_exists = _safe_index_exists(v3_index)
         v4_exists = _safe_index_exists(v4_index)
@@ -119,9 +162,7 @@ def migrate_to_alias_based_indices() -> dict[str, Any]:
 
     # 'speakers' is a concrete index — need to detect its dimension and rename
     dimension = _get_index_embedding_dimension(alias_name)
-    doc_count = 0
-    with contextlib.suppress(Exception):
-        doc_count = _client.opensearch_client.count(index=alias_name)["count"]
+    doc_count = _count_docs(alias_name)
 
     if dimension == PYANNOTE_EMBEDDING_DIMENSION_V3 or dimension == 512:
         target_index = v3_index
@@ -130,21 +171,43 @@ def migrate_to_alias_based_indices() -> dict[str, Any]:
         target_index = v4_index
         mode_label = "v4"
     elif doc_count == 0:
-        # Empty index with unknown dimension — delete and let ensure_indices_exist handle it
+        # Confirmed-empty index with unknown dimension — delete and let
+        # ensure_indices_exist recreate it. `doc_count is None` (count did not
+        # answer) must NOT reach here; see the guard below.
         _client.opensearch_client.indices.delete(index=alias_name)
         logger.info(f"Deleted empty concrete '{alias_name}' index (no dimension detected)")
         return {"status": "deleted_empty"}
+    elif doc_count is None:
+        # Unknown dimension AND unknown doc count: refuse to guess.
+        logger.error(
+            f"Refusing to migrate '{alias_name}': its embedding dimension and document "
+            "count are both unknown. Retrying on the next startup."
+        )
+        return {"status": "error", "reason": "indeterminate_index_state"}
     else:
         # Unknown dimension with data — default to v3 to be safe
         target_index = v3_index
         mode_label = "v3 (fallback)"
 
+    if doc_count is None:
+        logger.error(
+            f"Refusing to migrate '{alias_name}' → '{target_index}': its document count "
+            "is unknown, so the merge direction cannot be decided safely."
+        )
+        return {"status": "error", "reason": "indeterminate_doc_count"}
+
     # Check if the target versioned index already exists
     if _safe_index_exists(target_index):
-        # Both concrete 'speakers' and versioned index exist — check which has more data
-        target_count = 0
-        with contextlib.suppress(Exception):
-            target_count = _client.opensearch_client.count(index=target_index)["count"]
+        # Both concrete 'speakers' and the versioned index exist. Whichever has
+        # fewer docs gets deleted, so an unanswered count cannot be defaulted —
+        # either default destroys the wrong copy. Abort instead.
+        target_count = _count_docs(target_index)
+        if target_count is None:
+            logger.error(
+                f"Refusing to reconcile '{alias_name}' and '{target_index}': the document "
+                f"count for '{target_index}' is unknown, and the loser is deleted."
+            )
+            return {"status": "error", "reason": "indeterminate_doc_count"}
 
         if target_count >= doc_count:
             # Versioned index has more/equal data — just delete concrete and alias
@@ -204,7 +267,11 @@ def _reindex_and_alias(source_index: str, target_index: str, alias_name: str) ->
             target_config["settings"]["index"]["knn"] = True
 
         _client.opensearch_client.indices.create(index=target_index, body=target_config)
-    except Exception as e:
+    except (*CLUSTER_UNAVAILABLE_ERRORS, KeyError) as e:
+        # Best-effort: the target may already exist, or the source mapping may be
+        # unreadable. Falling through to a plain reindex is correct — and if the
+        # cluster is genuinely down, the unguarded reindex below raises anyway,
+        # before anything is deleted.
         logger.warning(f"Could not create target from source mapping: {e}. Trying plain reindex.")
 
     # Reindex data
@@ -306,20 +373,14 @@ def get_active_speaker_index() -> str:
 
     result = main_index
     try:
-        # If alias is set up, check if v4 staging has more data (pre-finalization)
-        main_count = 0
-        v4_count = 0
-
         # Count through alias (resolves to active versioned index)
-        with contextlib.suppress(Exception):
-            main_count = _client.opensearch_client.count(index=main_index)["count"]
+        main_count = _count_docs(main_index) or 0
 
         if _safe_index_exists(v4_index):
             # Only check v4 if it's NOT the alias target (i.e., during pre-finalization)
             alias_target = _get_alias_target(main_index)
             if alias_target != v4_index:
-                with contextlib.suppress(Exception):
-                    v4_count = _client.opensearch_client.count(index=v4_index)["count"]
+                v4_count = _count_docs(v4_index) or 0
 
                 if v4_count > main_count:
                     logger.debug(
@@ -330,8 +391,11 @@ def get_active_speaker_index() -> str:
                     )
                     result = v4_index
 
-    except Exception as e:
-        logger.debug("Error detecting active speaker index: %s", e)
+    except OpenSearchUnavailableError as e:
+        # Read path: keeping the alias is the correct degrade (it is what the
+        # v4 staging check exists to *refine*), but do not cache the guess.
+        logger.warning(f"Could not detect the active speaker index, using '{main_index}': {e}")
+        return main_index
 
     _active_index_cache = (result, now)
     return result

--- a/backend/app/services/opensearch_service/client.py
+++ b/backend/app/services/opensearch_service/client.py
@@ -4,6 +4,12 @@ Owns the process-wide ``opensearch_client`` singleton. Every other module in
 this package reads it through this module (``client.opensearch_client``) so the
 lazy re-initialisation performed by :func:`get_opensearch_client` is visible
 everywhere.
+
+The index-introspection helpers below deliberately separate **"the thing is
+absent"** from **"the cluster could not answer"**. Collapsing the two (the
+previous ``except Exception: return False``) made a misconfigured or
+unreachable cluster indistinguishable from an empty one — and callers use
+these answers to decide whether to create, alias, or *delete* an index.
 """
 
 import logging
@@ -11,11 +17,37 @@ from typing import Any
 
 from opensearchpy import OpenSearch
 from opensearchpy import RequestsHttpConnection
+from opensearchpy.exceptions import ConnectionError as OpenSearchConnectionError
+from opensearchpy.exceptions import ImproperlyConfigured
+from opensearchpy.exceptions import NotFoundError
+from opensearchpy.exceptions import SerializationError
+from opensearchpy.exceptions import TransportError
 
 from app.core.config import settings
 from app.core.opensearch_auth import opensearch_connection_kwargs
 
 logger = logging.getLogger(__name__)
+
+
+class OpenSearchUnavailableError(RuntimeError):
+    """The cluster could not answer a request (connection/auth/transport).
+
+    Raised by the index-introspection helpers instead of returning a
+    "not present" answer, so a broken cluster can never be mistaken for an
+    empty one by index bootstrap, alias migration, or index deletion logic.
+    """
+
+
+# Errors that mean "the cluster could not answer", as opposed to NotFoundError
+# which means "the cluster answered: that index/alias does not exist".
+# NotFoundError also subclasses TransportError, so it must be caught FIRST.
+CLUSTER_UNAVAILABLE_ERRORS = (
+    OpenSearchConnectionError,  # includes ConnectionTimeout and SSLError
+    TransportError,  # includes Authentication/Authorization/Request/Conflict
+    SerializationError,
+    ImproperlyConfigured,
+    OSError,  # builtin socket/DNS failures raised below opensearch-py
+)
 
 
 # Initialize the OpenSearch client (skipped when OPENSEARCH_ENABLED=false)
@@ -29,11 +61,13 @@ else:
             **opensearch_connection_kwargs(connection_class=RequestsHttpConnection)
         )
         logger.info("OpenSearch client initialized successfully")
-    except (ConnectionError, ValueError) as e:
+    except (ImproperlyConfigured, OpenSearchConnectionError, ValueError, OSError) as e:
         logger.error(f"Configuration error initializing OpenSearch client: {e}")
         opensearch_client = None
-    except Exception as e:
-        logger.error(f"Unexpected error initializing OpenSearch client: {e}")
+    except Exception:
+        # Construction is pure config parsing; anything else is unexpected, but
+        # a bad OpenSearch config must not prevent the process from booting.
+        logger.exception("Unexpected error initializing OpenSearch client")
         opensearch_client = None
 
 
@@ -85,23 +119,46 @@ def get_opensearch_client() -> "OpenSearch | None":
         )
         logger.info("OpenSearch client lazily initialized successfully")
         return opensearch_client
-    except Exception as e:
+    except (ImproperlyConfigured, OpenSearchConnectionError, ValueError, OSError) as e:
         logger.warning(f"Lazy OpenSearch client initialization failed: {e}")
         return None
 
 
 def _is_alias(name: str) -> bool:
-    """Check if a name is an alias (not a concrete index)."""
+    """Report whether ``name`` resolves to an alias rather than a concrete index.
+
+    Args:
+        name: Alias or index name to test.
+
+    Returns:
+        True if ``name`` is an alias; False if the cluster answered that it is
+        not (absent, or a concrete index).
+
+    Raises:
+        OpenSearchUnavailableError: The cluster could not answer.
+    """
     if not opensearch_client:
         return False
     try:
         return bool(opensearch_client.indices.exists_alias(name=name))
-    except Exception:
+    except NotFoundError:
         return False
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        raise OpenSearchUnavailableError(f"Could not check alias '{name}': {e}") from e
 
 
 def _get_alias_target(alias_name: str) -> str | None:
-    """Get the concrete index an alias points to. Returns None if not an alias."""
+    """Resolve the concrete index an alias points to.
+
+    Args:
+        alias_name: Alias to resolve.
+
+    Returns:
+        The concrete index name, or None if ``alias_name`` is not an alias.
+
+    Raises:
+        OpenSearchUnavailableError: The cluster could not answer.
+    """
     if not opensearch_client:
         return None
     try:
@@ -109,31 +166,65 @@ def _get_alias_target(alias_name: str) -> str | None:
         # result is {concrete_index_name: {aliases: {alias_name: {}}}}
         indices = list(result.keys())
         return indices[0] if indices else None
-    except Exception:
+    except NotFoundError:
         return None
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        raise OpenSearchUnavailableError(f"Could not resolve alias '{alias_name}': {e}") from e
 
 
 def _safe_index_exists(index_name: str) -> bool:
-    """Check if an index exists, returning False on any error."""
+    """Report whether a concrete index exists.
+
+    Args:
+        index_name: Index to test.
+
+    Returns:
+        True if the index exists, False if the cluster answered that it does not.
+
+    Raises:
+        OpenSearchUnavailableError: The cluster could not answer. Callers must
+            not treat this as "absent" — see the module docstring.
+    """
     if not opensearch_client:
         return False
     try:
         return bool(opensearch_client.indices.exists(index=index_name))
-    except Exception:
+    except NotFoundError:
         return False
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        raise OpenSearchUnavailableError(f"Could not check index '{index_name}': {e}") from e
 
 
 def _get_index_embedding_dimension(index_name: str) -> int | None:
-    """Get the knn_vector dimension from an index's mapping."""
+    """Read the ``embedding`` knn_vector dimension from an index mapping.
+
+    Args:
+        index_name: Index whose mapping to read.
+
+    Returns:
+        The declared dimension, or None when the index has no ``embedding``
+        field, no declared dimension, or does not exist.
+
+    Raises:
+        OpenSearchUnavailableError: The cluster could not answer.
+    """
     if not opensearch_client:
         return None
     try:
         mapping = opensearch_client.indices.get_mapping(index=index_name)
-        props = mapping.get(index_name, {}).get("mappings", {}).get("properties", {})
-        emb = props.get("embedding", {})
-        dim = emb.get("dimension")
-        return int(dim) if dim is not None else None
-    except Exception:
+    except NotFoundError:
+        return None
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        raise OpenSearchUnavailableError(f"Could not read mapping for '{index_name}': {e}") from e
+
+    props = mapping.get(index_name, {}).get("mappings", {}).get("properties", {})
+    dim = props.get("embedding", {}).get("dimension")
+    if dim is None:
+        return None
+    try:
+        return int(dim)
+    except (TypeError, ValueError):
+        logger.warning(f"Index '{index_name}' declares a non-numeric embedding dimension: {dim!r}")
         return None
 
 

--- a/backend/app/services/opensearch_service/indices.py
+++ b/backend/app/services/opensearch_service/indices.py
@@ -1,6 +1,5 @@
 """Index creation / bootstrap for the transcript and speaker indices."""
 
-import contextlib
 import logging
 
 from app.core.config import settings
@@ -10,7 +9,10 @@ from app.core.constants import get_speaker_index
 from app.core.constants import get_speaker_index_v3
 from app.core.constants import get_speaker_index_v4
 from app.services.opensearch_service import client as _client
+from app.services.opensearch_service.aliases import _count_docs
 from app.services.opensearch_service.aliases import migrate_to_alias_based_indices
+from app.services.opensearch_service.client import CLUSTER_UNAVAILABLE_ERRORS
+from app.services.opensearch_service.client import OpenSearchUnavailableError
 from app.services.opensearch_service.client import _is_alias
 from app.services.opensearch_service.client import _safe_index_exists
 
@@ -60,8 +62,65 @@ def _ensure_versioned_speaker_index(index_name: str, dimension: int) -> None:
         }
         _client.opensearch_client.indices.create(index=index_name, body=config)
         logger.info(f"Created versioned speaker index: {index_name} (dim={dimension})")
-    except Exception as e:
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
         logger.error(f"Error creating speaker index {index_name}: {e}")
+
+
+def _restore_v3_from_backup(v3_index: str) -> None:
+    """Reindex the legacy ``speakers_v3_backup`` into ``speakers_v3`` when empty.
+
+    No-op unless both indices exist, ``v3_index`` is **confirmed** empty, and the
+    backup has documents. A count that could not be obtained reads as None, not
+    0, so an unreachable cluster never triggers a restore.
+
+    Args:
+        v3_index: The concrete v3 speaker index to restore into.
+    """
+    from app.core.constants import get_speaker_index_v3_backup
+
+    if not _client.opensearch_client:
+        return
+
+    v3_backup = get_speaker_index_v3_backup()
+    if not (_safe_index_exists(v3_backup) and _safe_index_exists(v3_index)):
+        return
+    if _count_docs(v3_index) != 0:
+        return
+    backup_count = _count_docs(v3_backup) or 0
+    if backup_count == 0:
+        return
+
+    try:
+        # Filter: only reindex docs with valid embeddings that match the v3
+        # dimension (512). Docs with null embeddings or wrong dimensions would
+        # fail knn_vector parsing.
+        result = _client.opensearch_client.reindex(
+            body={
+                "source": {
+                    "index": v3_backup,
+                    "query": {
+                        "bool": {
+                            "must": [{"exists": {"field": "embedding"}}],
+                            "must_not": [{"term": {"embedding": []}}],
+                        }
+                    },
+                },
+                "dest": {"index": v3_index},
+            },
+            wait_for_completion=True,
+        )
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        logger.warning(f"Failed to restore v3 backup: {e}")
+        return
+
+    restored = result.get("created", 0) + result.get("updated", 0)
+    failures = result.get("failures", [])
+    logger.info(
+        f"Restored {restored} docs from '{v3_backup}' → '{v3_index}' "
+        f"({len(failures)} failures, backup had {backup_count} docs)"
+    )
+    for f in failures[:3]:
+        logger.warning(f"Reindex failure: {f.get('cause', {}).get('reason', f)}")
 
 
 def ensure_indices_exist():
@@ -123,52 +182,7 @@ def ensure_indices_exist():
         _ensure_versioned_speaker_index(v3_index, PYANNOTE_EMBEDDING_DIMENSION_V3)
         _ensure_versioned_speaker_index(get_speaker_index_v4(), PYANNOTE_EMBEDDING_DIMENSION_V4)
 
-        # Restore v3 data from legacy backup if speakers_v3 is empty
-        from app.core.constants import get_speaker_index_v3_backup
-
-        v3_backup = get_speaker_index_v3_backup()
-        if _safe_index_exists(v3_backup) and _safe_index_exists(v3_index):
-            v3_count = 0
-            with contextlib.suppress(Exception):
-                v3_count = _client.opensearch_client.count(index=v3_index)["count"]
-            if v3_count == 0:
-                backup_count = 0
-                with contextlib.suppress(Exception):
-                    backup_count = _client.opensearch_client.count(index=v3_backup)["count"]
-                if backup_count > 0:
-                    try:
-                        # Filter: only reindex docs with valid embeddings that
-                        # match the v3 dimension (512). Docs with null embeddings
-                        # or wrong dimensions would fail knn_vector parsing.
-                        result = _client.opensearch_client.reindex(
-                            body={
-                                "source": {
-                                    "index": v3_backup,
-                                    "query": {
-                                        "bool": {
-                                            "must": [{"exists": {"field": "embedding"}}],
-                                            "must_not": [{"term": {"embedding": []}}],
-                                        }
-                                    },
-                                },
-                                "dest": {"index": v3_index},
-                            },
-                            wait_for_completion=True,
-                        )
-                        restored = result.get("created", 0) + result.get("updated", 0)
-                        failures = len(result.get("failures", []))
-                        logger.info(
-                            f"Restored {restored} docs from '{v3_backup}' → '{v3_index}' "
-                            f"({failures} failures, backup had {backup_count} docs)"
-                        )
-                        if failures > 0:
-                            # Log first few failures for debugging
-                            for f in result.get("failures", [])[:3]:
-                                logger.warning(
-                                    f"Reindex failure: {f.get('cause', {}).get('reason', f)}"
-                                )
-                    except Exception as e:
-                        logger.warning(f"Failed to restore v3 backup: {e}")
+        _restore_v3_from_backup(v3_index)
 
         # Ensure the 'speakers' alias exists pointing to something
         alias_name = get_speaker_index()
@@ -179,12 +193,19 @@ def ensure_indices_exist():
                 _client.opensearch_client.indices.put_alias(index=target, name=alias_name)
                 logger.info(f"Created default alias: {alias_name} → {target}")
 
-    except ConnectionError as e:
-        logger.error(f"Connection error creating indices: {e}")
+    except OpenSearchUnavailableError as e:
+        logger.error(f"Index bootstrap aborted — OpenSearch unavailable: {e}")
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        # The previous handler was `except ConnectionError` — the *builtin*,
+        # which opensearch-py's ConnectionError does not subclass, so every
+        # cluster failure fell through to the generic handler below.
+        logger.error(f"OpenSearch error creating indices: {e}")
     except ValueError as e:
         logger.error(f"Configuration error creating indices: {e}")
-    except Exception as e:
-        logger.error(f"Unexpected error creating indices: {e}")
+    except Exception:
+        # Startup path: index bootstrap must never take the process down, so a
+        # genuinely unexpected error is swallowed — but with a full traceback.
+        logger.exception("Unexpected error creating indices")
 
 
 def create_speaker_index_v4(index_name: str | None = None) -> bool:
@@ -258,7 +279,7 @@ def create_speaker_index_v4(index_name: str | None = None) -> bool:
         logger.info(f"Created v4 speaker index: {index_name}")
         return True
 
-    except Exception as e:
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
         logger.error(f"Error creating v4 speaker index: {e}")
         return False
 
@@ -271,9 +292,9 @@ def ensure_v4_index_exists() -> bool:
 
     v4_index = get_speaker_index_v4()
     try:
-        if _client.opensearch_client.indices.exists(index=v4_index):
+        if _safe_index_exists(v4_index):
             return True
-    except Exception as e:
+    except OpenSearchUnavailableError as e:
         logger.warning(f"Error checking v4 index existence: {e}")
 
     return create_speaker_index_v4()

--- a/backend/app/services/opensearch_service/profiles.py
+++ b/backend/app/services/opensearch_service/profiles.py
@@ -4,9 +4,14 @@ import datetime
 import logging
 from typing import Any
 
+from opensearchpy.exceptions import NotFoundError
+
 from app.core.constants import get_speaker_index
 from app.core.constants import get_speaker_index_v4
 from app.services.opensearch_service import client as _client
+from app.services.opensearch_service.client import CLUSTER_UNAVAILABLE_ERRORS
+from app.services.opensearch_service.client import OpenSearchUnavailableError
+from app.services.opensearch_service.client import _safe_index_exists
 from app.services.opensearch_service.client import _speaker_org_filter_clauses
 from app.services.opensearch_service.indices import ensure_indices_exist
 
@@ -293,17 +298,23 @@ def remove_profile_embedding(profile_uuid: str) -> bool:
         _client.opensearch_client.delete(index=get_speaker_index(), id=doc_id)
         logger.info(f"Removed profile {profile_uuid} embedding from main index")
         success = True
-    except Exception as e:
-        logger.warning(f"Error removing profile embedding from main index (may not exist): {e}")
+    except NotFoundError:
+        logger.debug(f"Profile {profile_uuid} not present in the main speaker index")
+    except CLUSTER_UNAVAILABLE_ERRORS as e:
+        logger.warning(f"Error removing profile {profile_uuid} embedding from main index: {e}")
 
-    # Also clean v4 staging index if it exists
+    # Also clean the v4 staging index. Best-effort by design: the staging index
+    # is rebuilt by the migration task, so a stale doc there is self-correcting
+    # and must not fail the caller's main-index delete.
     try:
         v4_index = get_speaker_index_v4()
-        if _client.opensearch_client.indices.exists(index=v4_index):
+        if _safe_index_exists(v4_index):
             _client.opensearch_client.delete(index=v4_index, id=doc_id)
             logger.debug(f"Removed profile {profile_uuid} from v4 staging index")
-    except Exception:  # nosec B110
-        pass  # Non-fatal
+    except NotFoundError:
+        logger.debug(f"Profile {profile_uuid} not present in the v4 staging index")
+    except (OpenSearchUnavailableError, *CLUSTER_UNAVAILABLE_ERRORS) as e:
+        logger.warning(f"Could not clean profile {profile_uuid} from the v4 staging index: {e}")
 
     return success
 

--- a/backend/app/services/opensearch_service/speaker_maintenance.py
+++ b/backend/app/services/opensearch_service/speaker_maintenance.py
@@ -3,10 +3,14 @@
 import datetime
 import logging
 
+from opensearchpy.exceptions import NotFoundError
+
 from app.core.constants import get_speaker_index
 from app.core.constants import get_speaker_index_v3
 from app.core.constants import get_speaker_index_v4
 from app.services.opensearch_service import client as _client
+from app.services.opensearch_service.client import CLUSTER_UNAVAILABLE_ERRORS
+from app.services.opensearch_service.client import OpenSearchUnavailableError
 from app.services.opensearch_service.client import _is_alias
 from app.services.opensearch_service.client import _safe_index_exists
 from app.services.opensearch_service.indices import ensure_indices_exist
@@ -123,7 +127,9 @@ def remove_speaker_embedding(speaker_uuid: str) -> bool:
 
     success = False
 
-    # Delete from all speaker indices (v3, v4, and alias target)
+    # Delete from all speaker indices (v3, v4, and alias target). Each index is
+    # independent: a speaker normally lives in only one of them, so "absent" is
+    # the common case and must not stop the loop.
     indices_to_clean = {get_speaker_index(), get_speaker_index_v3(), get_speaker_index_v4()}
     for idx in indices_to_clean:
         try:
@@ -131,8 +137,13 @@ def remove_speaker_embedding(speaker_uuid: str) -> bool:
                 _client.opensearch_client.delete(index=idx, id=str(speaker_uuid))
                 logger.debug(f"Removed speaker {speaker_uuid} from {idx}")
                 success = True
-        except Exception:  # nosec B110
-            pass  # Non-fatal: speaker may not exist in this index
+        except NotFoundError:
+            logger.debug(f"Speaker {speaker_uuid} not present in {idx}")
+        except (OpenSearchUnavailableError, *CLUSTER_UNAVAILABLE_ERRORS) as e:
+            # A real failure to delete leaves an orphan voiceprint behind, so it
+            # is reported (the periodic consistency task reconciles it) but does
+            # not abort cleanup of the remaining indices.
+            logger.warning(f"Could not remove speaker {speaker_uuid} from {idx}: {e}")
 
     if success:
         logger.info(f"Removed speaker {speaker_uuid} from speaker indices")

--- a/backend/app/services/search/hybrid_search_service.py
+++ b/backend/app/services/search/hybrid_search_service.py
@@ -665,8 +665,17 @@ class HybridSearchService:
 
             with session_scope() as db:
                 cfg = resolve_effective_config(db, user_id)
-        except Exception as exc:  # noqa: BLE001 — never break search on redaction failure
-            logger.debug("Snippet redaction config unavailable: %s", exc)
+        except Exception:  # noqa: BLE001 — never break search on redaction failure
+            # FAIL CLOSED. Returning here rendered every snippet unmasked. The
+            # scope is narrow (profanity + custom wordlist only — this path
+            # never carries PII spans), but it is still a policy bypass, so drop
+            # the snippets rather than show unmasked ones. Results, counts and
+            # ranking are unaffected; only the preview text is withheld.
+            logger.exception("Snippet redaction config unavailable; withholding snippet text")
+            for hit in getattr(result, "results", []) or []:
+                for occ in getattr(hit, "occurrences", []) or []:
+                    if getattr(occ, "snippet", None):
+                        occ.snippet = "[redacted — masking unavailable]"
             return
 
         if not cfg.enabled:

--- a/backend/app/services/subtitle_service.py
+++ b/backend/app/services/subtitle_service.py
@@ -5,6 +5,7 @@ Supports overlapping speech display where multiple speakers talk simultaneously.
 """
 
 import io
+import logging
 import re
 import textwrap
 import zipfile
@@ -21,6 +22,8 @@ from app.models.media import Speaker
 from app.models.media import TranscriptSegment
 from app.utils.time_format import format_srt_timestamp
 from app.utils.time_format import format_timestamp_simple
+
+logger = logging.getLogger(__name__)
 
 
 class SubtitleService:
@@ -129,13 +132,11 @@ class SubtitleService:
         """
         if redaction_cfg is None or not getattr(redaction_cfg, "enabled", False):
             return
-        import contextlib
 
         from app.services.redaction.service import RedactionService
 
         for seg in segments:
-            # Never break export rendering if masking a single segment fails.
-            with contextlib.suppress(Exception):
+            try:
                 masked, _ = RedactionService.mask_segment(
                     str(seg.text or ""),
                     seg.redactions or [],
@@ -143,7 +144,19 @@ class SubtitleService:
                     redaction_cfg,
                     reveal_categories or set(),
                 )
-                seg.text = masked
+            except Exception:
+                # FAIL CLOSED. The assignment used to sit inside a
+                # `contextlib.suppress(Exception)`, so a masking failure left
+                # `seg.text` as the raw DB text and every downstream formatter
+                # wrote it into the exported subtitle file. Redaction is enabled
+                # here by definition, so substitute a placeholder: a rendering
+                # gap is recoverable, an exported unmasked file is not.
+                logger.exception(
+                    "Redaction masking failed for a segment; withholding its text from the export"
+                )
+                seg.text = "[redacted — masking unavailable]"
+                continue
+            seg.text = masked
 
     @staticmethod
     def _format_overlap_for_subtitle(

--- a/backend/app/tasks/README.md
+++ b/backend/app/tasks/README.md
@@ -70,10 +70,13 @@ tasks/
 The transcription pipeline runs as three chained Celery tasks, separating concerns and allowing the GPU worker to be freed as early as possible:
 
 ```
-preprocess_task  →  gpu_transcription_task  →  postprocess_task
-(download audio)    (WhisperX + PyAnnote)       (index + notify + dispatch enrichment)
-     CPU                   GPU                          CPU
+preprocess_for_transcription  →  transcribe_gpu_task  →  finalize_transcription
+     (download audio)            (WhisperX + PyAnnote)   (index + notify + dispatch)
+          CPU                            GPU                      CPU
 ```
+
+Celery task names: `transcription.preprocess` → `transcription.gpu_transcribe` →
+`transcription.postprocess`.
 
 Enrichment tasks (speaker embedding, LLM identification) are dispatched asynchronously from postprocess — they do not block the GPU worker.
 
@@ -81,14 +84,14 @@ Enrichment tasks (speaker embedding, LLM identification) are dispatched asynchro
 - Downloads file from MinIO
 - Extracts audio with FFmpeg
 - Extracts media metadata with ExifTool
-- Dispatches `gpu_transcription_task`
+- Dispatches `transcribe_gpu_task`
 
 ### Stage 2: GPU Transcription (`core.py`)
 Main GPU-side orchestrator:
 
 ```python
-@celery_app.task(bind=True, name="gpu_transcription_task", queue="gpu")
-def gpu_transcription_task(self, file_id: int):
+@celery_app.task(bind=True, name="transcription.gpu_transcribe", queue=CeleryQueues.GPU)
+def transcribe_gpu_task(self, preprocess_context: dict) -> dict:
     """
     Run WhisperX transcription + PyAnnote speaker diarization.
 
@@ -97,7 +100,7 @@ def gpu_transcription_task(self, file_id: int):
     2. Run WhisperX with configured model (admin-pinned via SystemSettings)
     3. Run PyAnnote speaker diarization
     4. Process and store transcript segments
-    5. Dispatch postprocess_task
+    5. Chain into finalize_transcription
     """
 ```
 
@@ -572,20 +575,20 @@ with session_scope() as db:
 ```python
 def test_preprocess_task_success(celery_app, db_session, sample_file):
     """Test successful preprocess task (stage 1)."""
-    from app.tasks.transcription.preprocess import preprocess_task
+    from app.tasks.transcription.preprocess import preprocess_for_transcription
 
     with patch('app.services.minio_service.download_file') as mock_download:
         mock_download.return_value = (sample_audio_data, 1024, "audio/wav")
 
-        result = preprocess_task.apply(args=[sample_file.id])
+        result = preprocess_for_transcription.apply(args=[sample_file.id])
 
         assert result.successful()
 
 def test_gpu_transcription_task_failure(celery_app, db_session, invalid_file):
     """Test GPU transcription task failure handling (stage 2)."""
-    from app.tasks.transcription.core import gpu_transcription_task
+    from app.tasks.transcription.core import transcribe_gpu_task
 
-    result = gpu_transcription_task.apply(args=[invalid_file.id])
+    result = transcribe_gpu_task.apply(args=[invalid_file.id])
     assert result.failed()
     # Verify file status set to ERROR and user notified
 ```

--- a/backend/app/tasks/speaker_identification_task.py
+++ b/backend/app/tasks/speaker_identification_task.py
@@ -335,8 +335,32 @@ def identify_speakers_llm_task(self, file_uuid: str):
                 update_task_status(db, task_id, "completed", progress=1.0, completed=True)
                 return {"status": "skipped", "message": "No speakers to identify"}
 
-            full_transcript = build_full_transcript(transcript_segments)
-            speaker_segments = build_speaker_segments(transcript_segments)
+            # Redact PII/profanity before the transcript leaves for the LLM
+            # provider, exactly as the summarization task does. This path used
+            # to pass no config at all, so `redact_before_llm` (and the admin
+            # `force_redact_before_llm` floor) had no effect on speaker
+            # identification. Fail closed if the policy cannot be resolved.
+            try:
+                from app.services.redaction.config import resolve_effective_config
+
+                _redact_cfg = resolve_effective_config(db, int(media_file.user_id))
+            except Exception as _redact_err:
+                logger.exception(
+                    "Could not resolve the redaction policy; aborting speaker identification "
+                    "rather than sending a possibly unredacted transcript to an external provider"
+                )
+                raise ValueError(
+                    "Redaction policy unavailable; speaker identification aborted to avoid "
+                    "sending unredacted content to an external provider"
+                ) from _redact_err
+
+            llm_redaction_cfg = (
+                _redact_cfg if (_redact_cfg.enabled and _redact_cfg.redact_before_llm) else None
+            )
+            full_transcript = build_full_transcript(transcript_segments, llm_redaction_cfg)
+            speaker_segments = build_speaker_segments(
+                transcript_segments, redaction_cfg=llm_redaction_cfg
+            )
             known_speakers = _get_known_speakers(db, int(media_file.user_id))
             metadata_context = _build_metadata_context(media_file)
             if metadata_context:

--- a/backend/app/tasks/summarization.py
+++ b/backend/app/tasks/summarization.py
@@ -532,15 +532,28 @@ def summarize_transcript_task(
 
             # Redact PII/profanity before sending to the LLM provider when the
             # owner's (or admin-forced) policy requires it (don't leak to third parties).
-            redaction_cfg = None
             try:
                 from app.services.redaction.config import resolve_effective_config
 
                 _cfg = resolve_effective_config(db, int(media_file.user_id))
-                if _cfg.enabled and _cfg.redact_before_llm:
-                    redaction_cfg = _cfg
-            except Exception as _redact_err:  # noqa: BLE001
-                logger.debug(f"Redaction config for LLM unavailable: {_redact_err}")
+            except Exception as _redact_err:
+                # FAIL CLOSED. Leaving redaction_cfg as None made `_seg_text`
+                # take its "redaction disabled" early return, so the full
+                # unredacted transcript was posted to an EXTERNAL LLM provider —
+                # defeating both `redact_before_llm` and the admin
+                # `force_redact_before_llm` floor, and it was logged at debug so
+                # the leak was silent. We cannot prove redaction is unnecessary,
+                # so we do not send the transcript off-box at all.
+                logger.exception(
+                    "Could not resolve the redaction policy; aborting summarization rather "
+                    "than sending a possibly unredacted transcript to an external provider"
+                )
+                raise ValueError(
+                    "Redaction policy unavailable; summarization aborted to avoid "
+                    "sending unredacted content to an external provider"
+                ) from _redact_err
+
+            redaction_cfg = _cfg if (_cfg.enabled and _cfg.redact_before_llm) else None
 
             full_transcript, speaker_stats = build_transcript_and_stats(
                 transcript_segments, redaction_cfg

--- a/backend/app/tasks/transcription/pipelines.py
+++ b/backend/app/tasks/transcription/pipelines.py
@@ -20,32 +20,6 @@ from .user_settings import _get_user_transcription_settings
 logger = logging.getLogger(__name__)
 
 
-_VALID_LOCAL_MODELS = frozenset(
-    {
-        "tiny",
-        "tiny.en",
-        "base",
-        "base.en",
-        "small",
-        "small.en",
-        "medium",
-        "medium.en",
-        "large-v1",
-        "large-v2",
-        "large-v3",
-        "large-v3-turbo",
-    }
-)
-
-
-class _ModelNotAvailableError(Exception):
-    """Raised when a requested model is not available on this worker."""
-
-    def __init__(self, model_name: str) -> None:
-        self.model_name = model_name
-        super().__init__(f"Model '{model_name}' not available on this worker")
-
-
 # Deprecation warning for legacy TRANSCRIPTION_ENGINE env var
 _engine = os.getenv("TRANSCRIPTION_ENGINE", "")
 if _engine and _engine.lower() != "native":
@@ -62,34 +36,6 @@ if _align:
         "Word-level timestamps are now provided natively by faster-whisper "
         "for all 100+ languages without a separate alignment model."
     )
-
-
-def _validate_model_override(model_name: str) -> str | None:
-    """Validate a per-task model override.
-
-    Returns:
-        'cpu' if model should run on CPU, 'gpu' if it matches the admin model,
-        or None if the model is rejected.
-    """
-    from app.transcription.config import TranscriptionConfig
-
-    if model_name not in _VALID_LOCAL_MODELS:
-        logger.warning("Unknown model '%s', rejecting override", model_name)
-        return None
-
-    if model_name in LIGHTWEIGHT_MODELS:
-        return "cpu"
-
-    if model_name == TranscriptionConfig._pinned_model_name:
-        return "gpu"
-
-    logger.warning(
-        "Model '%s' is valid but not loaded (admin model is '%s'). "
-        "Only lightweight models or the admin model are supported.",
-        model_name,
-        TranscriptionConfig._pinned_model_name,
-    )
-    return None
 
 
 def _resolve_language_settings(

--- a/backend/app/utils/transcript_builders.py
+++ b/backend/app/utils/transcript_builders.py
@@ -69,19 +69,25 @@ def build_full_transcript(transcript_segments, redaction_cfg=None) -> str:
     return "\n" + "\n".join(lines)
 
 
-def build_speaker_segments(transcript_segments, limit: int = 50) -> list[dict[str, Any]]:
+def build_speaker_segments(
+    transcript_segments, limit: int = 50, redaction_cfg=None
+) -> list[dict[str, Any]]:
     """Build speaker segments data for LLM analysis.
 
     Args:
         transcript_segments: List of TranscriptSegment ORM objects.
         limit: Maximum number of segments to include (default 50).
+        redaction_cfg: Effective redaction config. When enabled, segment text is
+            masked before it leaves for an external LLM provider
+            (``redact_before_llm``). This payload goes off-box exactly like
+            ``build_full_transcript``'s, so it needs the same masking.
     """
     return [
         {
             "speaker_label": segment.speaker.name if segment.speaker else "Unknown",
             "start_time": segment.start_time,
             "end_time": segment.end_time,
-            "text": segment.text[:200],
+            "text": _seg_text(segment, redaction_cfg)[:200],
         }
         for segment in transcript_segments[:limit]
     ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,10 +40,12 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "__init__.py" = ["F401"]
 # Speaker clustering uses mathematical variable names (M, MT, Z) and complex algorithms
 "**/speaker_clustering_service.py" = ["N806", "C901"]
-# OpenSearch service has complex index rebuild/repair logic and best-effort cleanup
-"**/opensearch_service/*.py" = ["C901", "S110"]
-# Embedding migration has best-effort index detection
-"**/speaker_embedding_migration.py" = ["S110"]
+# Long linear index-rebuild / bulk-scroll routines (rebuild_speaker_index,
+# iter_speaker_embeddings). Narrowed from the whole opensearch_service package
+# to these two files in #284 A3.3; S110 (try-except-pass) is no longer exempt
+# anywhere outside tests.
+"**/opensearch_service/repair.py" = ["C901"]
+"**/opensearch_service/speaker_read.py" = ["C901"]
 # Migrations and alembic versions use string-based SQL construction
 "**/migrations/**" = ["E501", "F401"]
 "**/alembic/**" = ["S608"]

--- a/docs/combined-engine-design.md
+++ b/docs/combined-engine-design.md
@@ -27,7 +27,7 @@ The engine splits the pipeline into three stages, each running on the appropriat
 
 ```
 [CPU worker]  Stage 1: preprocess  →  [GPU worker]  Stage 2: GPU inference  →  [CPU worker]  Stage 3: finalize
-preprocess_for_transcription()           transcribe_gpu_task()                    postprocess_task()
+preprocess_for_transcription()           transcribe_gpu_task()                    finalize_transcription()
 ```
 
 ---


### PR DESCRIPTION
## #284 Phase 3B (A3.3) — replace broad exception swallowing with specific handling

Backend only. **The frontend is untouched** (that is Phase 3C's scope).

> **Route table unchanged**: 409 routes, digest `b409de499c9755f9` — identical to master.

---

## ⚠️ Security: eleven fail-open handlers now fail closed

This issue exists because of controls that look correct and silently do nothing. The audit
of `backend/app/` found eleven broad `except` blocks that swallowed a security result and
**continued as if the check had passed**. Each is listed individually below. Reviewers
should read this section first.

### Certificate revocation is bypassable (highest severity)

**1. `auth/pki_auth.py:_verify_ocsp_signature` returned `True` from its catch-all handler.**
`True` means "this OCSP response is authentic". OCSP is fetched over plain HTTP, so a
forged `GOOD` response — or any malformed response that made the verify block raise — was
accepted as **proof of non-revocation** and cached for `PKI_CRL_CACHE_SECONDS`. Because a
`False` (= not revoked) OCSP result returns immediately from `_check_revocation`, this also
skipped the CRL cross-check **and defeated `PKI_REVOCATION_SOFT_FAIL=false`** — the code
believed the check had *succeeded*, so hard-fail mode never engaged. Net effect: a revoked
client certificate could authenticate. Now returns `False` → OCSP inconclusive → CRL
fallback → the soft-fail setting decides, which is the supported place to make that call.

**2.** Same function: an unrecognised signature-algorithm OID returned `True`.
**3.** `_verify_signature_by_key_type`: an unsupported public-key type returned `True`.
**4.** `_parse_and_verify_crl` trusted a downloaded CRL with **no signature check at all**
when no issuer certificate was loaded. `validate_pki_settings` already requires
`PKI_CA_CERT_PATH` whenever `PKI_VERIFY_REVOCATION` is on, so a missing issuer means the CA
file is unreadable — an operator problem, not a reason to trust the CRL.

**Deployment note:** a deployment whose CA certificate file is unreadable is now governed by
`PKI_REVOCATION_SOFT_FAIL` instead of silently trusting unverified revocation data. That is
the intended behaviour, but it is a behaviour change for a broken configuration.

### Authentication: a denial became a valid session

**5. `api/endpoints/auth/dependencies.get_current_user`.** The user lookup sits in a broad
`except Exception` whose `TESTING` branch **fabricates a `User` and returns it as
authenticated**. `credentials_exception` (401, no such user) and `HTTPException(400,
"Inactive user")` are HTTPExceptions raised *inside* that try — so the handler caught them
and replaced the denial with the fabricated user. An unknown user id in an otherwise-valid
JWT, and a **deactivated account**, both resolved to a working session. The A0.8 double-gate
bounds this to relaxed environments — but the test suite runs exactly there, so the
"inactive users are rejected" control was not actually being exercised. Now re-raises
`HTTPException` first; the shortcut covers only the unavailable-database case it was written
for.

### Content redaction: unmasked data returned, exported, and sent off-box

Same bug class as the `transcript_builders._seg_text` prior art.

**6. `services/formatting_service._apply_redaction`.** `segment_dict["text"]` is only
overwritten *after* `mask_segment` returns, so on failure the handler shipped the **raw DB
text** — including admin-forced categories — straight to the client.

**7. `api/endpoints/files/crud._resolve_redaction_for_request`.** Returning `(None, set())`
told every downstream reader redaction was **off**: `_apply_redaction` short-circuits on a
`None` config and returned every segment raw, `_redaction_pending` stopped withholding
transcripts mid-detection, and no `transcript.view_unredacted` audit event fired because
`reveal` was empty — **an unredacted read with no compliance trail**. Now raises 503.

**8. `api/endpoints/files/subtitles._resolve_subtitle_redaction`.** Same swallow on the
**export** path, and returning `None` skipped the `export_locked` branch immediately below
it — users downloaded fully unredacted SRT/VTT/TXT under the admin `force_export_redacted`
floor. Now raises 503.

**9. `services/subtitle_service._redact_segments_inplace`.** `seg.text = masked` sat inside
a `contextlib.suppress(Exception)`, so a masking failure left the raw text in place and every
downstream formatter wrote it into the exported file.

**10. `tasks/summarization`.** A failure resolving the redaction policy left `redaction_cfg`
as `None`, so `_seg_text` took its "disabled" early return and the **full unredacted
transcript was posted to the configured external LLM provider** — defeating
`redact_before_llm` *and* the admin `force_redact_before_llm` floor. Logged at `debug`, so
the leak was silent. Now aborts the task.

**11. `services/gdpr_erasure_service._erase_speaker_voiceprints`** logged its failures but
never touched `summary["errors"]`. All three callers derive their audit outcome from
`SUCCESS if not summary["errors"] else PARTIAL`, so a failed **biometric** (voiceprint)
deletion was recorded as a *completed* GDPR Art. 17 erasure while the embeddings were still
indexed. Now reports PARTIAL. The deletion itself stays best-effort — the relational and
object-storage erasure remains the legally-binding part and is not blocked by an OpenSearch
outage.

### Also fixed (found while fixing #10, same control, not an `except`)

`tasks/speaker_identification_task` called `build_full_transcript` and
`build_speaker_segments` with **no redaction config at all**, and `build_speaker_segments`
had no such parameter — so LLM speaker identification sent raw transcript text off-box
regardless of `redact_before_llm`. Parameter added; both call sites now pass the resolved
config and fail closed if it cannot be resolved.

### Lower severity

`services/search/hybrid_search_service._redact_snippets` returned on a config failure,
rendering snippets unmasked. Narrow scope (profanity + custom wordlist only — this path never
carries PII spans), so a policy bypass rather than a PII leak. Snippet text is now withheld;
results, counts and ranking are unaffected.

---

## Data destruction: an unreachable OpenSearch read as an empty one

The four index-introspection helpers in `opensearch_service/client.py` all ended in
`except Exception: return False/None`, making a genuine config/auth/connection failure
**indistinguishable from "the index is absent"** — and those answers drive index bootstrap,
alias migration, and index **deletion**.

`migrate_to_alias_based_indices` reads the concrete `speakers` index's embedding dimension
and its document count. Both were swallowed to `None`/`0` on error, and the branch
`elif doc_count == 0:` then ran `indices.delete(index="speakers")` — an unanswered mapping
read plus an unanswered count **deleted a live speaker index** because the code believed it
was an empty one. The same defaulting decided which of two indices to delete when
reconciling `speakers` against its versioned copy: whichever has fewer docs is destroyed,
and an unanswered count silently made the answer `0`.

- New `OpenSearchUnavailableError` + `CLUSTER_UNAVAILABLE_ERRORS`. Helpers now catch
  `NotFoundError` (the cluster answered: absent) and raise on
  connection/auth/transport/serialization failures. `NotFoundError` subclasses
  `TransportError`, so it is caught first.
- `migrate_to_alias_based_indices` is now a fail-closed wrapper: an unavailable cluster
  aborts and touches nothing. The migration is idempotent and re-runs on the next startup.
- New `_count_docs` returns **`None`**, not `0`, when a count cannot be obtained. Every
  destructive branch now requires a *confirmed* count.
- `ensure_indices_exist` caught the **builtin** `ConnectionError`, which opensearch-py's
  `ConnectionError` does not subclass — so every real cluster failure fell through to the
  generic handler. Fixed.

---

## Endpoint hygiene (no behaviour change)

- **Silent handlers: 7 → 0.** Each now logs with `logger.exception` plus a one-line comment
  saying why swallowing is correct there. All seven are genuine best-effort paths (a Redis
  dedup guard, an optional status sub-field, an advisory task count, a per-file bulk-action
  outcome, an optional debug-report section, and the watch-source connection test — whose
  entire job is to report failure as a result).
- **Tracebacks: 67 → 165 of 245 broad handlers.** 98 `logger.error(...)` → `logger.exception(...)`
  where that call is the only logging in a broad handler. Messages untouched; `logger.exception`
  takes the same arguments and adds the traceback. The remaining 79 were left alone
  deliberately — warning/debug level for expected conditions, or multiple log calls needing
  individual judgement.
- **Leaked internals:** four 5xx responses interpolated the raw exception into `detail`
  (GPU profile reads, two Celery worker-restart broadcasts, subtitle validation). Now a
  fixed message, detail logged server-side.
- **`files/subtitles.get_subtitles`** raised a deliberate 404 for an empty transcript that
  the broad handler converted into a 500 embedding the 404's text. An AST sweep confirms
  this and the auth-dependency case were the **only two** such occurrences in
  `api/endpoints`.

## Lint carve-outs

- **`S110` (try-except-pass) exemptions removed entirely** — both `opensearch_service/*.py`
  and `speaker_embedding_migration.py`. S110 now has **no exemption anywhere outside tests**,
  verified by running ruff with the per-file ignores stripped.
- **`C901` narrowed** from the whole `opensearch_service` package to `repair.py` and
  `speaker_read.py` (`rebuild_speaker_index` at 27, `iter_speaker_embeddings` at 17 — long
  linear rebuild/scroll routines). `ensure_indices_exist` was brought under the limit by
  extracting `_restore_v3_from_backup`.

## Dead code / stale docs

- Deleted `_ModelNotAvailableError`, `_validate_model_override` and their supporting
  `_VALID_LOCAL_MODELS` frozenset (`tasks/transcription/pipelines.py`) — definitions, zero
  callers repo-wide.
- The docs referenced a `gpu_transcription_task` symbol **that has never existed**. Corrected
  to the real names (`preprocess_for_transcription` → `transcribe_gpu_task` →
  `finalize_transcription`) in `app/tasks/README.md`, `backend/README.md`, and
  `docs/combined-engine-design.md`.

## Verification

- `pytest backend/tests/` — green (exit 0), run against a throwaway Postgres with the CI
  job's own configuration (`alembic upgrade head`, `SKIP_S3=True`, `SKIP_OPENSEARCH=True`).
  The MinIO/OpenSearch-backed suites were **deliberately skipped** rather than pointed at the
  shared dev stack, so they are not covered here — CI's `backend-tests` job runs the same
  configuration.
- `import app.main` — OK.
- `pre-commit run --all-files` — green (includes mypy, bandit, import-linter, and the full
  frontend build).
- Route digest — `b409de499c9755f9`, 409 routes, byte-identical to master.

## Found but NOT fixed

Reported for follow-up; all are documented, knob-gated fail-open behaviour whose defaults
are a product decision rather than a refactor:

- `auth/mfa.py` TOTP replay protection and `auth/mfa_tokens` single-use JTI blacklist both
  fail open when Redis errors unless `MFA_REQUIRE_REDIS=true` (default `false`).
- `auth/session.py` / `auth/lockout.py` silently swap the token-revocation blacklist and
  lockout ledger for **per-process memory** when Redis is lost — revoked JTIs are accepted
  until natural expiry and lockout counters split per worker.
- `auth/token_service` revocation failures return `False`/`0` and **every caller ignores the
  return value**, so refresh-token rotation leaves the old token valid and `/logout` always
  reports success. Worst case: `auth/password_reset.py:144` calls `revoke_all_user_tokens`
  before its own commit, and the handler's `db.rollback()` discards the **uncommitted new
  password hash** — yet `reset_password` still returns success.
- `auth/password_policy.py:278` — if `verify_func` raises on every stored hash (realistic
  during the bcrypt→PBKDF2/FIPS migration) the loop exits and reports "not reused", allowing
  password reuse.
- `services/redaction/service.py` — detection is **cached once and never re-run**
  (`redaction_status = DONE`). A transient Presidio/LLM failure means that segment has no PII
  spans *forever*, rendering unmasked while the UI says redaction is on. Fixing this means
  marking the file FAILED instead, which is a real behaviour change and wants its own PR.
- `services/auth_config_service.py:327` returns the **ciphertext** as the config value when
  decryption fails.

**Do not merge** — for review.

Refs #284 (A3.3)
