### PR TITLE
security(auth): consult the database when Redis is down instead of a per-process store

### DIFF
--- a/backend/app/api/endpoints/auth/dependencies.py
+++ b/backend/app/api/endpoints/auth/dependencies.py
@@ -152,7 +152,7 @@ def get_current_user(
         if (
             settings.TOKEN_REVOCATION_ENABLED
             and token_jti
-            and token_service.is_token_revoked(token_jti)
+            and token_service.is_token_revoked(token_jti, db=db, user_uuid=user_uuid_str)
         ):
             logger.warning(f"Rejected revoked token (jti={token_jti[:8]}...)")
             raise credentials_exception
@@ -304,7 +304,7 @@ def get_optional_current_user(
         if (
             settings.TOKEN_REVOCATION_ENABLED
             and token_jti
-            and token_service.is_token_revoked(token_jti)
+            and token_service.is_token_revoked(token_jti, db=db, user_uuid=user_uuid_str)
         ):
             return None
 

--- a/backend/app/api/websockets.py
+++ b/backend/app/api/websockets.py
@@ -241,7 +241,7 @@ def _try_authenticate_token(
         if (
             settings.TOKEN_REVOCATION_ENABLED
             and token_jti
-            and token_service.is_token_revoked(token_jti)
+            and token_service.is_token_revoked(token_jti, db=db, user_uuid=user_identifier)
         ):
             logger.warning("Rejected revoked token on WebSocket (jti=%s...)", token_jti[:8])
             return None

--- a/backend/app/auth/token_service.py
+++ b/backend/app/auth/token_service.py
@@ -29,11 +29,31 @@ from app.auth.session import InMemoryStore
 from app.auth.session import get_redis_client
 from app.core.config import settings
 from app.models.refresh_token import RefreshToken
+from app.models.user import User
 
 logger = logging.getLogger(__name__)
 
 # Redis key prefix for revoked tokens (not a password)
 REVOKED_TOKEN_PREFIX = "revoked:jti:"  # noqa: S105 # nosec B105
+
+
+def _record_degradation(control: str, fallback: str) -> None:
+    """Count a security control running without its shared state store.
+
+    Imported lazily and never allowed to raise: metrics must not be able to break
+    an authentication path. Prometheus is optional in some deployments, and this
+    runs on the request path for every revocation check while Redis is down.
+    """
+    try:
+        from app.core.metrics import security_state_degraded_total
+
+        security_state_degraded_total.labels(control=control, fallback=fallback).inc()
+    except Exception:  # pragma: no cover - metrics must never break auth
+        # Swallowed on purpose, but never silently: PR #322 removed the blanket
+        # S110 exemption precisely because silent handlers hide real faults. A
+        # broken counter must not turn into a failed login, so this degrades to a
+        # log line instead of propagating.
+        logger.debug("Could not record security degradation metric", exc_info=True)
 
 
 class TokenService:
@@ -53,6 +73,18 @@ class TokenService:
     def __init__(self):
         """Initialize the token service."""
         self._store = None
+        self._degraded = False
+
+    @property
+    def degraded(self) -> bool:
+        """Whether the revocation blacklist is running without shared state.
+
+        True means Redis was unreachable and this process fell back to a
+        per-process store. The blacklist is then neither shared across replicas
+        nor durable across restarts, so it must not be trusted as the answer to
+        "is this token revoked?" — see :meth:`is_token_revoked`.
+        """
+        return self._degraded
 
     @property
     def store(self):
@@ -61,10 +93,20 @@ class TokenService:
             redis_client = get_redis_client()
             if redis_client:
                 self._store = redis_client
+                self._degraded = False
             else:
-                logger.warning(
-                    "Redis unavailable for token revocation. "
-                    "Using in-memory store (not recommended for production)."
+                self._degraded = True
+                # Not a warning. Without shared state, revocation stops working
+                # across replicas: a token revoked on one replica still passes on
+                # every other, so "log out all devices" and password-reset
+                # revocation silently mean nothing (issue #324). This used to log
+                # at warning level and scrolled past unnoticed.
+                _record_degradation("token_revocation", "database")
+                logger.critical(
+                    "Redis unavailable for token revocation — falling back to the "
+                    "database for refresh-token revocation checks. Revocation is "
+                    "NOT shared across replicas while this persists. Restore Redis; "
+                    "on AWS use ElastiCache with Multi-AZ and automatic failover."
                 )
                 self._store = InMemoryStore()
         return self._store
@@ -314,7 +356,7 @@ class TokenService:
                 return None, None
 
             # Check Redis blacklist first (fast path)
-            if self.is_token_revoked(jti):
+            if self.is_token_revoked(jti, db=db):
                 logger.warning(f"Token verification failed: JTI {jti[:8]}... is revoked")
                 return None, None
 
@@ -475,22 +517,139 @@ class TokenService:
             db.rollback()
             return 0
 
-    def is_token_revoked(self, jti: str) -> bool:
+    def is_token_revoked(
+        self,
+        jti: str,
+        db: Session | None = None,
+        user_uuid: str | None = None,
+    ) -> bool:
         """
         Check if a token JTI is on the revocation blacklist.
 
+        Redis is a **cache** here, not the system of record: ``refresh_token``
+        carries a durable ``revoked_at``. So when Redis is unreachable this does
+        NOT trust the per-process fallback store (which is empty on a fresh
+        process and unshared between replicas, i.e. it answers "not revoked" to
+        everything). It consults the database instead — authoritative, durable,
+        and shared by every replica — and denies when it cannot (issue #324).
+
         Args:
             jti: The JWT ID to check
+            db: Session used for the authoritative fallback. Without it, a
+                degraded check fails **closed**.
+            user_uuid: Subject of the token. Lets the fallback answer for
+                *access* tokens, which have no ``refresh_token`` row of their own.
 
         Returns:
-            True if revoked, False if valid
+            True if revoked (or if revocation cannot be verified), False if valid
         """
         if not settings.TOKEN_REVOCATION_ENABLED:
             return False
 
         key = f"{REVOKED_TOKEN_PREFIX}{jti}"
-        result = self.store.get(key)
+
+        # Touch `store` first: it sets `_degraded` on the first failed connect.
+        store = self.store
+        if self._degraded:
+            return self._is_revoked_without_redis(jti, db, user_uuid)
+
+        try:
+            result = store.get(key)
+        except Exception:
+            # Redis was reachable at startup and died since.
+            self._degraded = True
+            logger.critical(
+                "Redis lookup failed for token revocation (jti=%s...); falling back "
+                "to the database. Revocation is NOT shared across replicas while "
+                "this persists.",
+                jti[:8],
+            )
+            return self._is_revoked_without_redis(jti, db, user_uuid)
         return result is not None
+
+    def _is_revoked_without_redis(
+        self,
+        jti: str,
+        db: Session | None,
+        user_uuid: str | None,
+    ) -> bool:
+        """Answer "is this token revoked?" from the database instead of Redis.
+
+        Cache-aside: on cache failure, consult the system of record. Returning
+        the per-process store's answer instead would report "not revoked" for
+        everything, because that store is empty in a fresh process and is never
+        shared between replicas.
+
+        Two cases, because access tokens have no ``refresh_token`` row:
+
+        1. **The JTI is a refresh token.** ``revoked_at`` is authoritative.
+        2. **The JTI is an access token.** Nothing durable records it, so fall
+           back to the user: if every one of their refresh tokens is revoked,
+           their sessions were terminated (logout-all, password reset, admin
+           action) and this access token goes with them. That covers the reason
+           revocation is actually used. Access tokens are short-lived, so an
+           unrevoked-user access token is bounded by its own expiry anyway.
+
+        Without a session, or if the query itself fails, this **denies**. A
+        wrongly-denied request costs a re-authentication; a wrongly-allowed one
+        honours a token someone explicitly revoked.
+        """
+        if db is None:
+            _record_degradation("token_revocation", "deny")
+            logger.critical(
+                "Cannot verify revocation for jti=%s... — Redis is down and no database "
+                "session was supplied. Denying (fail closed).",
+                jti[:8],
+            )
+            return True
+
+        try:
+            row = db.query(RefreshToken).filter(RefreshToken.jti == jti).first()
+            if row is not None:
+                _record_degradation("token_revocation", "database")
+                return row.revoked_at is not None
+
+            if user_uuid is None:
+                _record_degradation("token_revocation", "deny")
+                return True
+
+            # Access token: no durable row of its own, so infer from the user's
+            # sessions — but only on POSITIVE evidence of revocation.
+            #
+            # "This user has no refresh tokens" is NOT such evidence. Some auth
+            # paths never mint one, so treating absence as revocation would lock
+            # those users out every time Redis blinked. Deny only when the user
+            # demonstrably had sessions and every one of them was revoked, which
+            # is what logout-all / password reset / admin termination produce.
+            # Otherwise allow, bounded by the access token's own short expiry.
+            has_any = (
+                db.query(RefreshToken)
+                .join(User, User.id == RefreshToken.user_id)
+                .filter(User.uuid == user_uuid)
+                .first()
+            )
+            _record_degradation("token_revocation", "database")
+            if has_any is None:
+                return False
+
+            live = (
+                db.query(RefreshToken)
+                .join(User, User.id == RefreshToken.user_id)
+                .filter(
+                    User.uuid == user_uuid,
+                    RefreshToken.revoked_at.is_(None),
+                    RefreshToken.expires_at > datetime.now(UTC),
+                )
+                .first()
+            )
+            return live is None
+        except Exception:
+            _record_degradation("token_revocation", "deny")
+            logger.critical(
+                "Database revocation fallback failed for jti=%s...; denying (fail closed).",
+                jti[:8],
+            )
+            return True
 
     def cleanup_expired_tokens(self, db: Session) -> int:
         """

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -86,6 +86,7 @@ http_requests_in_flight: Gauge
 db_query_duration_seconds: Histogram
 db_queries_per_request: Histogram
 cache_operations_total: Counter
+security_state_degraded_total: Counter
 celery_queue_depth: Gauge
 user_signups_total: Counter
 files_uploaded_total: Counter
@@ -107,6 +108,7 @@ def _register() -> None:
     global db_query_duration_seconds
     global db_queries_per_request
     global cache_operations_total
+    global security_state_degraded_total
     global celery_queue_depth
     global user_signups_total
     global files_uploaded_total
@@ -152,6 +154,15 @@ def _register() -> None:
         "cache_operations_total",
         "Cache lookups by backend and result.",
         ["cache", "result"],
+    )
+    security_state_degraded_total = Counter(
+        "security_state_degraded_total",
+        "Times a security control could not reach its shared state store (Redis) and "
+        "fell back. ALERT ON THIS: shared state is what makes revocation, lockout and "
+        "MFA replay protection work across replicas. `control` is the control affected; "
+        "`fallback` is what was used instead (database = authoritative, deny = failed "
+        "closed, local = per-process approximation).",
+        ["control", "fallback"],
     )
     celery_queue_depth = Gauge(
         "celery_queue_depth",

--- a/backend/tests/unit/test_handler_and_ws_hardening.py
+++ b/backend/tests/unit/test_handler_and_ws_hardening.py
@@ -132,7 +132,7 @@ def test_websocket_auth_returns_none_for_revoked_token(monkeypatch):
     import app.auth.provider_registry as _registry
 
     monkeypatch.setattr(_registry, "has_verifiers", lambda: False)
-    monkeypatch.setattr(ws_module.token_service, "is_token_revoked", lambda jti: True)
+    monkeypatch.setattr(ws_module.token_service, "is_token_revoked", lambda jti, **_kw: True)
 
     assert ws_module._try_authenticate_token("tok", db) is None
 
@@ -159,7 +159,7 @@ def test_websocket_auth_accepts_active_user_with_valid_token(monkeypatch):
     import app.auth.provider_registry as _registry
 
     monkeypatch.setattr(_registry, "has_verifiers", lambda: False)
-    monkeypatch.setattr(ws_module.token_service, "is_token_revoked", lambda jti: False)
+    monkeypatch.setattr(ws_module.token_service, "is_token_revoked", lambda jti, **_kw: False)
 
     assert ws_module._try_authenticate_token("tok", db) is cast("User", active)
 

--- a/backend/tests/unit/test_revocation_fails_closed.py
+++ b/backend/tests/unit/test_revocation_fails_closed.py
@@ -1,0 +1,195 @@
+"""Token revocation must not silently weaken when Redis is unavailable (issue #324).
+
+`TokenService.store` falls back to a per-process `InMemoryStore` when Redis cannot
+be reached. That store is empty in a fresh process and is never shared between
+replicas, so trusting it answers "not revoked" to *everything*: on multi-replica
+AWS a token revoked on one replica still passes on every other, and "log out all
+devices" / password-reset revocation silently stop meaning anything.
+
+Redis here is a cache, not the system of record — `refresh_token.revoked_at` is
+durable and shared. So the degraded path consults the database, and denies when it
+cannot. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.auth.token_service import TokenService
+
+
+@pytest.mark.unit
+class TestRevocationFailsClosed:
+    """When Redis is gone, never answer "not revoked" from per-process memory."""
+
+    def test_degraded_without_db_denies(self):
+        """No database session while degraded must deny, not allow.
+
+        This is the core regression: the old code consulted the empty in-memory
+        store and returned False (valid) for every token.
+        """
+        svc = TokenService()
+        svc._store = _RaisingStore()
+        svc._degraded = True
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            assert svc.is_token_revoked("some-jti") is True
+
+    def test_degraded_uses_db_verdict_for_refresh_token(self):
+        """A refresh token's `revoked_at` is authoritative while degraded."""
+        svc = TokenService()
+        svc._degraded = True
+
+        revoked = _Row(revoked_at=datetime.now(UTC))
+        live = _Row(revoked_at=None)
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            assert svc.is_token_revoked("jti", db=cast(Session, _DbReturning(revoked))) is True
+            assert svc.is_token_revoked("jti", db=cast(Session, _DbReturning(live))) is False
+
+    def test_degraded_access_token_denied_when_all_sessions_revoked(self):
+        """An access token dies with the user's last live refresh token.
+
+        Access tokens have no `refresh_token` row, so the fallback infers from the
+        user's sessions: they had some, all are revoked => logout-all / password
+        reset happened => deny.
+        """
+        svc = TokenService()
+        svc._degraded = True
+
+        revoked = _Row(revoked_at=datetime.now(UTC))
+        with patch.object(type(svc), "store", _RaisingStore()):
+            # jti not found; user HAS tokens; none live => revoked.
+            db = _DbSequence([None, revoked, None])
+            assert svc.is_token_revoked("access-jti", db=cast(Session, db), user_uuid="u") is True
+
+            # jti not found; user has tokens; one still live => valid.
+            live = _Row(revoked_at=None, expires_at=datetime.now(UTC) + timedelta(hours=1))
+            db2 = _DbSequence([None, live, live])
+            assert svc.is_token_revoked("access-jti", db=cast(Session, db2), user_uuid="u") is False
+
+    def test_user_with_no_refresh_tokens_is_not_treated_as_revoked(self):
+        """Absence of refresh tokens is NOT evidence of revocation.
+
+        Regression: an earlier version of this fallback denied whenever the user had
+        no live refresh token, which also denied users whose auth path never mints
+        one — locking out valid sessions every time Redis blinked. It broke
+        `test_websocket_auth_accepts_active_user_with_valid_token`. Deny requires
+        positive evidence: the user had sessions and all of them were revoked.
+        """
+        svc = TokenService()
+        svc._degraded = True
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            # jti not found, and the user has no refresh tokens at all.
+            db = _DbSequence([None, None])
+            assert svc.is_token_revoked("access-jti", db=cast(Session, db), user_uuid="u") is False
+
+    def test_degraded_access_token_without_user_denies(self):
+        """Cannot identify the subject while degraded => deny."""
+        svc = TokenService()
+        svc._degraded = True
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            assert svc.is_token_revoked("access-jti", db=cast(Session, _DbReturning(None))) is True
+
+    def test_db_failure_while_degraded_denies(self):
+        """If the authoritative fallback itself fails, deny rather than allow."""
+        svc = TokenService()
+        svc._degraded = True
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            assert (
+                svc.is_token_revoked("jti", db=cast(Session, _DbRaising()), user_uuid="u") is True
+            )
+
+    def test_redis_failing_mid_flight_switches_to_db(self):
+        """A store that starts healthy and then raises must fall back, not 500."""
+        svc = TokenService()
+        svc._degraded = False
+
+        with patch.object(type(svc), "store", _RaisingStore()):
+            revoked = _Row(revoked_at=datetime.now(UTC))
+            assert svc.is_token_revoked("jti", db=cast(Session, _DbReturning(revoked))) is True
+            assert svc.degraded is True, "must latch the degraded flag"
+
+
+# ---------------------------------------------------------------------------
+# Fakes — this exercises the degraded decision path, not SQL or Redis.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingStore:
+    """Stands in for Redis being unreachable at lookup time."""
+
+    def get(self, _key):
+        raise ConnectionError("redis down")
+
+
+class _Row:
+    def __init__(self, revoked_at=None, expires_at=None):
+        self.revoked_at = revoked_at
+        self.expires_at = expires_at
+
+
+class _Q:
+    def __init__(self, db):
+        self._db = db
+
+    def filter(self, *_a, **_k):
+        return self
+
+    def join(self, *_a, **_k):
+        return self
+
+    def first(self):
+        return self._db._next_result()
+
+
+class _DbReturning:
+    """Returns `first` on the first query and `second` on the next."""
+
+    def __init__(self, first, second=None):
+        self._results = [first, second]
+        self._i = 0
+
+    def _next_result(self):
+        r = self._results[min(self._i, len(self._results) - 1)]
+        self._i += 1
+        return r
+
+    def query(self, *_a, **_k):
+        return _Q(self)
+
+
+class _DbSequence:
+    """Returns each queued result in turn, then repeats the last.
+
+    The access-token path issues up to three queries: the jti lookup, the
+    "does this user have any refresh token" probe, then the "is any of them
+    live" probe.
+    """
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._i = 0
+
+    def _next_result(self):
+        r = self._results[min(self._i, len(self._results) - 1)]
+        self._i += 1
+        return r
+
+    def query(self, *_a, **_k):
+        return _Q(self)
+
+
+class _DbRaising:
+    def query(self, *_a, **_k):
+        raise RuntimeError("database unavailable")


### PR DESCRIPTION
Implements the plan agreed in #324 (see [that comment](https://github.com/attevon-llc/OpenTranscribe/issues/324#issuecomment-5197479357) for the full reasoning). Covers items 1 and 2. Refs #284.

## The defect

`TokenService.store` falls back to an `InMemoryStore` when Redis is unreachable, logging at `warning`. That store is **empty in a fresh process and never shared between replicas**, so trusting it answers "not revoked" to every token.

On a multi-replica deployment that is a real bypass: a token revoked on one replica still passes on every other, so **"log out all devices" and password-reset revocation silently stop meaning anything** — the control you reach for *during* an incident. On a single node it is less severe (one process, so per-process state *is* shared state) but still loses durability across restarts.

## The fix: fall back to the database, not to memory, and not to blanket-deny

Redis here is a **cache**, not the system of record — `refresh_token.revoked_at` is durable and shared by every replica. So the degraded path does the standard cache-aside thing and consults the system of record. That is simultaneously secure (authoritative), available (no forced logout during a blip), and correct across replicas.

| Case | Behaviour when Redis is unavailable |
|---|---|
| JTI is a refresh token | `revoked_at` is authoritative |
| JTI is an access token | Infer from the user`s sessions — **positive evidence only** (see below) |
| No DB session, or the fallback query raises | **Deny** |

**"This user has no refresh tokens" is deliberately NOT treated as revocation.** My first cut denied whenever there was no *live* refresh token, which would also have denied users whose auth path never mints one — locking valid sessions out every time Redis blinked. Deny now requires that the user demonstrably had sessions and every one was revoked, which is what logout-all / password reset / admin termination produce. Otherwise allow, bounded by the access token`s own short expiry.

A wrongly-denied request costs a re-authentication; a wrongly-allowed one honours a token someone explicitly revoked.

## Visibility

Degradation logs at `logger.critical` (was `warning` — silent degradation is the actual defect) and increments a new `security_state_degraded_total{control,fallback}` counter so it can page someone. The metric helper cannot raise — a broken counter must not become a failed login — but it **logs rather than swallowing silently**, since PR #322 removed the blanket `S110` exemption for exactly that reason.

## Same posture for self-hosted and cloud

Gating is `ENVIRONMENT`-based, which defaults to `production`; only `{development, dev, testing, test, local}` relax. So a single box at home and multi-replica AWS behave identically — only a developer laptop keeps the in-memory convenience. This is deliberately **not** an open-source-vs-cloud distinction.

**No opt-out flag, deliberately.** An off-switch on a security control gets flipped during exactly the incident it guards against. The availability objection does not hold either: Redis is also the Celery broker, so if it is down transcription is already dead — and the DB fallback shrinks the genuinely-degraded window to near zero.

## API change

`is_token_revoked` gains optional `db` and `user_uuid`. All four call sites pass them (`auth/dependencies.py` ×2, `websockets.py`, and the internal call in `verify_refresh_token`). Two WS test stubs used the old single-argument signature and are updated. Redis failing *mid-flight* is caught and latches the degraded flag rather than surfacing a 500.

## Tests

Seven regression tests: deny without a session; DB verdict for refresh tokens; access-token inference in both directions; **absence-is-not-revocation**; deny when the fallback query raises; and latching on a mid-flight Redis failure.

Honest caveat: unlike #331`s tests, these **cannot** be shown to fail against the old code — the signature changed, so they would `TypeError` rather than fail meaningfully. What they prove is the behavioural claim directly: the in-memory store would answer "not revoked", the database says revoked, and the code returns revoked.

Note the test environment has **no Redis**, so the entire suite now exercises this degraded path on every run.

## Follow-up not in this PR

AWS deployment docs should require **ElastiCache Redis with Multi-AZ + automatic failover**, so the degraded window is seconds of failover rather than an outage. Items 4–6 of #324 remain open.