### PR TITLE
fix(file-detail): re-emit tagsUpdated from TagsSection (#335)

### DIFF
--- a/frontend/src/components/TagsSection.svelte
+++ b/frontend/src/components/TagsSection.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import { slide } from 'svelte/transition';
   import { t } from '$stores/locale';
+  import type { Tag } from '$lib/types/tag';
   import TagsEditor from './TagsEditor.svelte';
 
   export let file: any = null;
   export let isTagsExpanded: boolean = false;
   export let aiTagSuggestions: Array<{name: string, confidence: number, rationale?: string}> = [];
 
+  const dispatch = createEventDispatcher<{ tagsUpdated: { tags: Tag[] } }>();
+
   function toggleTags() {
     isTagsExpanded = !isTagsExpanded;
   }
 
-  function handleTagsUpdated(event: any) {
-    // Re-emit the event to parent component
-    if (file) {
-      file.tags = event.detail.tags;
-    }
+  // The file-detail page owns `file`; forward the editor's update instead of
+  // mutating the prop, so the page can update its state and `reactiveFile`.
+  function forwardTagsUpdated(event: CustomEvent<{ tags: Tag[] }>) {
+    dispatch('tagsUpdated', event.detail);
   }
 </script>
 
@@ -52,7 +55,7 @@
           fileId={String(file.uuid)}
           tags={file.tags || []}
           aiSuggestions={aiTagSuggestions}
-          on:tagsUpdated={handleTagsUpdated}
+          on:tagsUpdated={forwardTagsUpdated}
         />
       {:else}
         <p>{$t('tags.loadingTags')}</p>

--- a/frontend/src/components/TagsSection.test.ts
+++ b/frontend/src/components/TagsSection.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression guard for #335.
+ *
+ * `TagsSection` used to carry a handler commented "Re-emit the event to parent
+ * component" that never called `dispatch` — it mutated the `file` prop and
+ * stopped. The file-detail page listens for `tagsUpdated` to update its own
+ * state and `reactiveFile`, so tag edits never propagated. These tests pin the
+ * forwarding: the editor's `tagsUpdated` must reach the page unchanged, and the
+ * section must not mutate the page-owned `file` object.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import TagsSection from './TagsSection.svelte';
+
+const axiosMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('$lib/axios', () => ({ default: axiosMock }));
+
+function fileWithTags() {
+  return {
+    uuid: 'file-uuid-1',
+    tags: [{ uuid: 'tag-uuid-1', name: 'alpha' }],
+  };
+}
+
+describe('TagsSection (#335 tag update forwarding)', () => {
+  beforeEach(() => {
+    axiosMock.get.mockReset().mockResolvedValue({ data: [] });
+    axiosMock.post.mockReset().mockResolvedValue({ data: {} });
+    axiosMock.delete.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  it('re-emits `tagsUpdated` from the editor to its parent', async () => {
+    const onTagsUpdated = vi.fn();
+    const file = fileWithTags();
+
+    const { container } = render(TagsSection, {
+      props: { file, isTagsExpanded: true },
+      events: { tagsUpdated: onTagsUpdated },
+    });
+
+    const removeButton = container.querySelector('.tag-remove') as HTMLButtonElement;
+    expect(removeButton).toBeTruthy();
+    await fireEvent.click(removeButton);
+
+    await waitFor(() => expect(onTagsUpdated).toHaveBeenCalledTimes(1));
+    expect((onTagsUpdated.mock.calls[0][0] as CustomEvent).detail).toEqual({ tags: [] });
+  });
+
+  it('leaves the page-owned `file.tags` untouched — the page applies the update', async () => {
+    const file = fileWithTags();
+
+    const { container } = render(TagsSection, {
+      props: { file, isTagsExpanded: true },
+      events: { tagsUpdated: vi.fn() },
+    });
+
+    await fireEvent.click(container.querySelector('.tag-remove') as HTMLButtonElement);
+
+    await waitFor(() => expect(axiosMock.delete).toHaveBeenCalledTimes(1));
+    expect(file.tags).toEqual([{ uuid: 'tag-uuid-1', name: 'alpha' }]);
+  });
+});


### PR DESCRIPTION
Fixes #335.

## The bug

`frontend/src/components/TagsSection.svelte` carried a handler whose comment said
"Re-emit the event to parent component" — but the file had no `createEventDispatcher`
and no `dispatch(...)` anywhere. It assigned `file.tags` on the prop object and stopped.

`routes/files/[id]/+page.svelte:2082` listens `on:tagsUpdated={handleTagsUpdated}`, and
*its* handler (`file.tags = ...` **plus** `reactiveFile.set(file)`) is the one that
matters. That line never ran, so `reactiveFile` and its subscribers kept stale tag state.
Both functions were named `handleTagsUpdated`, which is likely how the dead wiring
survived review.

Because the child mutated the shared `file` object in place, the header preview *did*
refresh — so the feature looked like it worked. That is the "code that reads correct and
silently does nothing" class #284 has been chasing.

## The fix

- Add `createEventDispatcher` and forward the editor's event unchanged, matching the
  sibling `CollectionsSection` and `components/fileDetail/CLAUDE.md`: *"The route page
  owns the state and orchestration; these children take props and dispatch events."*
- **Drop the child's direct `file.tags` mutation.** The page owns `file`, applies the
  update, and the new value flows back down as a prop (verified in a browser — the header
  preview still refreshes on both add and remove). Keeping both would leave two paths
  doing the same job, and it was that mutation that disguised the bug.
- Rename the child's handler to `forwardTagsUpdated`; the page keeps `handleTagsUpdated`
  next to `handleCollectionsUpdated`. Direction is now legible: child forwards, page handles.
- New `TagsSection.test.ts` pins both halves: the event is re-emitted with the editor's
  payload, and the page-owned `file.tags` is left untouched. Both tests fail against the
  pre-fix component.

## Verification

Gates: `npm run lint` (0 errors), `svelte-check --threshold error` (0 errors),
`npm run build`, `npm run test` (29 files / 153 tests), `npm run check:i18n`,
and the full `pre-commit` run — all green.

Browser, against the live dev stack, **light and dark**, with a temporary probe exposing
the page's `reactiveFile` (probe removed before committing — the committed diff is the two
files above):

| | page handler calls | `reactiveFile` emissions | header preview |
|---|---|---|---|
| **before fix** | 0 | `[[]]` (initial only) | still updated — the misleading symptom |
| **after fix** | 2 (add, remove) | `[] -> [Important] -> []` | updates on add and remove |

Add was exercised in light mode, remove in dark mode.

**No dev data left behind.** An existing library tag (`Important`, `usage_count` 0) was
attached and then detached in the same session — no new tag rows. Confirmed afterwards:
`GET /api/files/{uuid}` returns `tags: []` and `GET /api/tags` still lists the same 4 tags,
all at `usage_count` 0.

## Out of scope

- `file: any` stays — the three-way tag-shape disagreement is #326 and needs a backend decision.
- Unrelated pre-existing 404 seen during verification: `GET /api/files/{uuid}/suggestions`
  returns 404 ("No AI suggestions found... Run extraction first") for files without
  extraction, and the page logs it as a console error. Present identically before and
  after this change; not touched here.
