### PR TITLE
perf(api): stop awaitless `async def` handlers from blocking the event loop (#320)

### DIFF
--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -730,7 +730,7 @@ def delete_admin_user(
 
 
 @router.get("/settings/retry-config", response_model=RetryConfig)
-async def get_retry_configuration(
+def get_retry_configuration(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> RetryConfig:
@@ -747,7 +747,7 @@ async def get_retry_configuration(
 
 
 @router.put("/settings/retry-config", response_model=RetryConfig)
-async def update_retry_configuration(
+def update_retry_configuration(
     config: RetryConfigUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -773,7 +773,7 @@ async def update_retry_configuration(
 
 
 @router.get("/settings/garbage-cleanup", response_model=GarbageCleanupConfig)
-async def get_garbage_cleanup_configuration(
+def get_garbage_cleanup_configuration(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> GarbageCleanupConfig:
@@ -790,7 +790,7 @@ async def get_garbage_cleanup_configuration(
 
 
 @router.put("/settings/garbage-cleanup", response_model=GarbageCleanupConfig)
-async def update_garbage_cleanup_configuration(
+def update_garbage_cleanup_configuration(
     config: GarbageCleanupConfigUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -840,7 +840,7 @@ def _get_retention_eligible_files(db: Session, retention_days: int, delete_error
 
 
 @router.get("/settings/retention-config", response_model=RetentionConfig)
-async def get_retention_configuration(
+def get_retention_configuration(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> RetentionConfig:
@@ -862,7 +862,7 @@ async def get_retention_configuration(
 
 
 @router.put("/settings/retention-config", response_model=RetentionConfig)
-async def update_retention_configuration(
+def update_retention_configuration(
     config: RetentionConfigUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -891,7 +891,7 @@ async def update_retention_configuration(
 
 
 @router.get("/settings/cache-config", response_model=CacheConfig)
-async def get_cache_configuration(
+def get_cache_configuration(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> CacheConfig:
@@ -911,7 +911,7 @@ async def get_cache_configuration(
 
 
 @router.put("/settings/cache-config", response_model=CacheConfig)
-async def update_cache_configuration(
+def update_cache_configuration(
     config: CacheConfigUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -931,7 +931,7 @@ async def update_cache_configuration(
 
 
 @router.post("/settings/cache-config/clear", response_model=CacheClearResponse)
-async def clear_cache_now(
+def clear_cache_now(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> CacheClearResponse:
@@ -947,7 +947,7 @@ async def clear_cache_now(
 
 
 @router.get("/settings/retention-config/preview", response_model=RetentionPreviewResponse)
-async def preview_retention_deletion(
+def preview_retention_deletion(
     retention_days: int = Query(..., ge=1, le=3650, description="Retention window in days"),
     delete_error_files: bool = Query(False, description="Include error-status files"),
     db: Session = Depends(get_db),
@@ -1008,7 +1008,7 @@ async def preview_retention_deletion(
 
 
 @router.post("/settings/retention-config/run", response_model=RetentionRunResponse)
-async def trigger_retention_run(
+def trigger_retention_run(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> RetentionRunResponse:
@@ -1037,7 +1037,7 @@ async def trigger_retention_run(
 
 
 @router.get("/settings/retention-config/status", response_model=RetentionConfig)
-async def get_retention_status(
+def get_retention_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> RetentionConfig:
@@ -1055,7 +1055,7 @@ async def get_retention_status(
 
 
 @router.get("/settings/media-sources", response_model=MediaSourcesList)
-async def get_media_sources(
+def get_media_sources(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> MediaSourcesList:
@@ -1065,7 +1065,7 @@ async def get_media_sources(
 
 
 @router.post("/settings/media-sources", response_model=MediaSource)
-async def add_media_source(
+def add_media_source(
     source: MediaSourceCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -1116,7 +1116,7 @@ async def add_media_source(
 
 
 @router.put("/settings/media-sources/{source_id}", response_model=MediaSource)
-async def update_media_source(
+def update_media_source(
     source_id: str,
     update: MediaSourceUpdate,
     db: Session = Depends(get_db),
@@ -1154,7 +1154,7 @@ async def update_media_source(
 
 
 @router.delete("/settings/media-sources/{source_id}")
-async def delete_media_source(
+def delete_media_source(
     source_id: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -1206,7 +1206,7 @@ def get_current_super_admin_user(
 
 
 @router.post("/users/{user_uuid}/reset-password")
-async def admin_reset_user_password(
+def admin_reset_user_password(
     user_uuid: str,
     request_body: AdminPasswordResetRequest,
     db: Session = Depends(get_db),
@@ -1242,7 +1242,7 @@ async def admin_reset_user_password(
 
 
 @router.post("/users/{user_uuid}/unlock")
-async def admin_unlock_account(
+def admin_unlock_account(
     user_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -1271,7 +1271,7 @@ async def admin_unlock_account(
 
 
 @router.post("/users/{user_uuid}/lock")
-async def admin_lock_account(
+def admin_lock_account(
     user_uuid: str,
     reason: str = Query("Admin action", description="Reason for locking the account"),
     db: Session = Depends(get_db),
@@ -1301,7 +1301,7 @@ async def admin_lock_account(
 
 
 @router.delete("/users/{user_uuid}/sessions")
-async def admin_terminate_user_sessions(
+def admin_terminate_user_sessions(
     user_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -1345,7 +1345,7 @@ async def admin_terminate_user_sessions(
 
 
 @router.get("/users/{user_uuid}/sessions")
-async def admin_get_user_sessions(
+def admin_get_user_sessions(
     user_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
@@ -1380,7 +1380,7 @@ async def admin_get_user_sessions(
 
 
 @router.put("/users/{user_uuid}/role")
-async def admin_change_user_role(
+def admin_change_user_role(
     user_uuid: str,
     new_role: str = Query(..., description="New role for the user (user, admin, super_admin)"),
     db: Session = Depends(get_db),
@@ -1422,7 +1422,7 @@ async def admin_change_user_role(
 
 
 @router.post("/users/{user_uuid}/mfa/reset")
-async def admin_reset_user_mfa(
+def admin_reset_user_mfa(
     user_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_super_admin_user),
@@ -1457,7 +1457,7 @@ async def admin_reset_user_mfa(
 
 
 @router.get("/users/search")
-async def admin_search_users(
+def admin_search_users(
     query: str | None = Query(None, description="Search query for email or name"),
     role: str | None = Query(None, description="Filter by role"),
     auth_type: str | None = Query(None, description="Filter by auth type"),
@@ -1510,7 +1510,7 @@ async def admin_search_users(
 
 
 @router.get("/reports/account-status")
-async def get_account_status_report(
+def get_account_status_report(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ):
@@ -1699,7 +1699,7 @@ def admin_erase_user(
 
 
 @router.post("/data-integrity")
-async def start_data_integrity_check(
+def start_data_integrity_check(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Start an OpenSearch orphan cleanup task.
@@ -1719,7 +1719,7 @@ async def start_data_integrity_check(
 
 
 @router.get("/data-integrity/status")
-async def get_data_integrity_status(
+def get_data_integrity_status(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Get data integrity check status, last run results, and index overview."""
@@ -1732,7 +1732,7 @@ async def get_data_integrity_status(
 
 
 @router.get("/data-integrity/counts")
-async def get_data_integrity_counts(
+def get_data_integrity_counts(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Quick dry-run scan to count orphaned documents without deleting."""
@@ -1747,7 +1747,7 @@ async def get_data_integrity_counts(
 
 
 @router.get("/embedding-consistency/status")
-async def get_embedding_consistency_status(
+def get_embedding_consistency_status(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Get embedding consistency check status and last run results."""
@@ -1757,7 +1757,7 @@ async def get_embedding_consistency_status(
 
 
 @router.get("/embedding-consistency/counts")
-async def get_embedding_consistency_counts(
+def get_embedding_consistency_counts(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Quick dry-run count of speakers missing from OpenSearch indices."""
@@ -1767,7 +1767,7 @@ async def get_embedding_consistency_counts(
 
 
 @router.post("/embedding-consistency/repair")
-async def start_embedding_consistency_repair(
+def start_embedding_consistency_repair(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Start an embedding consistency repair task."""
@@ -1790,7 +1790,7 @@ async def start_embedding_consistency_repair(
 
 
 @router.get("/gpu-profiles")
-async def get_gpu_profiles(
+def get_gpu_profiles(
     current_user: User = Depends(get_current_admin_user),
     limit: int = Query(default=20, ge=1, le=100),
 ) -> list[dict]:
@@ -1819,7 +1819,7 @@ async def get_gpu_profiles(
 
 
 @router.post("/embedding-consistency/stop")
-async def stop_embedding_consistency_repair(
+def stop_embedding_consistency_repair(
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:
     """Cancel a running embedding consistency repair."""
@@ -1829,7 +1829,7 @@ async def stop_embedding_consistency_repair(
 
 
 @router.post("/profile-embeddings/repair")
-async def repair_profile_embeddings(
+def repair_profile_embeddings(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin_user),
 ) -> dict:

--- a/backend/app/api/endpoints/auth/keycloak.py
+++ b/backend/app/api/endpoints/auth/keycloak.py
@@ -41,7 +41,7 @@ _OIDC_STATE_EXPIRY_SECONDS = 600
 
 
 @router.get("/keycloak/login")
-async def keycloak_login(db: Session = Depends(get_db)):
+def keycloak_login(db: Session = Depends(get_db)):
     """
     Initiate Keycloak OIDC login flow.
 

--- a/backend/app/api/endpoints/auth/methods.py
+++ b/backend/app/api/endpoints/auth/methods.py
@@ -22,7 +22,7 @@ router = APIRouter()
 
 
 @router.get("/methods")
-async def get_auth_methods(db: Session = Depends(get_db)):
+def get_auth_methods(db: Session = Depends(get_db)):
     """
     Get available authentication methods.
 
@@ -78,7 +78,7 @@ async def get_auth_methods(db: Session = Depends(get_db)):
 
 
 @router.get("/banner", response_model=LoginBannerResponse)
-async def get_login_banner():
+def get_login_banner():
     """
     PUBLIC endpoint - returns banner text without authentication.
     Called before login to display classification banner.
@@ -101,7 +101,7 @@ async def get_login_banner():
 
 
 @router.post("/banner/acknowledge")
-async def acknowledge_banner(
+def acknowledge_banner(
     request: Request,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),

--- a/backend/app/api/endpoints/auth/pki.py
+++ b/backend/app/api/endpoints/auth/pki.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post("/pki/authenticate", response_model=Token)
-async def pki_login(request: Request, db: Session = Depends(get_db)):
+def pki_login(request: Request, db: Session = Depends(get_db)):
     """
     Authenticate via X.509 client certificate.
 

--- a/backend/app/api/endpoints/auth_config.py
+++ b/backend/app/api/endpoints/auth_config.py
@@ -16,6 +16,7 @@ from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import Request
 from fastapi import status
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from app.api.endpoints.auth import get_current_active_user
@@ -59,7 +60,7 @@ def get_current_super_admin_user(
 
 
 @router.get("", response_model=dict[str, list[AuthConfigResponse]])
-async def get_all_configs(
+def get_all_configs(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_super_admin_user),
 ) -> dict[str, list[AuthConfigResponse]]:
@@ -113,7 +114,7 @@ async def get_all_configs(
 
 
 @router.get("/status", response_model=AuthConfigStatusResponse)
-async def get_auth_status(
+def get_auth_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_super_admin_user),
 ) -> AuthConfigStatusResponse:
@@ -130,7 +131,7 @@ async def get_auth_status(
 
 
 @router.get("/{category}", response_model=dict[str, Any])
-async def get_config_by_category(
+def get_config_by_category(
     category: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_super_admin_user),
@@ -171,7 +172,7 @@ async def get_config_by_category(
 
 
 @router.put("/{category}", response_model=dict[str, Any])
-async def update_config_category(
+def update_config_category(
     category: str,
     config: dict[str, Any],
     request: Request,
@@ -266,7 +267,9 @@ async def test_auth_connection(
     logger.info(f"Auth connection test for '{category}' by super admin {current_user.email}")
 
     if category == "ldap":
-        return await _test_ldap_connection(config)
+        # ldap3 is blocking; keep it off the event loop (issue #320).
+        ldap_result: AuthMethodTestResponse = await run_in_threadpool(_test_ldap_connection, config)
+        return ldap_result
     elif category == "keycloak":
         return await _test_keycloak_connection(config)
     else:
@@ -277,7 +280,7 @@ async def test_auth_connection(
 
 
 @router.get("/audit/{category}", response_model=list[AuthConfigAuditResponse])
-async def get_audit_log(
+def get_audit_log(
     category: str,
     limit: int = 100,
     offset: int = 0,
@@ -324,7 +327,7 @@ async def get_audit_log(
 
 
 @router.post("/migrate")
-async def migrate_from_env(
+def migrate_from_env(
     request: Request,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_super_admin_user),
@@ -358,8 +361,11 @@ async def migrate_from_env(
         ) from e
 
 
-async def _test_ldap_connection(config: dict[str, Any]) -> AuthMethodTestResponse:
+def _test_ldap_connection(config: dict[str, Any]) -> AuthMethodTestResponse:
     """Test LDAP connection with provided configuration.
+
+    Synchronous: ``ldap3`` binds are blocking with a 10 s connect timeout, so the
+    caller must run this off the event loop (issue #320).
 
     Args:
         config: LDAP configuration to test

--- a/backend/app/api/endpoints/combined_speaker_migration.py
+++ b/backend/app/api/endpoints/combined_speaker_migration.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.get("/status")
-async def get_combined_migration_status(
+def get_combined_migration_status(
     current_user: User = Depends(get_current_active_superuser),
 ):
     """Get the current combined speaker migration status."""
@@ -46,7 +46,7 @@ async def get_combined_migration_status(
 
 
 @router.post("/start")
-async def start_combined_migration(
+def start_combined_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -77,7 +77,7 @@ async def start_combined_migration(
 
 
 @router.post("/stop")
-async def stop_combined_migration(
+def stop_combined_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -151,7 +151,7 @@ async def stop_combined_migration(
 
 
 @router.delete("/progress")
-async def clear_combined_progress(
+def clear_combined_progress(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/endpoints/embedding_migration.py
+++ b/backend/app/api/endpoints/embedding_migration.py
@@ -70,7 +70,7 @@ def _compute_ground_truth_status(db: Session) -> dict | None:
 
 
 @router.get("/status")
-async def get_migration_status(
+def get_migration_status(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -138,7 +138,7 @@ async def get_migration_status(
 
 
 @router.get("/progress")
-async def get_migration_progress(
+def get_migration_progress(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -165,7 +165,7 @@ async def get_migration_progress(
 
 
 @router.post("/start")
-async def start_migration(
+def start_migration(
     user_id: int | None = None,
     force: bool = False,
     current_user: User = Depends(get_current_active_superuser),
@@ -232,7 +232,7 @@ async def start_migration(
 
 
 @router.post("/stop")
-async def stop_migration(
+def stop_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -319,7 +319,7 @@ async def stop_migration(
 
 
 @router.post("/finalize")
-async def finalize_migration(
+def finalize_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -369,7 +369,7 @@ async def finalize_migration(
 
 
 @router.delete("/progress")
-async def clear_progress(
+def clear_progress(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -410,7 +410,7 @@ async def clear_progress(
 
 
 @router.post("/retry-failed")
-async def retry_failed_files(
+def retry_failed_files(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -491,7 +491,7 @@ async def retry_failed_files(
 
 
 @router.post("/force-complete")
-async def force_complete_migration(
+def force_complete_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -543,7 +543,7 @@ async def force_complete_migration(
 
 
 @router.get("/mode")
-async def get_embedding_mode(
+def get_embedding_mode(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/endpoints/files/__init__.py
+++ b/backend/app/api/endpoints/files/__init__.py
@@ -755,7 +755,7 @@ def _download_event_frame(data: dict, mode: str) -> tuple[str | None, bool]:
 
 
 @router.get("/{file_uuid}/download-stream")
-async def download_stream(
+def download_stream(
     file_uuid: str,
     mode: str = Query(
         ..., description="video_subtitles|video_original|audio_mp3|audio_wav|audio_original"

--- a/backend/app/api/endpoints/files/subtitles.py
+++ b/backend/app/api/endpoints/files/subtitles.py
@@ -60,7 +60,7 @@ def _resolve_subtitle_redaction(db, media_file, current_user, redact: bool):
 
 
 @router.get("/{file_uuid}/subtitles", response_class=Response)
-async def get_subtitles(
+def get_subtitles(
     file_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -141,7 +141,7 @@ async def get_subtitles(
 
 
 @router.get("/{file_uuid}/subtitles/validate", response_model=SubtitleValidationResult)
-async def validate_subtitles(
+def validate_subtitles(
     file_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -266,7 +266,7 @@ def prepare_bulk_export(
 
 
 @router.get("/bulk-export-stream")
-async def bulk_export_stream(
+def bulk_export_stream(
     job: str = Query(..., description="Job id returned by /bulk-export/prepare"),
     current_user: User = Depends(get_current_active_user),  # cookie-auth gates the stream
 ):
@@ -351,7 +351,7 @@ async def bulk_export_stream(
 
 
 @router.get("/supported-formats")
-async def get_supported_formats():
+def get_supported_formats():
     """
     Get list of supported subtitle formats.
 

--- a/backend/app/api/endpoints/llm_settings.py
+++ b/backend/app/api/endpoints/llm_settings.py
@@ -624,7 +624,7 @@ def delete_all_user_configurations(
 
 
 @router.post("/test", response_model=schemas.ConnectionTestResponse)
-async def test_llm_connection(
+def test_llm_connection(
     *,
     test_request: schemas.ConnectionTestRequest,
     db: Session = Depends(get_db),
@@ -708,7 +708,7 @@ async def test_llm_connection(
 
 
 @router.post("/test-current", response_model=schemas.ConnectionTestResponse)
-async def test_active_configuration(
+def test_active_configuration(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> Any:
@@ -769,7 +769,7 @@ async def test_active_configuration(
         base_url=str(user_config.base_url) if user_config.base_url else None,
     )
 
-    result = await test_llm_connection(test_request=test_request, current_user=current_user)
+    result = test_llm_connection(test_request=test_request, current_user=current_user)
 
     # Only write back test status if the current user owns the config
     if user_config.user_id == current_user.id:
@@ -784,7 +784,7 @@ async def test_active_configuration(
 
 
 @router.post("/test-config/{config_uuid}", response_model=schemas.ConnectionTestResponse)
-async def test_specific_configuration(
+def test_specific_configuration(
     config_uuid: str,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
@@ -816,7 +816,7 @@ async def test_specific_configuration(
         base_url=str(user_config.base_url) if user_config.base_url else None,
     )
 
-    result = await test_llm_connection(test_request=test_request, current_user=current_user)
+    result = test_llm_connection(test_request=test_request, current_user=current_user)
 
     # Only write back test status if the current user owns the config
     if user_config.user_id == current_user.id:
@@ -831,7 +831,7 @@ async def test_specific_configuration(
 
 
 @router.get("/config/{config_uuid}/api-key")
-async def get_config_api_key(
+def get_config_api_key(
     config_uuid: str,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),

--- a/backend/app/api/endpoints/llm_status.py
+++ b/backend/app/api/endpoints/llm_status.py
@@ -89,7 +89,7 @@ async def get_llm_status(
 
 
 @router.post("/test-connection")
-async def test_llm_connection(
+def test_llm_connection(
     current_user: User = Depends(get_current_active_user),
 ) -> dict[str, Any]:
     """

--- a/backend/app/api/endpoints/speaker_attribute_migration.py
+++ b/backend/app/api/endpoints/speaker_attribute_migration.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.get("/status")
-async def get_attribute_migration_status(
+def get_attribute_migration_status(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -85,7 +85,7 @@ async def get_attribute_migration_status(
 
 
 @router.post("/start")
-async def start_attribute_migration(
+def start_attribute_migration(
     force: bool = False,
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
@@ -125,7 +125,7 @@ async def start_attribute_migration(
 
 
 @router.post("/stop")
-async def stop_attribute_migration(
+def stop_attribute_migration(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):
@@ -208,7 +208,7 @@ async def stop_attribute_migration(
 
 
 @router.delete("/progress")
-async def clear_attribute_progress(
+def clear_attribute_progress(
     current_user: User = Depends(get_current_active_superuser),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/endpoints/summarization.py
+++ b/backend/app/api/endpoints/summarization.py
@@ -165,7 +165,7 @@ async def trigger_summarization(
 
 
 @router.get("/{file_uuid}/summary", response_model=SummaryResponse)
-async def get_file_summary(
+def get_file_summary(
     file_uuid: str = Path(..., description="UUID of the media file"),
     current_user: User = Depends(get_current_active_user),
     ctx: RequestContext = Depends(get_current_context),
@@ -195,7 +195,7 @@ async def get_file_summary(
     try:
         # Try to get structured summary from OpenSearch
         summary_service = OpenSearchSummaryService()
-        opensearch_result = await summary_service.get_summary_by_file_id(file_id, current_user.id)
+        opensearch_result = summary_service.get_summary_by_file_id(file_id, current_user.id)
 
         if opensearch_result and opensearch_result.get("summary_data"):
             # Return flexible summary structure - no field normalization needed
@@ -239,7 +239,7 @@ async def get_file_summary(
 
 
 @router.post("/search", response_model=SummarySearchResponse)
-async def search_summaries(
+def search_summaries(
     search_request: SummarySearchRequest,
     current_user: User = Depends(get_current_active_user),
 ):
@@ -278,7 +278,7 @@ async def search_summaries(
         }
 
         # Execute search
-        results = await summary_service.search_summaries(
+        results = summary_service.search_summaries(
             query=search_params,
             user_id=current_user.id,
             size=search_request.size,
@@ -385,7 +385,7 @@ async def identify_speakers(
 
 
 @router.delete("/{file_uuid}/summary")
-async def delete_summary(
+def delete_summary(
     file_uuid: str = Path(..., description="UUID of the media file"),
     current_user: User = Depends(get_current_active_user),
     ctx: RequestContext = Depends(get_current_context),
@@ -417,7 +417,7 @@ async def delete_summary(
 
         # Delete from OpenSearch if document ID exists
         if hasattr(media_file, "summary_opensearch_id") and media_file.summary_opensearch_id:
-            opensearch_deleted = await summary_service.delete_summary(
+            opensearch_deleted = summary_service.delete_summary(
                 str(media_file.summary_opensearch_id)
             )
             if opensearch_deleted:

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -29,7 +29,7 @@ router = APIRouter()
 
 
 @router.get("/capabilities")
-async def get_system_capabilities(request: Request) -> dict[str, Any]:
+def get_system_capabilities(request: Request) -> dict[str, Any]:
     """Edition + capability map driving server-side feature gating.
 
     The frontend calls this once at bootstrap and renders only the surfaces
@@ -92,9 +92,7 @@ def _device_mode_info(gpu_stats: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 @router.get("/stats", response_model=dict[str, Any])
-async def get_system_stats(
-    db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
-):
+def get_system_stats(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     """
     Get system statistics accessible to all authenticated users.
 
@@ -215,7 +213,7 @@ async def get_system_stats(
 
 
 @router.get("/config/protected-media-auth", response_model=list[dict[str, Any]])
-async def get_protected_media_auth(current_user: User = Depends(get_current_user)):
+def get_protected_media_auth(current_user: User = Depends(get_current_user)):
     """Return public auth configuration for protected media providers.
 
     Used by the frontend to decide when to prompt for username/password

--- a/backend/app/api/endpoints/tags.py
+++ b/backend/app/api/endpoints/tags.py
@@ -278,7 +278,7 @@ def cleanup_unused_tags(
 
 
 @router.post("/files/{file_uuid}/tags", response_model=TagSchema)
-async def add_tag_to_file(
+def add_tag_to_file(
     request: Request,
     file_uuid: str,
     tag_data: dict = Body(...),

--- a/backend/app/api/endpoints/user_files.py
+++ b/backend/app/api/endpoints/user_files.py
@@ -307,7 +307,7 @@ def get_file_detailed_status(
 
 
 @router.post("/{file_uuid}/retry", response_model=dict[str, Any])
-async def retry_file_processing(
+def retry_file_processing(
     file_uuid: str,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
@@ -403,7 +403,7 @@ async def retry_file_processing(
 
 
 @router.post("/request-recovery", response_model=dict[str, Any])
-async def request_user_recovery(
+def request_user_recovery(
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -417,7 +417,7 @@ async def request_user_recovery(
         # This could be implemented with Redis or database tracking
 
         # Schedule user-specific recovery
-        async def run_user_recovery():
+        def run_user_recovery():
             try:
                 from app.tasks.recovery import recover_user_files_task
 

--- a/backend/app/api/endpoints/user_settings.py
+++ b/backend/app/api/endpoints/user_settings.py
@@ -1423,7 +1423,7 @@ def get_download_system_defaults() -> DownloadSystemDefaults:
 
 
 @router.get("/auto-label")
-async def get_auto_label_settings(
+def get_auto_label_settings(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),
 ) -> dict:
@@ -1435,7 +1435,7 @@ async def get_auto_label_settings(
 
 
 @router.put("/auto-label")
-async def update_auto_label_settings(
+def update_auto_label_settings(
     settings_data: AutoLabelSettingsSchema = Body(...),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_active_user),

--- a/backend/app/services/opensearch_summary_service.py
+++ b/backend/app/services/opensearch_summary_service.py
@@ -3,6 +3,14 @@ OpenSearch Summary Service
 
 Handles indexing, searching, and analytics for AI-generated summaries
 stored in OpenSearch for advanced search capabilities.
+
+Every method here is **synchronous**, like the rest of the OpenSearch plane
+(``app/services/opensearch_service/``): ``opensearchpy.OpenSearch`` is a blocking
+client. These used to be ``async def`` with no ``await`` inside, which meant an
+``await`` on them never yielded — the event loop stayed blocked for the whole
+round trip and Celery callers paid for a throwaway loop per call via
+``asyncio.run`` (issue #320). Callers that live on the event loop must declare
+themselves ``def`` so Starlette runs them in its threadpool.
 """
 
 import datetime
@@ -92,7 +100,7 @@ class OpenSearchSummaryService:
         except Exception as e:
             logger.error(f"Error creating summary index: {e}")
 
-    async def index_summary(self, summary_data: dict[str, Any]) -> str | None:
+    def index_summary(self, summary_data: dict[str, Any]) -> str | None:
         """
         Index a summary document in OpenSearch with flexible structure support.
 
@@ -154,7 +162,7 @@ class OpenSearchSummaryService:
             )
             return None
 
-    async def get_summary(self, document_id: str) -> dict[str, Any] | None:
+    def get_summary(self, document_id: str) -> dict[str, Any] | None:
         """
         Retrieve a summary document by ID with flexible structure.
 
@@ -187,7 +195,7 @@ class OpenSearchSummaryService:
             logger.error(f"Error retrieving summary: {e}")
             return None
 
-    async def get_summary_by_file_id(self, file_id: int, user_id: int) -> dict[str, Any] | None:
+    def get_summary_by_file_id(self, file_id: int, user_id: int) -> dict[str, Any] | None:
         """
         Get the latest summary for a specific file with flexible structure support.
 
@@ -247,7 +255,7 @@ class OpenSearchSummaryService:
             logger.error(f"Error getting summary for file {file_id}: {e}")
             return None
 
-    async def search_summaries(
+    def search_summaries(
         self, query: dict[str, Any], user_id: int, size: int = 20, from_: int = 0
     ) -> dict[str, Any]:
         """
@@ -364,7 +372,7 @@ class OpenSearchSummaryService:
             logger.error(f"Error searching summaries: {e}")
             return {"hits": [], "total": 0}
 
-    async def get_summary_analytics(
+    def get_summary_analytics(
         self, user_id: int, filters: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """
@@ -461,7 +469,7 @@ class OpenSearchSummaryService:
             logger.error(f"Error getting summary analytics: {e}")
             return {}
 
-    async def update_summary(self, document_id: str, updates: dict[str, Any]) -> bool:
+    def update_summary(self, document_id: str, updates: dict[str, Any]) -> bool:
         """
         Update a summary document
 
@@ -493,7 +501,7 @@ class OpenSearchSummaryService:
             logger.error(f"Error updating summary: {e}")
             return False
 
-    async def get_max_version(self, file_id: int, user_id: int) -> int:
+    def get_max_version(self, file_id: int, user_id: int) -> int:
         """
         Get the highest version number for a file's summaries
 
@@ -529,7 +537,7 @@ class OpenSearchSummaryService:
             logger.error(f"Failed to get max version for file {file_id}: {e}")
             return 0
 
-    async def delete_summary(self, document_id: str) -> bool:
+    def delete_summary(self, document_id: str) -> bool:
         """
         Delete a summary document
 

--- a/backend/app/tasks/summarization.py
+++ b/backend/app/tasks/summarization.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import time
 from typing import Any
@@ -29,7 +28,7 @@ def _handle_force_regeneration(media_file: MediaFile, db: Session) -> None:
     if media_file.summary_opensearch_id:
         try:
             summary_service = OpenSearchSummaryService()
-            asyncio.run(summary_service.delete_summary(str(media_file.summary_opensearch_id)))
+            summary_service.delete_summary(str(media_file.summary_opensearch_id))
             logger.info(f"Cleared OpenSearch document {media_file.summary_opensearch_id}")
         except Exception as e:
             logger.warning(f"Could not clear OpenSearch summary: {e}")
@@ -126,7 +125,7 @@ def _store_summary_to_opensearch(
     summary_service = OpenSearchSummaryService()
 
     # Get the latest version number for proper versioning
-    max_version = asyncio.run(summary_service.get_max_version(file_id, int(media_file.user_id)))
+    max_version = summary_service.get_max_version(file_id, int(media_file.user_id))
 
     # Make a copy for OpenSearch indexing with tracking fields
     opensearch_data = summary_data.copy()
@@ -141,7 +140,7 @@ def _store_summary_to_opensearch(
     )
 
     # Index in OpenSearch
-    document_id = asyncio.run(summary_service.index_summary(opensearch_data))
+    document_id = summary_service.index_summary(opensearch_data)
 
     return document_id
 

--- a/backend/tests/api/test_handler_blocking_io.py
+++ b/backend/tests/api/test_handler_blocking_io.py
@@ -1,18 +1,21 @@
-"""Regression guards for issue #284 Phase 2 (A2.4 / A2.5).
+"""Regression guards for issue #284 Phase 2 (A2.4 / A2.5) and issue #320.
 
 An ``async def`` FastAPI handler runs **on the event loop**. If its body is nothing
 but blocking work — synchronous SQLAlchemy, a Redis round trip, a yt-dlp metadata
 fetch — then every other request served by that process is stalled for the duration.
 A plain ``def`` handler is dispatched to Starlette's threadpool instead, so the loop
-stays free.
+stays free. Production runs a single uvicorn worker (``app/core/metrics.py`` assumes
+one process), so there is no second worker to absorb the stall.
 
-These tests encode that rule for the modules hardened in Phase 2:
+These tests encode that rule for the modules hardened in Phase 2 and issue #320:
 
 1. ``test_no_awaitless_async_handlers`` is the self-maintaining guard: it AST-parses
    each hardened module and fails if a route handler is ``async def`` yet contains no
    ``await`` / ``async for`` / ``async with``. Adding such a handler regresses the fix.
 2. ``test_hardened_handlers_are_sync`` pins the specific handlers by name via the
    mounted app, so a rename or a silent revert is caught at the routing layer.
+3. ``test_blocking_helpers_are_sync`` covers the two blocking helpers that are not
+   route handlers, so the AST guard cannot see them.
 """
 
 from __future__ import annotations
@@ -24,17 +27,53 @@ from pathlib import Path
 
 import pytest
 
+import app.api.endpoints.admin as admin
+import app.api.endpoints.auth.keycloak as auth_keycloak
+import app.api.endpoints.auth.methods as auth_methods
+import app.api.endpoints.auth.pki as auth_pki
+import app.api.endpoints.auth_config as auth_config
+import app.api.endpoints.combined_speaker_migration as combined_speaker_migration
+import app.api.endpoints.embedding_migration as embedding_migration
+import app.api.endpoints.files as files_endpoints
+import app.api.endpoints.files.subtitles as subtitles
 import app.api.endpoints.files.url_processing as url_processing
+import app.api.endpoints.llm_settings as llm_settings
+import app.api.endpoints.llm_status as llm_status
 import app.api.endpoints.media_collections as media_collections
+import app.api.endpoints.speaker_attribute_migration as speaker_attribute_migration
+import app.api.endpoints.summarization as summarization
+import app.api.endpoints.system as system_endpoints
+import app.api.endpoints.tags as tags
 import app.api.endpoints.tasks as tasks_endpoints
 import app.api.endpoints.topics as topics
+import app.api.endpoints.user_files as user_files
+import app.api.endpoints.user_settings as user_settings
 
 # Modules whose route handlers must never be awaitless coroutines.
 HARDENED_MODULES = [
+    # Phase 2 (A2.4 / A2.5)
     media_collections,
     topics,
     tasks_endpoints,
     url_processing,
+    # Issue #320
+    admin,
+    auth_config,
+    auth_keycloak,
+    auth_methods,
+    auth_pki,
+    combined_speaker_migration,
+    embedding_migration,
+    files_endpoints,
+    llm_settings,
+    llm_status,
+    speaker_attribute_migration,
+    subtitles,
+    summarization,
+    system_endpoints,
+    tags,
+    user_files,
+    user_settings,
 ]
 
 _ROUTE_METHODS = (
@@ -102,7 +141,7 @@ def test_no_awaitless_async_handlers(module) -> None:
     assert not offenders, (
         f"{module.__name__}: these handlers are `async def` but never await — they block "
         f"the event loop with synchronous I/O. Declare them `def` so Starlette runs them "
-        f"in its threadpool (issue #284 A2.5): {offenders}"
+        f"in its threadpool (issue #284 A2.5 / #320): {offenders}"
     )
 
 
@@ -121,6 +160,34 @@ HARDENED_HANDLERS = [
     (tasks_endpoints, "task_system_health"),
     (tasks_endpoints, "recover_all_stuck_tasks"),
     (tasks_endpoints, "retry_file_processing"),
+    # Issue #320 — heavy aggregate queries, blocking OpenSearch, blocking HTTP probes
+    (admin, "admin_search_users"),
+    (admin, "get_account_status_report"),
+    (admin, "preview_retention_deletion"),
+    (admin, "repair_profile_embeddings"),
+    (auth_config, "get_all_configs"),
+    (auth_config, "update_config_category"),
+    (auth_keycloak, "keycloak_login"),
+    (auth_methods, "get_auth_methods"),
+    (auth_pki, "pki_login"),
+    (combined_speaker_migration, "get_combined_migration_status"),
+    (embedding_migration, "get_migration_status"),
+    (embedding_migration, "start_migration"),
+    (files_endpoints, "download_stream"),
+    (llm_settings, "test_llm_connection"),
+    (llm_settings, "test_active_configuration"),
+    (llm_settings, "test_specific_configuration"),
+    (llm_status, "test_llm_connection"),
+    (speaker_attribute_migration, "get_attribute_migration_status"),
+    (subtitles, "get_subtitles"),
+    (subtitles, "bulk_export_stream"),
+    (summarization, "get_file_summary"),
+    (summarization, "search_summaries"),
+    (summarization, "delete_summary"),
+    (system_endpoints, "get_system_stats"),
+    (tags, "add_tag_to_file"),
+    (user_files, "request_user_recovery"),
+    (user_settings, "get_auto_label_settings"),
 ]
 
 
@@ -163,3 +230,29 @@ def test_hardened_handlers_are_sync_on_the_mounted_app(client) -> None:
 
     missing = set(wanted.values()) - seen
     assert not missing, f"handlers missing from the mounted app: {sorted(missing)}"
+
+
+BLOCKING_HELPERS = [
+    # ldap3 binds block for up to the 10 s connect timeout; the caller hands this to
+    # ``run_in_threadpool`` because ``test_auth_connection`` must stay a coroutine for
+    # the genuinely-async Keycloak branch (issue #320).
+    (auth_config, "_test_ldap_connection"),
+]
+
+
+@pytest.mark.parametrize(
+    ("module", "name"),
+    BLOCKING_HELPERS,
+    ids=[f"{m.__name__.rsplit('.', 1)[-1]}.{n}" for m, n in BLOCKING_HELPERS],
+)
+def test_blocking_helpers_are_sync(module, name: str) -> None:
+    """Blocking helpers awaited from coroutine handlers must not be coroutines.
+
+    The AST guard only inspects route handlers, so these need pinning by name.
+    """
+    helper = getattr(module, name)
+    assert not asyncio.iscoroutinefunction(helper), (
+        f"{module.__name__}.{name} is a coroutine again; awaiting it never yields, so the "
+        f"blocking call runs on the event loop. Keep it `def` and offload it with "
+        f"`run_in_threadpool` (issue #320)."
+    )


### PR DESCRIPTION
Closes #320. Refs #284.

FastAPI runs a non-coroutine handler in Starlette's threadpool, but runs an `async def` handler **directly on the event loop**. An `async def` whose body is entirely synchronous therefore blocks the loop for its full duration, and production runs a **single uvicorn worker** (deliberate — the Prometheus registry in `app/core/metrics.py` assumes one process), so there is no second worker to absorb the stall: every concurrent request across the app waits.

This is the remainder of the pattern #284 Phase 2 (PR #318) fixed for `media_collections.py`, `topics.py`, `tasks.py`, and `url_processing.py`.

## Part A — `OpenSearchSummaryService`

637 lines, **8 `async def` methods, zero `await`**, every one calling the blocking `opensearchpy` client.

**Chose option 1: make them honest `def`.** Reasons:

- It matches `app/services/opensearch_service/`, which is already plain sync — the repo has one convention for the OpenSearch plane, and option 2 would have created a second.
- The Celery caller (`app/tasks/summarization.py`) was paying `asyncio.run(...)` **three times** — spinning up and tearing down a throwaway event loop per OpenSearch call — purely to satisfy a coroutine signature with nothing async in it. Option 2 keeps that wart; option 1 deletes it (and the now-unused `import asyncio`).
- No `run_in_threadpool` shim was needed at any of the three endpoint call sites after all: the service call was each handler's **only** `await`, so `get_file_summary`, `search_summaries`, and `delete_summary` become plain `def` — which is what they should have been, since they also do blocking SQLAlchemy.

`trigger_summarization` and `identify_speakers` stay `async def` — they genuinely `await is_llm_available(...)`.

## Part B — 78 awaitless `async def` handlers

Converted to plain `def` across 16 endpoint modules, verified `await`-free by AST before conversion:

| module | handlers |
|---|---|
| `admin.py` | 34 |
| `embedding_migration.py` | 9 |
| `auth_config.py` | 6 |
| `auth/` (`methods` 3, `keycloak` 1, `pki` 1) | 5 |
| `combined_speaker_migration.py` | 4 |
| `speaker_attribute_migration.py` | 4 |
| `files/subtitles.py` | 4 |
| `system.py` | 3 |
| `user_files.py` | 2 |
| `llm_settings.py` | 2 |
| `user_settings.py` | 2 |
| `files/__init__.py` | 1 |
| `llm_status.py` | 1 |
| `tags.py` | 1 |
| **total** | **78** |

`admin.py` was the priority: 34 handlers running heavy aggregate queries on the loop.

### Three cases that needed more than dropping `async`

1. **`auth_config._test_ldap_connection`** — not a route handler, but the same defect in a worse form: a blocking `ldap3` bind with a **10 s connect timeout**, declared `async def` and `await`ed from `test_auth_connection`. Now `def`, offloaded with `run_in_threadpool`. `test_auth_connection` stays a coroutine because its Keycloak branch genuinely awaits `httpx`.
2. **`llm_settings.test_llm_connection`** — called directly (not just routed) by `test_active_configuration` and `test_specific_configuration`. With it sync, those two lose their only `await`, so they are converted too — leaving them `async def` would have been a fresh instance of the same bug in front of a blocking HTTP probe.
3. **`user_files.request_user_recovery`** — its nested `async def run_user_recovery` background callable is now `def`, matching the identical helper Phase 2 already converted in `endpoints/tasks.py`.

### Handlers deliberately left `async def`

Every handler that genuinely awaits, e.g. `admin.get_admin_stats` (`await asyncio.to_thread(_collect_system_stats)` — already correct), `summarization.trigger_summarization` / `identify_speakers`, `llm_status.get_llm_status`, `auth_config.test_auth_connection`.

The two SSE handlers (`files/subtitles.bulk_export_stream`, `files/download_stream`) **were** converted: the awaits live in a nested async generator that Starlette drives on the loop after the handler returns. Creating an async generator does not require a running loop — it binds at first iteration, on the loop thread — and `download_stream`'s body does a blocking `get_media_file_by_uuid` that genuinely belongs off the loop.

## Regression guard

Extended the existing PR #318 AST guard (`backend/tests/api/test_handler_blocking_io.py`) — no new test infrastructure:

- **`HARDENED_MODULES` +17**: `admin`, `auth_config`, `auth.keycloak`, `auth.methods`, `auth.pki`, `combined_speaker_migration`, `embedding_migration`, `files`, `files.subtitles`, `llm_settings`, `llm_status`, `speaker_attribute_migration`, `summarization`, `system`, `tags`, `user_files`, `user_settings`.
- **`HARDENED_HANDLERS` +25** pinned by name and by identity on the mounted app.
- **`BLOCKING_HELPERS`** — one small parametrized check for `_test_ldap_connection`, which the AST walk cannot see because it is not a route handler.

62 tests in that file, all green.

## Verification

- `pytest tests/unit tests/api` → **2038 passed, 39 skipped, 0 failed**.
- `import app.main` succeeds.
- `pre-commit run --all-files` green (ruff, ruff-format, mypy, bandit, gitleaks, import-linter, hadolint, shellcheck, prettier, frontend build).
- **Route table unchanged**: 409 routes, digest `b409de499c9755f9` — identical before and after.

The suite ran against a throwaway Postgres 16 (same shape as the CI `backend-tests` job) rather than the shared dev stack, so the MinIO/OpenSearch-gated suites were skipped; the changed OpenSearch paths have no dedicated tests in-tree either way.

## Out of scope, found not fixed

- 8 awaitless `async def` remain outside the endpoint layer: `main.py` (`_setup_minio`, `_adopt_managed_embedding_model` — startup-only; `handle_app_error` — exception handler), `api/websockets.py` (`setup_redis`, `connect`), `utils/file_hash.py` (`check_duplicate_by_hash`, `cleanup_failed_duplicates`), `utils/thumbnail.py` (`generate_and_upload_thumbnail`). The last three are on request paths and are worth a follow-up.
- Both SSE generators call **sync** Redis (`get_redis().get(...)`) and, in `download_stream`, sync SQLAlchemy from inside the async generator — still on the loop. Pre-existing, a different defect from this issue.
