### PR TITLE
fix(sse): re-check the bulk-export result cache after subscribing (#334)

### DIFF
--- a/backend/app/api/CLAUDE.md
+++ b/backend/app/api/CLAUDE.md
@@ -63,6 +63,11 @@ See `backend/CLAUDE.md`, `backend/app/auth/CLAUDE.md`, `backend/app/services/CLA
   first, then a same-named system row. Tag names are only unique **per owner**, so
   `remove_tag_from_file` resolves the tag by joining `FileTag` for that file, never by name.
 - `GET /api/auth/session` must **never 401** (200 for anonymous); it is the SPA's session probe.
+- **Both SSE streams go check → subscribe → re-check.** `download_stream` (`files/__init__.py`)
+  and `bulk_export_stream` (`files/subtitles.py`) read their readiness signal, subscribe to the
+  pub/sub channel, then read it **again**. A single check-then-subscribe loses a worker
+  completion published in the gap and the stream waits on `get_message` forever (#284 A1.22,
+  #334). `test_handler_blocking_io.py` AST-pins the ordering for both.
 - The WS endpoint `accept()`s *before* authenticating (cookie, else a 10 s first-message
   `authenticate` frame), then closes with 4001/4002/4003 — not HTTP status codes.
 - Never touch `websockets.manager` from sync code; publish with

--- a/backend/app/api/endpoints/files/subtitles.py
+++ b/backend/app/api/endpoints/files/subtitles.py
@@ -273,8 +273,9 @@ def bulk_export_stream(
     """Server-Sent Events stream for an async bulk export.
 
     Events: ``progress`` (status text), ``ready`` (``{url, filename, exported, skipped}``),
-    ``error`` (``{message}``). On connect the reconnect-safe result cache is checked first,
-    so a dropped EventSource still delivers once the worker has finished — no polling.
+    ``error`` (``{message}``). The reconnect-safe result cache is read both before and
+    after subscribing, so a dropped EventSource — or a job that finishes inside the
+    subscribe window (issue #334) — still delivers without polling.
     """
     import asyncio
     import contextlib
@@ -298,16 +299,36 @@ def bulk_export_stream(
         client = aioredis.from_url(
             settings.REDIS_URL, health_check_interval=30, socket_keepalive=True
         )
+
+        async def ready_frame() -> str | None:
+            """SSE ``ready`` frame if the worker already cached a result, else None."""
+            cached = await client.get(f"bulk_export_result:{job}")
+            return sse("ready", _json.loads(cached)) if cached else None
+
         try:
             # 1. Already finished? deliver immediately (covers reconnects after completion).
-            cached = await client.get(f"bulk_export_result:{job}")
-            if cached:
-                yield sse("ready", _json.loads(cached))
+            frame = await ready_frame()
+            if frame:
+                yield frame
                 return
 
             pubsub = client.pubsub()
             await pubsub.subscribe(bulk_export_channel(job))
             try:
+                # 2. RE-CHECK after subscribing (issue #334, mirroring #284 A1.22).
+                #
+                # A single check-then-subscribe has a lost-wakeup race: a worker that
+                # finishes in the gap writes the result key and publishes to an empty
+                # channel, and this stream then waits on `get_message` forever for an
+                # event that already happened — the export appears to hang while the
+                # ZIP sits ready in object storage. Re-reading after subscribing means
+                # the completion is either buffered on the subscription or visible to
+                # this second read; it cannot fall between them.
+                frame = await ready_frame()
+                if frame:
+                    yield frame
+                    return
+
                 yield sse("progress", {"message": "Preparing export…", "progress": 0})
                 while True:
                     try:

--- a/backend/tests/api/test_files_subtitles.py
+++ b/backend/tests/api/test_files_subtitles.py
@@ -1,23 +1,29 @@
 """Characterization tests for ``files/subtitles.py``.
 
-Covers subtitle export (SRT/VTT/TXT), validation, supported-formats, and the
-async bulk-export prepare endpoint wired under ``/api/files``.
+Covers subtitle export (SRT/VTT/TXT), validation, supported-formats, the async
+bulk-export prepare endpoint, and the bulk-export SSE stream wired under
+``/api/files``.
 
 Rows are created on the savepoint-isolated ``db_session`` (rolled back at
 teardown) with fabricated transcript segments where a real transcript is needed,
 so dev data is never touched. Celery dispatch is no-op'd by the autouse conftest
 fixture, so the bulk-export prepare path asserts the queued-job envelope, not
-worker side effects.
+worker side effects. The SSE test drives the generator against a stub async Redis
+client — no broker, no worker, and nothing written to the dev stack's Redis.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import uuid
 
 from fastapi import status
 
+from app.api.endpoints.files import subtitles
 from app.models.media import MediaFile
 from app.models.media import TranscriptSegment
+from app.models.user import User
 
 
 def _make_file(db_session, owner, *, file_status: str = "completed", **overrides) -> MediaFile:
@@ -279,3 +285,95 @@ def test_bulk_export_unauthorized(client):
         json={"file_uuids": [str(uuid.uuid4())], "subtitle_format": "srt"},
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# GET /api/files/bulk-export-stream  (SSE)
+# ---------------------------------------------------------------------------
+
+
+class _RaceyPubSub:
+    """Pub/sub stub that lets the worker finish exactly during ``subscribe``.
+
+    ``get_message`` never returns a message: the worker's ``completed`` publish
+    landed while nobody was subscribed, so it is gone for good. That is the lost
+    wakeup of issue #334 — the only remaining signal is the result cache.
+    """
+
+    def __init__(self, on_subscribe):
+        self._on_subscribe = on_subscribe
+        self.channel: str | None = None
+
+    async def subscribe(self, channel):
+        self.channel = channel
+        self._on_subscribe()
+
+    async def get_message(self, **_kwargs):
+        return None
+
+    async def unsubscribe(self, _channel):
+        return None
+
+    async def close(self):
+        return None
+
+
+class _RaceyRedis:
+    """Async Redis stub whose result key appears only once ``subscribe`` was called."""
+
+    def __init__(self, result):
+        self._result = result
+        self._finished = False
+        self.gets: list[str] = []
+        self._pubsub = _RaceyPubSub(self._worker_finishes)
+
+    def _worker_finishes(self):
+        self._finished = True
+
+    async def get(self, key):
+        self.gets.append(key)
+        return json.dumps(self._result) if self._finished else None
+
+    def pubsub(self):
+        return self._pubsub
+
+    async def close(self):
+        return None
+
+
+async def _first_frame(response):
+    """Return the first SSE frame emitted by a StreamingResponse."""
+    async for frame in response.body_iterator:
+        return frame
+    raise AssertionError("the stream closed without emitting a frame")
+
+
+def test_bulk_export_stream_recovers_a_completion_during_subscribe(monkeypatch):
+    """A job finishing in the check→subscribe gap must still deliver ``ready`` (#334).
+
+    The stub completes the job at the moment ``pubsub.subscribe`` is called and
+    publishes to nobody, exactly like a fast worker. With only the pre-subscribe
+    cache read the stream emits ``progress`` and then waits on ``get_message``
+    forever; the post-subscribe re-check is what turns it back into ``ready``.
+    """
+    result = {
+        "url": "https://storage.test/bulk/job-334.zip",
+        "filename": "transcripts_srt.zip",
+        "exported": 2,
+        "skipped": 0,
+    }
+    fake_redis = _RaceyRedis(result)
+    monkeypatch.setattr("redis.asyncio.from_url", lambda *args, **kwargs: fake_redis)
+
+    response = subtitles.bulk_export_stream(job="job-334", current_user=User())
+    frame = asyncio.run(_first_frame(response))
+
+    assert frame.startswith("event: ready"), (
+        f"expected the cached result, got {frame!r} — the completion published during "
+        "the subscribe window was lost, so the stream would hang until the client gave up"
+    )
+    assert json.loads(frame.split("data: ", 1)[1]) == result
+    assert fake_redis.gets == ["bulk_export_result:job-334"] * 2, (
+        "the result cache must be read before AND after subscribing"
+    )
+    assert fake_redis.pubsub().channel == "download_events:bulk:job-334"

--- a/backend/tests/api/test_handler_blocking_io.py
+++ b/backend/tests/api/test_handler_blocking_io.py
@@ -20,8 +20,9 @@ These tests encode that rule for the modules hardened in Phase 2 and issue #320:
    generators. Making their *handlers* ``def`` does nothing for the generator body:
    Starlette iterates that on the event loop for the whole life of the stream, so a
    synchronous Redis/object-storage call in there blocks far longer than one request.
-5. ``test_download_stream_keeps_the_check_subscribe_recheck_order`` pins the #284 A1.22
-   lost-wakeup fix, which the offload above must not reorder.
+5. ``test_sse_streams_keep_the_check_subscribe_recheck_order`` pins the lost-wakeup
+   fixes (#284 A1.22 for ``download_stream``, #334 for ``bulk_export_stream``), which
+   the offload above must not reorder.
 """
 
 from __future__ import annotations
@@ -353,16 +354,9 @@ def test_sse_generators_do_not_call_blocking_helpers_inline(
     )
 
 
-def test_download_stream_keeps_the_check_subscribe_recheck_order() -> None:
-    """The readiness check must straddle the pub/sub subscribe (issue #284 A1.22).
-
-    Check-then-subscribe alone loses a completion published in the gap and the stream
-    hangs forever. Offloading the checks to the threadpool must not collapse the
-    second one back into the first.
-    """
-    tree = _generator_ast(files_endpoints, "download_stream", "event_stream")
-
-    checks = [
+def _threadpooled_ready_frame_lines(tree: ast.AST) -> list[int]:
+    """Lines of ``run_in_threadpool(_ready_frame)`` — download_stream's readiness check."""
+    return [
         node.lineno
         for node in ast.walk(tree)
         if isinstance(node, ast.Call)
@@ -372,6 +366,44 @@ def test_download_stream_keeps_the_check_subscribe_recheck_order() -> None:
         and isinstance(node.args[0], ast.Name)
         and node.args[0].id == "_ready_frame"
     ]
+
+
+def _awaited_ready_frame_lines(tree: ast.AST) -> list[int]:
+    """Lines of ``ready_frame()`` — bulk_export_stream's async result-cache read."""
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ready_frame"
+    ]
+
+
+# (module, handler, generator, locator for that stream's readiness checks)
+READINESS_STRADDLE = [
+    (files_endpoints, "download_stream", "event_stream", _threadpooled_ready_frame_lines),
+    (subtitles, "bulk_export_stream", "event_stream", _awaited_ready_frame_lines),
+]
+
+
+@pytest.mark.parametrize(
+    ("module", "handler", "generator", "find_checks"),
+    READINESS_STRADDLE,
+    ids=[h for _, h, _, _ in READINESS_STRADDLE],
+)
+def test_sse_streams_keep_the_check_subscribe_recheck_order(
+    module, handler: str, generator: str, find_checks
+) -> None:
+    """Each SSE stream's readiness check must straddle its pub/sub subscribe.
+
+    Check-then-subscribe alone loses a completion published in the gap and the stream
+    hangs forever — #284 A1.22 for ``download_stream``, #334 for ``bulk_export_stream``
+    (where the ZIP sat ready in object storage while the browser waited). Neither the
+    threadpool offload nor a later refactor may collapse the second check into the first.
+    """
+    tree = _generator_ast(module, handler, generator)
+
+    checks = find_checks(tree)
     subscribes = [
         node.lineno
         for node in ast.walk(tree)
@@ -380,8 +412,8 @@ def test_download_stream_keeps_the_check_subscribe_recheck_order() -> None:
         and node.func.attr == "subscribe"
     ]
 
-    assert len(checks) == 2, f"expected two readiness checks, found {checks}"
-    assert len(subscribes) == 1, f"expected one pubsub.subscribe, found {subscribes}"
+    assert len(checks) == 2, f"{handler}: expected two readiness checks, found {checks}"
+    assert len(subscribes) == 1, f"{handler}: expected one pubsub.subscribe, found {subscribes}"
     assert checks[0] < subscribes[0] < checks[1], (
-        f"readiness checks at {checks} no longer straddle subscribe at {subscribes[0]}"
+        f"{handler}: readiness checks at {checks} no longer straddle subscribe at {subscribes[0]}"
     )


### PR DESCRIPTION
Closes #334.

## The race

`bulk_export_stream` (`backend/app/api/endpoints/files/subtitles.py`) read
`bulk_export_result:<job>` once and then subscribed to the job's pub/sub channel with
**no second read**. A worker that finished inside that window missed both signals: the
cache read had already happened, and its `completed` publish landed before any subscriber
existed. The stream then polled `pubsub.get_message(..., timeout=15.0)` forever for an
event that was already gone — the user's bulk export appeared to hang indefinitely while
the ZIP sat ready in object storage. Most likely exactly when the export is *fast*.

## The fix

Mirror the check → subscribe → re-check ordering `download_stream` got under #284 A1.22:

- the readiness read is now a local `ready_frame()` helper (one cache-read path, used twice);
- it runs again immediately after `await pubsub.subscribe(...)`, **inside** the pub/sub `try`
  so an early return still unsubscribes/closes;
- it uses the `redis.asyncio` client the generator already creates (same URL / db 0 as the
  `tasks/media_download.py` writer), **not** the sync `get_redis()` singleton that #332
  deliberately removed from this path;
- the client-created-first / `finally`-close structure from #332 is preserved, so an early
  cache hit still never opens a pub/sub connection.

`download_stream` is untouched.

## Tests

1. **AST guard (extended, not duplicated).** `test_download_stream_keeps_the_check_subscribe_recheck_order`
   became `test_sse_streams_keep_the_check_subscribe_recheck_order`, parametrized over both
   SSE generators with a per-stream locator for its readiness check
   (`run_in_threadpool(_ready_frame)` vs `ready_frame()`). Either stream losing its re-check
   now fails at the ordering level.
2. **Functional race test** (`tests/api/test_files_subtitles.py`): drives the generator against
   a stub async Redis client whose result key appears exactly when `pubsub.subscribe` is called
   and whose `get_message` never yields a message (the publish went to nobody). Asserts the
   first SSE frame is still `ready` with the cached payload, and that the cache was read twice.

Both new tests were verified to **fail** with the re-check deleted — the functional one emits
`event: progress` and would then loop forever, which is the reported hang. The same scenario
was also driven by hand against a throwaway real Redis (real `SETEX`/`PUBLISH`/`SUBSCRIBE`):
`ready` with the fix, `progress` without.

## Verification

- `pytest backend/tests/unit backend/tests/api` → **2053 passed, 39 skipped** (throwaway
  Postgres matching the CI job's shape; removed afterwards).
- `import app.main` OK; route digest `b409de499c9755f9` over **409** routes — unchanged.
- `pre-commit run --all-files` green (`frontend-check` skipped: no frontend file is touched and
  that hook shells out to a full Vite build).
- Unauthenticated `GET /api/files/bulk-export-stream` still 401 (dev stack probe + the existing
  `TestBulkExportStreamAuth` case).

Also adds a one-line gotcha to `backend/app/api/CLAUDE.md` so the ordering rule is documented
next to the endpoints it governs.