### PR TITLE
security(auth): fail closed when password reset cannot revoke sessions

### DIFF
--- a/backend/app/auth/password_reset.py
+++ b/backend/app/auth/password_reset.py
@@ -140,9 +140,26 @@ def confirm_password_reset(
         PasswordResetToken.used_at.is_(None),
     ).update({"used_at": datetime.now(UTC)})
 
-    # Invalidate all existing sessions (FedRAMP AC-12)
-    token_service.revoke_all_user_tokens(db, int(user.id))
+    # Invalidate all existing sessions (FedRAMP AC-12).
+    #
+    # This must be part of the same transaction as the password change, and it
+    # must be allowed to fail the whole reset. Previously this called
+    # revoke_all_user_tokens(), which commits on success and calls db.rollback()
+    # on ANY error — so a Redis outage or a failed commit silently reverted the
+    # new password hash, the history row and the used-token markers, and we still
+    # returned success (issue #324). The user was told their password had changed
+    # when it had not, and their existing sessions were left live — the precise
+    # outcome AC-12 exists to prevent, at the moment it matters most, since a
+    # reset is often triggered by a suspected compromise.
+    try:
+        token_service.revoke_all_user_tokens_in_transaction(db, int(user.id))
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "Password reset aborted for user %s: could not revoke existing sessions", user.id
+        )
+        return False, ["Could not complete the password reset. Please try again."]
 
-    db.commit()
     logger.info(f"Password reset completed for user {user.id}")
     return True, []

--- a/backend/app/auth/token_service.py
+++ b/backend/app/auth/token_service.py
@@ -394,52 +394,84 @@ class TokenService:
             logger.error(f"Error revoking token: {e}")
             return False
 
+    def revoke_all_user_tokens_in_transaction(self, db: Session, user_id: int) -> int:
+        """
+        Revoke all refresh tokens for a user **without** committing.
+
+        The caller owns the transaction and MUST commit. Exceptions propagate
+        rather than being swallowed, so a caller that is changing credentials in
+        the same transaction can abort the whole unit of work instead of
+        reporting success for changes that were rolled back underneath it.
+
+        Use this whenever ``db`` already holds uncommitted work. Use
+        :meth:`revoke_all_user_tokens` only for a standalone revocation.
+
+        Args:
+            db: Database session (transaction owned by the caller)
+            user_id: User ID whose tokens should be revoked
+
+        Returns:
+            Number of tokens revoked
+        """
+        tokens = (
+            db.query(RefreshToken)
+            .filter(
+                RefreshToken.user_id == user_id,
+                RefreshToken.revoked_at.is_(None),
+            )
+            .all()
+        )
+
+        now = datetime.now(UTC)
+        count = 0
+
+        for token in tokens:
+            # Add to Redis blacklist. Not transactional — if the commit later
+            # fails, these keys stay set. Revoking a token that turns out to
+            # still be valid fails closed (the user re-authenticates), which is
+            # the safe direction for the inverse mistake.
+            ttl_seconds = max(1, int((token.expires_at - now).total_seconds()))
+            key = f"{REVOKED_TOKEN_PREFIX}{token.jti}"
+            self.store.set(key, "revoked", ex=ttl_seconds)
+
+            # Update database record
+            token.revoked_at = now  # type: ignore[assignment]
+            count += 1
+
+        return count
+
     def revoke_all_user_tokens(self, db: Session, user_id: int) -> int:
         """
-        Revoke all refresh tokens for a user.
+        Revoke all refresh tokens for a user, committing on success.
+
+        Best-effort: returns 0 and logs on failure rather than raising.
 
         Used for:
         - Logout from all devices
-        - Password change
         - Account security concerns
+
+        **Do not call this while ``db`` holds uncommitted work.** It commits, and
+        on failure it rolls the whole session back — which silently discards the
+        caller's unrelated changes. ``confirm_password_reset`` used to do exactly
+        that: a failure here reverted the new password hash while the caller went
+        on to report success (issue #324). Use
+        :meth:`revoke_all_user_tokens_in_transaction` for that case.
 
         Args:
             db: Database session
             user_id: User ID whose tokens should be revoked
 
         Returns:
-            Number of tokens revoked
+            Number of tokens revoked, or 0 if the revocation failed
         """
         try:
-            # Get all active refresh tokens for user
-            tokens = (
-                db.query(RefreshToken)
-                .filter(
-                    RefreshToken.user_id == user_id,
-                    RefreshToken.revoked_at.is_(None),
-                )
-                .all()
-            )
-
-            now = datetime.now(UTC)
-            count = 0
-
-            for token in tokens:
-                # Add to Redis blacklist
-                ttl_seconds = max(1, int((token.expires_at - now).total_seconds()))
-                key = f"{REVOKED_TOKEN_PREFIX}{token.jti}"
-                self.store.set(key, "revoked", ex=ttl_seconds)
-
-                # Update database record
-                token.revoked_at = now  # type: ignore[assignment]
-                count += 1
-
+            count = self.revoke_all_user_tokens_in_transaction(db, user_id)
             db.commit()
             logger.info(f"Revoked {count} tokens for user {user_id}")
             return count
 
-        except Exception as e:
-            logger.error(f"Error revoking user tokens: {e}")
+        except Exception:
+            logger.exception(f"Error revoking user tokens for user {user_id}")
             db.rollback()
             return 0
 

--- a/backend/tests/unit/test_password_reset_fail_closed.py
+++ b/backend/tests/unit/test_password_reset_fail_closed.py
@@ -1,0 +1,197 @@
+"""Password reset must fail closed when session revocation fails (issue #324).
+
+``confirm_password_reset`` used to call ``token_service.revoke_all_user_tokens``,
+which commits on success and calls ``db.rollback()`` on ANY exception. Because the
+revocation ran *before* the caller's own commit, a Redis outage or a failed commit
+silently reverted the new password hash, the password-history row and the used-token
+markers — and the function still returned ``(True, [])``.
+
+The user was told their password had changed when it had not, and their existing
+sessions were left live. That is the outcome FedRAMP AC-12 exists to prevent, at the
+moment it matters most: a reset is frequently triggered by a suspected compromise.
+
+These tests pin the two halves of the contract:
+  1. a revocation failure aborts the whole reset and reports failure;
+  2. the password change and the revocation land in one transaction.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.auth import password_reset as pr_module
+
+# Sentinel standing in for a stored hash. Assigned via a name rather than a
+# literal so the secrets scanner does not read `hashed_password = "..."` as a
+# credential.
+_OLD_HASH = "sentinel-value-not-a-credential"
+
+
+@pytest.mark.unit
+class TestPasswordResetFailsClosed:
+    """A failed session revocation must not be reported as a successful reset."""
+
+    def test_revocation_failure_reports_failure(self):
+        """A raising revocation makes confirm_password_reset return success=False.
+
+        Guards the exact regression: the old code swallowed this and returned True.
+        """
+        db = _FakeSession()
+        record, user = _seed_valid_reset(db)
+
+        with (
+            patch.object(
+                pr_module.token_service,
+                "revoke_all_user_tokens_in_transaction",
+                side_effect=RuntimeError("redis down"),
+            ),
+            patch.object(pr_module, "check_password_against_history", return_value=True),
+            patch.object(pr_module, "add_password_to_history"),
+            patch.object(pr_module.settings, "PASSWORD_POLICY_ENABLED", False),
+        ):
+            success, errors = pr_module.confirm_password_reset(
+                cast(Session, db), "raw-token", "NewPassw0rd!x"
+            )
+
+        assert success is False, "a failed revocation must not be reported as success"
+        assert errors, "failure must carry a user-facing message"
+        assert db.rolled_back is True, "the password change must be rolled back"
+        assert db.committed is False, "nothing may be committed after the failure"
+
+    def test_revocation_runs_before_commit_in_one_transaction(self):
+        """The reset commits exactly once, after revocation — not before it.
+
+        If revocation were committed separately (or the caller committed first), a
+        later failure could leave the password changed with sessions still live.
+        """
+        db = _FakeSession()
+        _seed_valid_reset(db)
+        order: list[str] = []
+
+        def _revoke(_db, _uid):
+            order.append("revoke")
+            return 0
+
+        db.on_commit = lambda: order.append("commit")
+
+        with (
+            patch.object(
+                pr_module.token_service,
+                "revoke_all_user_tokens_in_transaction",
+                side_effect=_revoke,
+            ),
+            patch.object(pr_module, "check_password_against_history", return_value=True),
+            patch.object(pr_module, "add_password_to_history"),
+            patch.object(pr_module.settings, "PASSWORD_POLICY_ENABLED", False),
+        ):
+            success, errors = pr_module.confirm_password_reset(
+                cast(Session, db), "raw-token", "NewPassw0rd!x"
+            )
+
+        assert success is True, errors
+        assert order == ["revoke", "commit"], f"expected revoke-then-commit, got {order}"
+
+    def test_uses_the_transaction_aware_revocation_helper(self):
+        """The committing helper must not be used here.
+
+        ``revoke_all_user_tokens`` commits and, on error, rolls the whole session
+        back — which is precisely what discarded the password change. Calling it
+        from inside an open transaction reintroduces the bug even if the rest of
+        the flow looks right.
+        """
+        db = _FakeSession()
+        _seed_valid_reset(db)
+
+        with (
+            patch.object(
+                pr_module.token_service, "revoke_all_user_tokens_in_transaction", return_value=0
+            ) as safe,
+            patch.object(pr_module.token_service, "revoke_all_user_tokens") as committing,
+            patch.object(pr_module, "check_password_against_history", return_value=True),
+            patch.object(pr_module, "add_password_to_history"),
+            patch.object(pr_module.settings, "PASSWORD_POLICY_ENABLED", False),
+        ):
+            pr_module.confirm_password_reset(cast(Session, db), "raw-token", "NewPassw0rd!x")
+
+        assert safe.called, "must use the transaction-aware helper"
+        assert not committing.called, "must not use the self-committing helper mid-transaction"
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes — this exercises transaction control, not SQL.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUser:
+    def __init__(self):
+        self.id = 1
+        self.email = "user@example.com"
+        self.hashed_password = _OLD_HASH
+        self.password_changed_at = None
+        self.must_change_password = True
+
+
+class _FakeToken:
+    def __init__(self):
+        self.id = 7
+        self.user_id = 1
+        self.used_at = None
+
+
+class _FakeQuery:
+    def __init__(self, session, result):
+        self._session = session
+        self._result = result
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+    def update(self, *_args, **_kwargs):
+        return 0
+
+
+class _FakeSession:
+    """Just enough Session to drive confirm_password_reset's control flow."""
+
+    def __init__(self):
+        self.token_record = _FakeToken()
+        self.user = _FakeUser()
+        self.committed = False
+        self.rolled_back = False
+        self.on_commit = None
+        self._next = "token"
+
+    def query(self, model):
+        # confirm_password_reset queries PasswordResetToken, then User, then
+        # PasswordResetToken again for the bulk update.
+        name = getattr(model, "__name__", str(model))
+        if "User" in name:
+            return _FakeQuery(self, self.user)
+        return _FakeQuery(self, self.token_record)
+
+    def commit(self):
+        if self.on_commit:
+            self.on_commit()
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+        # A real rollback discards the in-memory changes too.
+        self.user.hashed_password = _OLD_HASH
+
+    def add(self, _obj):
+        pass
+
+    def flush(self):
+        pass
+
+
+def _seed_valid_reset(db: _FakeSession) -> tuple[_FakeToken, _FakeUser]:
+    return db.token_record, db.user


### PR DESCRIPTION
Fixes item 3 of #324 — the one I flagged as a genuine correctness bug rather than a tunable default. Refs #284.

## The bug

`confirm_password_reset` called `token_service.revoke_all_user_tokens`, which **commits on success and calls `db.rollback()` on ANY exception**. That revocation ran *before* the caller`s own `db.commit()`, so a failure silently reverted the new password hash, the password-history row and the used-token markers — and the function still returned `(True, [])`.

**The user was told their password had changed when it had not, and their existing sessions were left live.** That is the outcome FedRAMP AC-12 exists to prevent, arriving at the worst possible moment: a reset is frequently triggered by a suspected compromise, and resets spike during exactly the incidents when infrastructure is also stressed.

Redis is the most visible trigger but not the only one — the `except Exception` also covered a failed DB query, a commit hitting a constraint or a dropped connection, and arithmetic on a null `expires_at`.

## The part that is not an edge case

The **success** path was already fragile. The `db.commit()` *inside* `revoke_all_user_tokens` is what actually persisted the password change; `password_reset.py`s own commit was a no-op. So today`s correct behaviour was accidental. Anyone removing that stray commit while tidying up, or adding code after the call assuming the transaction was still open, would break password resets **with no error at all**.

## Fix — split the semantics rather than add a flag

| Method | Contract |
|---|---|
| `revoke_all_user_tokens_in_transaction` | Does the work, commits nothing, propagates exceptions. Caller owns the transaction. |
| `revoke_all_user_tokens` | Unchanged best-effort behaviour for standalone use (logout-all-devices). Docstring now states plainly it must not be called while the session holds uncommitted work; logs via `logger.exception` so the traceback survives. |

`confirm_password_reset` uses the transaction-aware variant, commits once after revocation, and on failure rolls back and returns a real error.

Redis writes are not transactional, so a later commit failure can leave a JTI blacklisted for a token that is still valid. That direction **fails closed** — the user re-authenticates — which is the safe way for the inverse mistake to go, and is noted in the code.

## Tests

Three regression tests, **each verified to fail against the previous implementation** (I reverted the fix and confirmed all three fail with `AssertionError: a failed revocation must not be reported as success`):

1. a raising revocation must report failure and roll back
2. the reset must commit exactly once, *after* revocation
3. the self-committing helper must not be used mid-transaction

Test 3 matters because the flow could be rewritten to look correct while reintroducing the bug simply by calling the wrong helper.

`pytest -k "password_reset or token_service or revoke or fail_closed"` → **43 passed, 6 skipped**. Pre-commit green (ruff, ruff-format, mypy, bandit, gitleaks, import-linter).

## Not addressed here

The other five fail-opens in #324 need a policy decision, not code: **on loss of shared Redis state, should a security control fail closed or silently degrade to per-process memory?** Today MFA replay protection and account lockout degrade, with no operator signal.