### PR TITLE
test: stop a `@pytest.mark.unit` test from downloading a HuggingFace model

### DIFF
--- a/backend/tests/unit/test_speaker_attribute_service.py
+++ b/backend/tests/unit/test_speaker_attribute_service.py
@@ -103,8 +103,16 @@ class TestServiceInitialization:
         original = mod._cached_service
         mod._cached_service = None
         try:
-            svc1 = get_cached_attribute_service()
-            svc2 = get_cached_attribute_service()
+            # get_cached_attribute_service() calls load_models(), which downloads the
+            # gender model from HuggingFace and re-raises on failure. This test asserts
+            # only the caching contract, so the real load is irrelevant to it — but
+            # unpatched it made a @pytest.mark.unit test depend on huggingface.co being
+            # reachable, and it randomly reddened CI on unrelated PRs (issue #325).
+            # CI has no model cache (requirements-ci.txt is CPU-only), so it refetched
+            # on every run.
+            with patch.object(SpeakerAttributeService, "load_models", return_value=None):
+                svc1 = get_cached_attribute_service()
+                svc2 = get_cached_attribute_service()
             assert svc1 is svc2
         finally:
             mod._cached_service = original


### PR DESCRIPTION
Closes #325.

## The problem

`test_speaker_attribute_service.py::TestServiceInitialization::test_get_cached_service_returns_same_instance` is marked `@pytest.mark.unit` but called `get_cached_attribute_service()` with **no mocking**. That runs `SpeakerAttributeService.load_models()`, which downloads `prithivMLmods/Common-Voice-Gender-Detection` and ends `except Exception as e: logger.error(...); raise` — so the test failed whenever the fetch failed. CI has no model cache (`requirements-ci.txt` is CPU-only), so it refetched every run.

## Evidence it was environmental, not a code failure

It reddened PR #322 (`1 failed, 2621 passed, 395 skipped`) with `OSError: Can't load feature extractor for 'prithivMLmods/Common-Voice-Gender-Detection'`. But:

- `git diff origin/master...origin/quality/phase3b --` on both the module and the test returned **empty** — that PR touched neither
- master's code is identical and already re-raises
- master's five most recent runs passed
- a re-run of the **identical commit** passed in 17m25s

The only variable was whether huggingface.co answered.

## The fix

The test asserts only the caching contract — that two calls return the same object — so the real model load was never relevant to it. `load_models` is patched out and **the assertion is unchanged**.

This restores the file's own stated contract. Its module docstring says *"All ML model calls are mocked so tests run on CPU without downloading the actual HuggingFace model."* Both sibling tests already honour it (`test_load_models_sets_loaded_flag` patches `sys.modules["transformers"]`, `test_load_models_idempotent` patches `builtins.__import__`), so this was an isolated oversight rather than a pattern — I checked the rest of the class and found no others.

## Why it was worth fixing now

A backend-tests job that randomly goes red on unrelated PRs trains everyone to dismiss a red CI, which is exactly how a genuine failure gets waved through. It also cost a full ~17-minute re-run plus investigation on #322.

## Verification

`pytest tests/unit/test_speaker_attribute_service.py` — **13 passed in 0.51s**. Pre-commit green (ruff, ruff-format, mypy, bandit).