### PR TITLE
perf(backend): stop blocking the event loop outside the endpoint layer (#320 follow-ups)

### DIFF
--- a/backend/app/api/endpoints/files/__init__.py
+++ b/backend/app/api/endpoints/files/__init__.py
@@ -28,6 +28,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from app.api.deps_context import RequestContext
 from app.api.deps_context import get_current_context
@@ -792,7 +793,12 @@ def download_stream(
         return f"event: {event}\ndata: {json.dumps(payload)}\n\n"
 
     def _ready_frame() -> str | None:
-        """SSE frame if the download is ready or errored, else None to keep waiting."""
+        """SSE frame if the download is ready or errored, else None to keep waiting.
+
+        Blocking: ``_resolve_ready_download`` stats object storage and presigns. The
+        generator below runs on the event loop, so it must never call this directly —
+        every call goes through ``run_in_threadpool`` (issue #320).
+        """
         try:
             ready = _resolve_ready_download(db_file, mode)
         except HTTPException as e:
@@ -802,7 +808,7 @@ def download_stream(
     async def event_stream():
         # 1. Fast path — already available (covers reconnects after completion). Checked
         # BEFORE touching Redis so a ready download still works when Redis is down.
-        frame = _ready_frame()
+        frame = await run_in_threadpool(_ready_frame)
         if frame:
             yield frame
             return
@@ -824,13 +830,17 @@ def download_stream(
             # to hang until the client gives up. Subscribing first and re-checking
             # means the completion is either buffered on the subscription or visible
             # to this second check; it cannot fall between them.
-            frame = _ready_frame()
+            frame = await run_in_threadpool(_ready_frame)
             if frame:
                 yield frame
                 return
 
             # 3. Make sure the work is running, then stream its events.
-            _ensure_prepare_enqueued(db_file, user_id, mode)
+            #
+            # Threadpooled because it is a synchronous Redis SETNX plus a Celery
+            # dispatch (another blocking broker round trip) — running it inline
+            # stalled the loop for every other request (issue #320).
+            await run_in_threadpool(_ensure_prepare_enqueued, db_file, user_id, mode)
             yield sse("progress", {"message": "Preparing your download…", "progress": 0})
 
             while True:

--- a/backend/app/api/endpoints/files/prepare_upload.py
+++ b/backend/app/api/endpoints/files/prepare_upload.py
@@ -249,9 +249,13 @@ async def prepare_upload(
         duplicate_id: str | None = None
         if request.file_hash:
             # First clean up any failed files with the same hash to allow re-upload
-            await cleanup_failed_duplicates(db, request.file_hash, current_user.id)
+            await run_in_threadpool(
+                cleanup_failed_duplicates, db, request.file_hash, current_user.id
+            )
 
-            duplicate_id = await check_duplicate_by_hash(db, request.file_hash, current_user.id)
+            duplicate_id = await run_in_threadpool(
+                check_duplicate_by_hash, db, request.file_hash, current_user.id
+            )
 
             if duplicate_id:
                 logger.info(

--- a/backend/app/api/endpoints/files/subtitles.py
+++ b/backend/app/api/endpoints/files/subtitles.py
@@ -285,58 +285,66 @@ def bulk_export_stream(
     from redis.exceptions import TimeoutError as RedisTimeoutError
 
     from app.core.config import settings
-    from app.core.redis import get_redis
     from app.services.download_events import bulk_export_channel
 
     def sse(event: str, payload: dict) -> str:
         return f"event: {event}\ndata: {_json.dumps(payload)}\n\n"
 
     async def event_stream():
-        # 1. Already finished? deliver immediately (covers reconnects after completion).
-        cached = get_redis().get(f"bulk_export_result:{job}")
-        if cached:
-            yield sse("ready", _json.loads(cached))
-            return
-
+        # The whole generator is iterated ON the event loop, so every Redis call in it
+        # must be async. The result-cache read used to go through the synchronous
+        # ``get_redis()`` singleton, stalling every other request for the round trip
+        # (issue #320); it now shares the async client already used for the pub/sub.
         client = aioredis.from_url(
             settings.REDIS_URL, health_check_interval=30, socket_keepalive=True
         )
-        pubsub = client.pubsub()
-        await pubsub.subscribe(bulk_export_channel(job))
-        yield sse("progress", {"message": "Preparing export…", "progress": 0})
         try:
-            while True:
-                try:
-                    msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=15.0)
-                except (TimeoutError, RedisTimeoutError):
-                    yield ": keepalive\n\n"
-                    continue
-                except RedisError as e:
-                    logger.warning(f"Bulk export SSE pubsub error for job {job}: {e}")
-                    yield sse("error", {"message": "Connection interrupted."})
-                    return
-                if msg is None:
-                    yield ": keepalive\n\n"
-                    continue
-                try:
-                    data = _json.loads(msg["data"])
-                except Exception:
-                    logger.debug("Skipping malformed bulk export event payload")
-                    continue
-                status = data.get("status")
-                if status == "completed" and data.get("url"):
-                    yield sse("ready", data)
-                    return
-                if status == "error":
-                    yield sse("error", data)
-                    return
-                yield sse("progress", data)
+            # 1. Already finished? deliver immediately (covers reconnects after completion).
+            cached = await client.get(f"bulk_export_result:{job}")
+            if cached:
+                yield sse("ready", _json.loads(cached))
+                return
+
+            pubsub = client.pubsub()
+            await pubsub.subscribe(bulk_export_channel(job))
+            try:
+                yield sse("progress", {"message": "Preparing export…", "progress": 0})
+                while True:
+                    try:
+                        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=15.0)
+                    except (TimeoutError, RedisTimeoutError):
+                        yield ": keepalive\n\n"
+                        continue
+                    except RedisError as e:
+                        logger.warning(f"Bulk export SSE pubsub error for job {job}: {e}")
+                        yield sse("error", {"message": "Connection interrupted."})
+                        return
+                    if msg is None:
+                        yield ": keepalive\n\n"
+                        continue
+                    try:
+                        data = _json.loads(msg["data"])
+                    except Exception:
+                        logger.debug("Skipping malformed bulk export event payload")
+                        continue
+                    status = data.get("status")
+                    if status == "completed" and data.get("url"):
+                        yield sse("ready", data)
+                        return
+                    if status == "error":
+                        yield sse("error", data)
+                        return
+                    yield sse("progress", data)
+            finally:
+                # Only reached once subscribed — unsubscribing an unsubscribed pubsub
+                # would open a connection just to tear it down.
+                with contextlib.suppress(Exception):
+                    await pubsub.unsubscribe(bulk_export_channel(job))
+                    await pubsub.close()
         except asyncio.CancelledError:
             raise
         finally:
             with contextlib.suppress(Exception):
-                await pubsub.unsubscribe(bulk_export_channel(job))
-                await pubsub.close()
                 await client.close()
 
     return StreamingResponse(

--- a/backend/app/api/endpoints/files/upload.py
+++ b/backend/app/api/endpoints/files/upload.py
@@ -496,7 +496,9 @@ async def process_file_upload(
     if client_file_hash and not existing_file_uuid:
         from app.utils.file_hash import check_duplicate_by_hash
 
-        duplicate_uuid = await check_duplicate_by_hash(db, client_file_hash, current_user.id)
+        duplicate_uuid = await run_in_threadpool(
+            check_duplicate_by_hash, db, client_file_hash, current_user.id
+        )
         if duplicate_uuid:
             logger.info(
                 f"Duplicate upload rejected for {file.filename} "

--- a/backend/app/api/websockets.py
+++ b/backend/app/api/websockets.py
@@ -31,8 +31,13 @@ class ConnectionManager:
         # user_id -> List[WebSocket]
         self.active_connections: dict[int, list[WebSocket]] = {}
 
-    async def connect(self, websocket: WebSocket, user_id: int):
-        """Register a WebSocket connection for a user (accept() must be called before this)."""
+    def connect(self, websocket: WebSocket, user_id: int):
+        """Register a WebSocket connection for a user (accept() must be called before this).
+
+        Bookkeeping only — no I/O — so it is a plain function, mirroring ``disconnect``.
+        It is still owned by the connection's own coroutine; nothing outside this
+        process may touch ``manager`` (publish via ``utils/websocket_notify.py``).
+        """
         if user_id not in self.active_connections:
             self.active_connections[user_id] = []
         self.active_connections[user_id].append(websocket)
@@ -98,8 +103,14 @@ manager = ConnectionManager()
 redis_client: redis.Redis | None = None
 
 
-async def setup_redis():
-    """Initialize Redis connection for pub/sub notifications."""
+def setup_redis():
+    """Initialize Redis connection for pub/sub notifications.
+
+    ``redis.asyncio.from_url`` only builds a lazily-connecting pool and
+    ``asyncio.create_task`` needs a running loop, not an ``await`` — so nothing here
+    yields. Declaring it ``async def`` claimed otherwise (issue #320); callers must
+    still invoke it from a coroutine so ``create_task`` has a loop to attach to.
+    """
     global redis_client
     if not redis_client:
         # health_check_interval + keepalive keep the long-lived pub/sub connection
@@ -183,7 +194,7 @@ async def redis_subscriber():
 async def publish_notification(user_id: int, notification_type: str, data: dict):
     """Publish notification via Redis pub/sub."""
     if not redis_client:
-        await setup_redis()
+        setup_redis()
 
     notification = {"user_id": user_id, "type": notification_type, "data": data}
 
@@ -267,7 +278,7 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
        message loop; on failure, close with an appropriate error code.
     """
     # Initialize Redis subscriber if not already running
-    await setup_redis()
+    setup_redis()
 
     # Accept the connection first, then authenticate
     await websocket.accept()
@@ -304,7 +315,7 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
             return
 
     # Register the authenticated connection
-    await manager.connect(websocket, user.id)
+    manager.connect(websocket, user.id)
 
     # Send initial connection status
     await websocket.send_text(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi.errors import RateLimitExceeded
+from starlette.concurrency import run_in_threadpool
 from starlette.responses import JSONResponse
 
 from app.api.router import api_router
@@ -149,12 +150,17 @@ async def _drain_websockets() -> None:
         logger.warning(f"WebSocket drain failed (non-fatal): {e}")
 
 
-async def _setup_minio():
+def _setup_minio():
     """Initialize the media bucket on startup.
 
     Creates the media bucket if it doesn't exist and ensures the bucket
     policy is private (no anonymous/public access). All file access goes
     through presigned URLs, so public read is unnecessary and a security risk.
+
+    Every call in here is a blocking object-storage round trip and the function never
+    awaited anything, so as an ``async def`` startup task it held the event loop for
+    the whole bucket bootstrap — with the API already accepting requests (issue #320).
+    The lifespan now dispatches it through ``run_in_threadpool``.
 
     Uses the shared storage client so ``STORAGE_BACKEND=s3`` bootstraps against
     the real bucket instead of a MinIO-shaped client built from raw env vars
@@ -453,7 +459,7 @@ def _managed_embedding_mode() -> bool:
     return settings.OPENSEARCH_EMBEDDING_MODE.strip().lower() == "managed"
 
 
-async def _adopt_managed_embedding_model(ml_service) -> None:
+def _adopt_managed_embedding_model(ml_service) -> None:
     """Use an embedding model the OpenSearch domain already hosts (issue #284 A1.13).
 
     The default "local" path mutates ML Commons cluster settings and registers a
@@ -462,6 +468,9 @@ async def _adopt_managed_embedding_model(ml_service) -> None:
     cluster-settings PUT and neural search never comes up. In "managed" mode the
     operator has already registered the model (typically a remote-model connector),
     and all we do is adopt its id and wire the ingest pipeline.
+
+    Synchronous: the model-id write and the ingest-pipeline PUT are both blocking
+    OpenSearch calls with nothing to await (issue #320). The caller offloads it.
 
     Args:
         ml_service: The ``MLModelService`` singleton.
@@ -516,7 +525,7 @@ async def _initialize_neural_search():
         ml_service = get_ml_model_service()
 
         if _managed_embedding_mode():
-            await _adopt_managed_embedding_model(ml_service)
+            await run_in_threadpool(_adopt_managed_embedding_model, ml_service)
             return
 
         # Configure ML Commons settings
@@ -712,7 +721,7 @@ async def lifespan(app: FastAPI):
         logger.warning(f"Migration state cleanup failed (non-fatal): {e}")
 
     logger.info("Setting up MinIO and task recovery...")
-    minio_task = asyncio.create_task(_setup_minio())
+    minio_task = asyncio.create_task(run_in_threadpool(_setup_minio))
     recovery_task = asyncio.create_task(_run_startup_recovery())
     search_maintenance = asyncio.create_task(_run_search_maintenance())
     thumbnail_migration = asyncio.create_task(_run_thumbnail_migration())
@@ -798,6 +807,12 @@ app.add_middleware(ObservabilityMiddleware)
 # Maps domain-specific exceptions to appropriate HTTP status codes so that
 # any ``OpenTranscribeError`` raised in endpoint code is automatically
 # serialised as a structured JSON response.
+#
+# Deliberately `async def` even though it never awaits, which is the one shape the
+# issue #320 sweep leaves alone: the body is a dict lookup and a JSONResponse
+# construction, with no I/O to block the loop. Starlette does accept a plain `def`
+# handler, but it dispatches one through `run_in_threadpool`, so declaring it `def`
+# would buy a thread hop on every error response and free nothing.
 @app.exception_handler(OpenTranscribeError)
 async def handle_app_error(request, exc: OpenTranscribeError):
     status_map = {

--- a/backend/app/services/media_download_service.py
+++ b/backend/app/services/media_download_service.py
@@ -33,7 +33,7 @@ from app.services.minio_service import upload_file
 from app.services.minio_service import upload_file_tuned
 from app.services.protected_media_providers import PROTECTED_MEDIA_PROVIDERS
 from app.services.protected_media_providers import ProtectedMediaProvider
-from app.utils.thumbnail import generate_and_upload_thumbnail_sync
+from app.utils.thumbnail import generate_and_upload_thumbnail
 from app.utils.url_validation import is_safe_url
 
 logger = logging.getLogger(__name__)
@@ -399,7 +399,7 @@ def _get_thumbnail_with_fallback(
 
     # Inline fallback — keeps legacy behavior for callers that opt out.
     try:
-        return generate_and_upload_thumbnail_sync(
+        return generate_and_upload_thumbnail(
             user_id=user_id,
             media_file_id=media_file_id,
             video_path=video_path,

--- a/backend/app/utils/file_hash.py
+++ b/backend/app/utils/file_hash.py
@@ -14,12 +14,15 @@ logger = logging.getLogger(__name__)
 # Hashing is now done client-side in the frontend
 
 
-async def check_duplicate_by_hash(
-    db_session, file_hash: str, user_id: int | None = None
-) -> str | None:
+def check_duplicate_by_hash(db_session, file_hash: str, user_id: int | None = None) -> str | None:
     """
     Check if a file with the same hash exists in the database.
     Only considers files that are not in failed states and have actually been uploaded.
+
+    Synchronous by design: the body is one blocking SQLAlchemy query. It used to be an
+    ``async def`` with no ``await``, so awaiting it from the upload handlers never
+    yielded and the query ran on the event loop (issue #320). Coroutine callers offload
+    it with ``run_in_threadpool``.
 
     Args:
         db_session: SQLAlchemy database session
@@ -125,7 +128,7 @@ def check_duplicate_by_imohash(db_session, imohash: str, exclude_file_id: int | 
     return query.first()
 
 
-async def cleanup_failed_duplicates(db_session, file_hash: str, user_id: int) -> int:
+def cleanup_failed_duplicates(db_session, file_hash: str, user_id: int) -> int:
     """
     Clean up any failed or incomplete files with the same hash.
     This includes:
@@ -133,6 +136,11 @@ async def cleanup_failed_duplicates(db_session, file_hash: str, user_id: int) ->
     - PENDING files that have no storage_path (incomplete uploads)
 
     This allows users to re-upload files that previously failed.
+
+    Synchronous by design: blocking SQLAlchemy plus one object-storage delete per
+    orphaned row. It used to be an ``async def`` with no ``await`` (issue #320), so the
+    whole loop — including every MinIO round trip — ran on the event loop. Coroutine
+    callers offload it with ``run_in_threadpool``.
 
     Args:
         db_session: SQLAlchemy database session

--- a/backend/app/utils/thumbnail.py
+++ b/backend/app/utils/thumbnail.py
@@ -173,7 +173,7 @@ def generate_thumbnail_from_url(
         return None
 
 
-async def generate_and_upload_thumbnail(
+def generate_and_upload_thumbnail(
     user_id: int,
     media_file_id: int,
     video_path: str | Path,
@@ -183,65 +183,10 @@ async def generate_and_upload_thumbnail(
     """
     Generate a thumbnail from a video file and upload it to storage.
 
-    Args:
-        user_id: User ID for storage path
-        media_file_id: Media file ID for storage path
-        video_path: Path to the video file
-        timestamp: Time in seconds to extract the thumbnail
-        output_format: Output format - "webp" or "jpeg" (default: webp)
-
-    Returns:
-        The storage path of the uploaded thumbnail, or None if generation failed
-    """
-    try:
-        # Generate thumbnail
-        thumbnail_bytes = generate_thumbnail(
-            video_path, timestamp=timestamp, output_format=output_format
-        )
-
-        if not thumbnail_bytes or isinstance(thumbnail_bytes, str):
-            logger.error(f"Failed to generate thumbnail for file {media_file_id}")
-            return None
-
-        # Determine extension and content type based on format
-        ext = "webp" if output_format == "webp" else "jpg"
-        content_type = "image/webp" if output_format == "webp" else "image/jpeg"
-
-        # Generate storage path for thumbnail
-        filename = (
-            Path(video_path).stem
-            if isinstance(video_path, (str, Path))
-            else f"file_{media_file_id}"
-        )
-        storage_path = f"user_{user_id}/file_{media_file_id}/thumbnail_{filename}.{ext}"
-
-        # Upload thumbnail to storage
-        if os.environ.get("SKIP_S3", "False").lower() != "true":
-            upload_file(
-                file_content=io.BytesIO(thumbnail_bytes),
-                file_size=len(thumbnail_bytes),
-                object_name=storage_path,
-                content_type=content_type,
-            )
-        else:
-            logger.info("Skipping S3 upload for thumbnail in test environment")
-
-        return storage_path
-
-    except Exception as e:
-        logger.error(f"Error generating and uploading thumbnail: {str(e)}")
-        return None
-
-
-def generate_and_upload_thumbnail_sync(
-    user_id: int,
-    media_file_id: int,
-    video_path: str | Path,
-    timestamp: float = 1.0,
-    output_format: Literal["webp", "jpeg"] = THUMBNAIL_FORMAT,  # type: ignore[assignment]
-) -> str | None:
-    """
-    Generate a thumbnail from a video file and upload it to storage (synchronous version).
+    ffmpeg extraction and the object-storage PUT are both blocking, so this is a
+    plain function: an ``async def`` twin used to exist alongside it with a
+    byte-identical body and no ``await``, which meant awaiting it never yielded
+    and the whole ffmpeg run blocked the event loop (issue #320).
 
     Args:
         user_id: User ID for storage path

--- a/backend/tests/api/test_handler_blocking_io.py
+++ b/backend/tests/api/test_handler_blocking_io.py
@@ -14,8 +14,14 @@ These tests encode that rule for the modules hardened in Phase 2 and issue #320:
    ``await`` / ``async for`` / ``async with``. Adding such a handler regresses the fix.
 2. ``test_hardened_handlers_are_sync`` pins the specific handlers by name via the
    mounted app, so a rename or a silent revert is caught at the routing layer.
-3. ``test_blocking_helpers_are_sync`` covers the two blocking helpers that are not
-   route handlers, so the AST guard cannot see them.
+3. ``test_blocking_helpers_are_sync`` covers the blocking helpers that are not route
+   handlers, so the AST guard cannot see them.
+4. ``test_sse_generators_do_not_call_blocking_helpers_inline`` covers the SSE async
+   generators. Making their *handlers* ``def`` does nothing for the generator body:
+   Starlette iterates that on the event loop for the whole life of the stream, so a
+   synchronous Redis/object-storage call in there blocks far longer than one request.
+5. ``test_download_stream_keeps_the_check_subscribe_recheck_order`` pins the #284 A1.22
+   lost-wakeup fix, which the offload above must not reorder.
 """
 
 from __future__ import annotations
@@ -48,6 +54,10 @@ import app.api.endpoints.tasks as tasks_endpoints
 import app.api.endpoints.topics as topics
 import app.api.endpoints.user_files as user_files
 import app.api.endpoints.user_settings as user_settings
+import app.api.websockets as websockets
+import app.main as app_main
+import app.utils.file_hash as file_hash
+import app.utils.thumbnail as thumbnail
 
 # Modules whose route handlers must never be awaitless coroutines.
 HARDENED_MODULES = [
@@ -237,7 +247,29 @@ BLOCKING_HELPERS = [
     # ``run_in_threadpool`` because ``test_auth_connection`` must stay a coroutine for
     # the genuinely-async Keycloak branch (issue #320).
     (auth_config, "_test_ldap_connection"),
+    # Issue #320 follow-ups — awaitless coroutines outside the endpoint layer.
+    # Blocking object storage, dispatched from the lifespan via run_in_threadpool.
+    (app_main, "_setup_minio"),
+    # Blocking OpenSearch (model-id write + ingest-pipeline PUT).
+    (app_main, "_adopt_managed_embedding_model"),
+    # Builds a lazily-connecting async pool and schedules a task; nothing to await.
+    (websockets, "setup_redis"),
+    # In-memory bookkeeping only, mirroring ConnectionManager.disconnect.
+    (websockets, "ConnectionManager.connect"),
+    # Blocking SQLAlchemy (+ object-storage deletes) on the upload request path.
+    (file_hash, "check_duplicate_by_hash"),
+    (file_hash, "cleanup_failed_duplicates"),
+    # ffmpeg + object-storage PUT; had a byte-identical `async def` twin until #320.
+    (thumbnail, "generate_and_upload_thumbnail"),
 ]
+
+
+def _resolve(module, dotted: str):
+    """Resolve a possibly dotted attribute path (``ConnectionManager.connect``)."""
+    target = module
+    for part in dotted.split("."):
+        target = getattr(target, part)
+    return target
 
 
 @pytest.mark.parametrize(
@@ -250,9 +282,106 @@ def test_blocking_helpers_are_sync(module, name: str) -> None:
 
     The AST guard only inspects route handlers, so these need pinning by name.
     """
-    helper = getattr(module, name)
+    helper = _resolve(module, name)
     assert not asyncio.iscoroutinefunction(helper), (
         f"{module.__name__}.{name} is a coroutine again; awaiting it never yields, so the "
         f"blocking call runs on the event loop. Keep it `def` and offload it with "
         f"`run_in_threadpool` (issue #320)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSE async generators
+# ---------------------------------------------------------------------------
+
+# (module, handler, generator, names that must never be *called* inside the generator)
+SSE_GENERATORS = [
+    # ``_ready_frame`` stats object storage and presigns; ``_ensure_prepare_enqueued``
+    # is a synchronous Redis SETNX plus a Celery dispatch. Both go through
+    # ``run_in_threadpool`` (passed as a bare name, never called inline).
+    (
+        files_endpoints,
+        "download_stream",
+        "event_stream",
+        {"_ready_frame", "_ensure_prepare_enqueued"},
+    ),
+    # The result-cache read uses the async client; the synchronous ``get_redis()``
+    # singleton must not come back.
+    (subtitles, "bulk_export_stream", "event_stream", {"get_redis"}),
+]
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """Return the first (async) function definition called ``name`` anywhere in ``tree``."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _generator_ast(module, handler: str, generator: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    tree = ast.parse(Path(module.__file__).read_text())
+    return _find_function(_find_function(tree, handler), generator)
+
+
+@pytest.mark.parametrize(
+    ("module", "handler", "generator", "blocking"),
+    SSE_GENERATORS,
+    ids=[f"{m.__name__.rsplit('.', 1)[-1]}.{h}" for m, h, _, _ in SSE_GENERATORS],
+)
+def test_sse_generators_do_not_call_blocking_helpers_inline(
+    module, handler: str, generator: str, blocking: set[str]
+) -> None:
+    """An SSE generator is iterated on the event loop for the life of the stream.
+
+    Converting the handler to ``def`` (PR #329) only moved the few lines that build
+    the generator object; a synchronous call *inside* it still stalls every other
+    request, and for far longer than one handler would.
+    """
+    offenders = [
+        f"{node.func.id}() at line {node.lineno}"
+        for node in ast.walk(_generator_ast(module, handler, generator))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in blocking
+    ]
+
+    assert not offenders, (
+        f"{module.__name__}.{handler}.{generator} calls blocking code inline: {offenders}. "
+        f"Use the async Redis client, or hand the callable to `run_in_threadpool` "
+        f"(issue #320)."
+    )
+
+
+def test_download_stream_keeps_the_check_subscribe_recheck_order() -> None:
+    """The readiness check must straddle the pub/sub subscribe (issue #284 A1.22).
+
+    Check-then-subscribe alone loses a completion published in the gap and the stream
+    hangs forever. Offloading the checks to the threadpool must not collapse the
+    second one back into the first.
+    """
+    tree = _generator_ast(files_endpoints, "download_stream", "event_stream")
+
+    checks = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_in_threadpool"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "_ready_frame"
+    ]
+    subscribes = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "subscribe"
+    ]
+
+    assert len(checks) == 2, f"expected two readiness checks, found {checks}"
+    assert len(subscribes) == 1, f"expected one pubsub.subscribe, found {subscribes}"
+    assert checks[0] < subscribes[0] < checks[1], (
+        f"readiness checks at {checks} no longer straddle subscribe at {subscribes[0]}"
     )

--- a/backend/tests/unit/test_opensearch_auth.py
+++ b/backend/tests/unit/test_opensearch_auth.py
@@ -173,8 +173,7 @@ def test_managed_embedding_mode_is_detected(monkeypatch):
     assert _managed_embedding_mode() is True
 
 
-@pytest.mark.asyncio
-async def test_managed_mode_adopts_the_configured_model_without_touching_the_cluster(
+def test_managed_mode_adopts_the_configured_model_without_touching_the_cluster(
     monkeypatch,
 ):
     """A managed domain exposes neither the ML Commons cluster settings nor URL-based
@@ -188,7 +187,7 @@ async def test_managed_mode_adopts_the_configured_model_without_touching_the_clu
     with patch(
         "app.services.search.indexing_service.ensure_neural_ingest_pipeline", return_value=True
     ) as ensure_pipeline:
-        await _adopt_managed_embedding_model(ml_service)
+        _adopt_managed_embedding_model(ml_service)
 
     ml_service.set_active_model_id.assert_called_once_with("abc123")
     ml_service.configure_ml_settings.assert_not_called()
@@ -196,8 +195,7 @@ async def test_managed_mode_adopts_the_configured_model_without_touching_the_clu
     ensure_pipeline.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_managed_mode_without_a_model_id_falls_back_to_the_active_one(monkeypatch):
+def test_managed_mode_without_a_model_id_falls_back_to_the_active_one(monkeypatch):
     from app.main import _adopt_managed_embedding_model
 
     monkeypatch.setattr(settings, "OPENSEARCH_NEURAL_MODEL_ID", "")
@@ -207,13 +205,12 @@ async def test_managed_mode_without_a_model_id_falls_back_to_the_active_one(monk
     with patch(
         "app.services.search.indexing_service.ensure_neural_ingest_pipeline", return_value=True
     ):
-        await _adopt_managed_embedding_model(ml_service)
+        _adopt_managed_embedding_model(ml_service)
 
     ml_service.set_active_model_id.assert_called_once_with("already-registered")
 
 
-@pytest.mark.asyncio
-async def test_managed_mode_with_no_model_at_all_is_a_logged_no_op(monkeypatch):
+def test_managed_mode_with_no_model_at_all_is_a_logged_no_op(monkeypatch):
     from app.main import _adopt_managed_embedding_model
 
     monkeypatch.setattr(settings, "OPENSEARCH_NEURAL_MODEL_ID", "")
@@ -223,7 +220,7 @@ async def test_managed_mode_with_no_model_at_all_is_a_logged_no_op(monkeypatch):
     with patch(
         "app.services.search.indexing_service.ensure_neural_ingest_pipeline"
     ) as ensure_pipeline:
-        await _adopt_managed_embedding_model(ml_service)
+        _adopt_managed_embedding_model(ml_service)
 
     ml_service.set_active_model_id.assert_not_called()
     ensure_pipeline.assert_not_called()


### PR DESCRIPTION
Follow-ups to #320 that PR #329 explicitly listed as still open. Two independent
defects, both the same shape: code that runs on the event loop while doing blocking
I/O in a single-uvicorn-worker process, so one slow call stalls *every* concurrent
request.

Route digest `b409de499c9755f9` / **409 routes** — verified identical to master
before and after. No schema change, no migration, no API contract change.
`frontend/` untouched.

---

## Part A — the 8 awaitless `async def` outside `api/endpoints`

These are not route handlers, so #329's rule ("declare it `def`, Starlette
threadpools it") doesn't apply on its own — each is *awaited* by a caller, so every
signature change had to be traced to its call sites first.

| Function | Change | Why |
|---|---|---|
| `utils/file_hash.py::check_duplicate_by_hash` | → `def` | Request path. One blocking SQLAlchemy query. |
| `utils/file_hash.py::cleanup_failed_duplicates` | → `def` | Request path. Blocking SQLAlchemy + one object-storage delete **per orphaned row**. |
| `utils/thumbnail.py::generate_and_upload_thumbnail` | **deleted** | Byte-identical, zero-caller `async def` twin of `generate_and_upload_thumbnail_sync`. |
| `main.py::_setup_minio` | → `def` + offloaded | Nothing but blocking bucket round trips; held the loop for the whole bootstrap while the API was already serving. |
| `main.py::_adopt_managed_embedding_model` | → `def` + offloaded | Blocking OpenSearch (model-id write + ingest-pipeline PUT). |
| `api/websockets.py::setup_redis` | → `def` | `redis.asyncio.from_url` only builds a lazily-connecting pool; `asyncio.create_task` wants a running loop, not an `await`. |
| `api/websockets.py::ConnectionManager.connect` | → `def` | In-memory bookkeeping, no I/O. Now matches `disconnect`. |
| `main.py::handle_app_error` | **left `async def`** | See below. |

### Call sites changed

| Call site | Before | After |
|---|---|---|
| `files/upload.py::process_file_upload` | `await check_duplicate_by_hash(...)` | `await run_in_threadpool(check_duplicate_by_hash, ...)` |
| `files/prepare_upload.py::prepare_upload` | `await cleanup_failed_duplicates(...)` | `await run_in_threadpool(cleanup_failed_duplicates, ...)` |
| `files/prepare_upload.py::prepare_upload` | `await check_duplicate_by_hash(...)` | `await run_in_threadpool(check_duplicate_by_hash, ...)` |
| `main.py::lifespan` | `asyncio.create_task(_setup_minio())` | `asyncio.create_task(run_in_threadpool(_setup_minio))` |
| `main.py::_initialize_neural_search` | `await _adopt_managed_embedding_model(...)` | `await run_in_threadpool(_adopt_managed_embedding_model, ...)` |
| `api/websockets.py::websocket_endpoint` ×2 | `await setup_redis()`, `await manager.connect(...)` | direct calls |
| `api/websockets.py::publish_notification` | `await setup_redis()` | direct call |
| `services/media_download_service.py` | imports/calls `..._sync` | imports/calls `generate_and_upload_thumbnail` |
| `tests/unit/test_opensearch_auth.py` ×3 | `@pytest.mark.asyncio` + `await ...` | plain `def` + direct call |

Both upload handlers genuinely await elsewhere, so they correctly stay coroutines —
only the blocking helper moved off the loop.

`generate_and_upload_thumbnail` and `..._sync` had **identical bodies**; only the
`_sync` one had a caller. Deleted the coroutine and dropped the now-meaningless
suffix from the survivor, per the repo's one-path-per-job rule.

### `handle_app_error` deliberately stays a coroutine

Starlette 0.48 *does* accept a plain `def` exception handler — `_exception_handler.py`
branches on `is_async_callable(handler)` and dispatches a sync one through
`run_in_threadpool`. So it is not *required* to be `async`. It stays `async def`
anyway because its body is a dict lookup and a `JSONResponse` construction with **no
I/O to free**: declaring it `def` would buy a thread hop on every error response and
nothing else. A comment now says so in place, so the next AST sweep doesn't "fix" it.

After this PR it is the **only** awaitless `async def` left in `backend/app` (verified
by a full-tree AST sweep).

---

## Part B — the SSE generators (a defect #329 did not reach)

Making the *handlers* `def` only moved the few lines that construct the generator
object. Starlette then iterates the generator **on the event loop** for the whole life
of the stream — so a synchronous call in there blocks far longer than a single
request would.

**`files/__init__.py::download_stream`**
- `_ready_frame()` → `await run_in_threadpool(_ready_frame)` (both call sites). It
  stats object storage and presigns.
- `_ensure_prepare_enqueued(...)` → `await run_in_threadpool(...)`. Synchronous Redis
  `SETNX` plus a Celery dispatch (a second blocking broker round trip).

**`files/subtitles.py::bulk_export_stream`**
- The result-cache read moved off the synchronous `get_redis()` singleton onto the
  `redis.asyncio` client the generator already creates for pub/sub. Same URL, same
  db 0 — `core/redis.py` and the generator both use `settings.REDIS_URL`, and the
  writer (`tasks/media_download.py`) uses `get_redis().setex` on the same key.
- The client is now created first and closed in a `finally`; the pub/sub teardown is
  nested inside so an early cache hit no longer opens a connection purely to
  unsubscribe from something it never subscribed to.

### The A1.22 ordering survived

`download_stream` is deliberately **check → subscribe → re-check** to close a
lost-wakeup race. Both checks were offloaded *in place*; the ordering is unchanged and
is now pinned by `test_download_stream_keeps_the_check_subscribe_recheck_order`, which
AST-asserts that the two `run_in_threadpool(_ready_frame)` calls straddle the single
`pubsub.subscribe(...)`. Deleting the second check makes that test fail (verified).

---

## Guards added to `tests/api/test_handler_blocking_io.py`

1. Seven converted helpers added to `BLOCKING_HELPERS`, with dotted-name resolution so
   `ConnectionManager.connect` can be pinned.
2. `test_sse_generators_do_not_call_blocking_helpers_inline` — AST-walks each SSE
   generator and fails if a blocking helper (`_ready_frame`,
   `_ensure_prepare_enqueued`, `get_redis`) is *called* inside it. Passing the callable
   to `run_in_threadpool` is a bare `Name`, not a `Call`, so the honest form passes.
3. `test_download_stream_keeps_the_check_subscribe_recheck_order` (above).

Both new guards were confirmed to **fail** on a deliberately reintroduced regression.

---

## Verification

- `pytest tests/unit tests/api` → **2048 passed, 39 skipped**, against a throwaway
  Postgres 16 matching CI's shape (removed afterwards). The pre-existing AST guard
  suite is green (72 tests).
- `import app.main` OK. Route digest `b409de499c9755f9` / 409 routes, unchanged.
- `pre-commit run --all-files` green (ruff, ruff-format, mypy, bandit, import-linter,
  gitleaks, hadolint, shellcheck, prettier, frontend build).
- **SSE endpoints exercised, not just type-checked.** A throwaway pytest harness
  (not committed) drove both endpoints through the real ASGI stack against a
  throwaway Redis container: unauthenticated `download-stream` and
  `bulk-export-stream` both still 401; the `download-stream` ready fast path emits a
  `ready` frame; the full path (both checks miss → subscribe → enqueue → `progress`
  frame → a `completed` message published by a background thread once `PUBSUB NUMSUB`
  shows the subscriber → `ready` frame) works; `bulk-export-stream` delivers both the
  seeded result-cache hit and the pub/sub `progress`→`ready` sequence. The **same
  harness passes unmodified against master's SSE code**, which is the behaviour-parity
  control.

### Stated plainly — not covered

- **MinIO/OpenSearch-gated suites were skipped** (`SKIP_S3`/`SKIP_OPENSEARCH=True`),
  deliberately, to avoid writing into the shared dev stack's live data. So
  `_setup_minio` and `_adopt_managed_embedding_model` have **no live-service run**;
  they have no dedicated tests in-tree either way. Same caveat #329 recorded.
- The WebSocket changes are covered only by import/route checks — there is no WS
  connect/disconnect test in the fast suite.

### Found, not fixed (out of scope)

`bulk_export_stream` has **no re-check after subscribe** — it is still plain
check-then-subscribe, the exact shape #284 A1.22 fixed for `download_stream`. If the
worker's `setex` + `publish` lands in the gap between the cache read and the
subscribe, that stream waits forever on a message it already missed. Closing it is a
behaviour change and belongs in its own PR.

Refs #320.
