### PR TITLE
feat(upload): browser-side presigned multipart upload with resume (#327)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,12 @@ MEDIA_URL_EXPIRE_SECONDS=21600   # 6h
 # are clamped and logged, never rejected.
 PRESIGNED_URL_MAX_SECONDS=21600  # 6h
 
+# Object size (MB) at or above which the browser uploads in presigned parts instead of
+# one presigned PUT. Multipart is mandatory above the backend's single-PUT ceiling
+# (5 GiB on native S3, 5 TiB on MinIO) and this value can never raise the threshold past
+# it; below the ceiling multipart is what makes an interrupted upload resumable.
+MULTIPART_THRESHOLD_MB=512
+
 #-----------------------------------------------------------------------------
 # Native AWS S3 backend (optional — leave everything below at its default for
 # the bundled MinIO container, which is the standard self-hosted setup)

--- a/backend/app/api/endpoints/files/__init__.py
+++ b/backend/app/api/endpoints/files/__init__.py
@@ -50,6 +50,7 @@ from app.services.formatting_service import FormattingService
 
 from . import cancel_upload
 from . import complete_upload
+from . import multipart
 from . import prepare_upload
 from .crud import _get_or_compute_analytics
 from .crud import delete_media_file
@@ -128,6 +129,7 @@ def _parse_speaker_params_from_headers(request: Request | None) -> SpeakerParams
 router.include_router(cancel_upload.router, prefix="", tags=["files"])
 router.include_router(prepare_upload.router, prefix="", tags=["files"])
 router.include_router(complete_upload.router, prefix="", tags=["files"])
+router.include_router(multipart.router, prefix="", tags=["files"])
 router.include_router(subtitles_router, prefix="", tags=["subtitles"])
 router.include_router(waveform_router, prefix="", tags=["waveform"])
 router.include_router(url_processing_router, prefix="", tags=["url-processing"])

--- a/backend/app/api/endpoints/files/cancel_upload.py
+++ b/backend/app/api/endpoints/files/cancel_upload.py
@@ -81,6 +81,13 @@ def cancel_upload(
     try:
         # Delete the file from storage if it was partially uploaded
         if db_file.storage_path:
+            # A cancelled browser-side multipart upload leaves its parts in the
+            # bucket, and S3/MinIO bill for them until the upload is aborted —
+            # deleting the (nonexistent) final object would not touch them.
+            # The upload_id is client state, so the uploads are found by key.
+            from app.services.multipart_upload import abort_uploads_for_object
+
+            abort_uploads_for_object(str(db_file.storage_path))
             try:
                 delete_file(str(db_file.storage_path))
                 logger.info(f"Deleted partial upload: {db_file.storage_path}")

--- a/backend/app/api/endpoints/files/complete_upload.py
+++ b/backend/app/api/endpoints/files/complete_upload.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+class UploadedPart(BaseModel):
+    """One finished part of a browser-side multipart upload."""
+
+    part_number: int = Field(..., ge=1, description="1-based part number")
+    etag: str = Field(..., description="ETag the storage backend returned for the part")
+
+
 class CompleteUploadRequest(BaseModel):
     """Payload for POST /files/complete.
 
@@ -47,12 +54,20 @@ class CompleteUploadRequest(BaseModel):
     ``*_ms`` fields are epoch-millisecond timestamps measured client-side;
     they are optional but strongly recommended so the timing report can
     show the full client → server → done wall-clock.
+
+    ``upload_id`` marks the multipart flow (issue #327): the object does not
+    exist until its parts are assembled, so completion happens here, before the
+    existing verify → fingerprint → dispatch tail runs unchanged.
     """
 
     file_id: str = Field(..., description="UUID of the MediaFile from /prepare")
     task_id: str | None = Field(None, description="Application task_id from /prepare response")
     file_hash: str | None = Field(None, description="Client-computed SHA-256")
     file_size: int | None = Field(None, description="Client-observed size in bytes")
+    upload_id: str | None = Field(None, description="Multipart upload_id from /prepare")
+    parts: list[UploadedPart] | None = Field(
+        None, description="Uploaded parts; omitted means read them back from storage"
+    )
     # Optional client-side timing markers (epoch-ms)
     client_hash_start_ms: int | None = None
     client_hash_end_ms: int | None = None
@@ -81,6 +96,35 @@ def _record_client_markers(task_id: str | None, req: CompleteUploadRequest) -> N
     ):
         if val is not None and val > 0:
             benchmark_timing.mark(task_id, name, val / 1000.0)
+
+
+def _assemble_multipart(req: CompleteUploadRequest, object_name: str) -> None:
+    """Turn the uploaded parts into the final object.
+
+    The client's part list is used when it sent one and the bucket's own list
+    otherwise, so a completion whose response was lost in transit can be retried:
+    the second attempt reads the parts back rather than failing on an empty list.
+    A genuinely dead ``upload_id`` surfaces as 400 here instead of the misleading
+    "no object at storage_path" the next step would raise.
+    """
+    from app.services import multipart_upload
+
+    parts = [{"part_number": p.part_number, "etag": p.etag} for p in (req.parts or [])]
+    try:
+        if not parts:
+            parts = multipart_upload.list_uploaded_parts(object_name, req.upload_id or "")
+        if not parts:
+            raise ValueError("multipart upload has no parts")
+        multipart_upload.complete_upload(object_name, req.upload_id or "", parts)
+    except Exception as e:
+        # Leave the upload for the abort path / lifecycle rule rather than
+        # aborting here: a retry of /complete is the cheap recovery, and
+        # aborting would throw away gigabytes the client could still assemble.
+        logger.warning(f"Multipart completion failed for {object_name}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not complete multipart upload: {e}",
+        ) from e
 
 
 @router.post("/complete", response_model=dict[str, Any])
@@ -117,6 +161,13 @@ def complete_upload(
 
     # Verify the object actually landed in MinIO — trust but verify.
     minio_size = object_exists_and_size(str(db_file.storage_path))
+
+    # A multipart upload has no object until its parts are assembled. Doing this
+    # only when the object is absent makes a retried /complete idempotent: the
+    # second call sees the finished object and skips straight to verification.
+    if minio_size is None and request.upload_id:
+        _assemble_multipart(request, str(db_file.storage_path))
+        minio_size = object_exists_and_size(str(db_file.storage_path))
     if minio_size is None:
         # The presigned PUT never completed, so the prepared row is an orphan.
         # Drop it (parity with the legacy path's failure cleanup) so it doesn't

--- a/backend/app/api/endpoints/files/multipart.py
+++ b/backend/app/api/endpoints/files/multipart.py
@@ -1,0 +1,126 @@
+"""Part-signing endpoint for browser-side multipart uploads (issue #327).
+
+``/files/prepare`` creates the multipart upload and hands out the first batch of
+part URLs; ``/files/complete`` assembles them. This is the middle of that flow:
+the browser asks for the next batch of signed part URLs, and — when resuming an
+interrupted upload — for the parts the bucket already holds.
+
+Batching is what keeps part URLs inside ``PRESIGNED_URL_MAX_SECONDS``. A 15 GB
+upload can outlive a 6 h clamp; eight 64 MiB parts cannot, so each batch is
+signed just before it is needed instead of minting one long-lived URL per part
+up front.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import status
+from pydantic import BaseModel
+from pydantic import Field
+from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
+
+from app.api.endpoints.auth import get_current_active_user
+from app.db.base import get_db
+from app.models.media import MediaFile
+from app.models.user import User
+from app.services import multipart_upload
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: Refuse to sign more than one batch per call. The batch size is the server's
+#: decision (``multipart_upload.PART_URL_BATCH``); a client asking for hundreds of
+#: URLs at once is either buggy or trying to mint long-lived credentials wholesale.
+MAX_PARTS_PER_REQUEST = 32
+
+
+class PartUrlRequest(BaseModel):
+    """Payload for POST /files/multipart/parts."""
+
+    file_id: str = Field(..., description="UUID of the MediaFile from /prepare")
+    upload_id: str = Field(..., description="Multipart upload_id from /prepare")
+    part_numbers: list[int] = Field(
+        default_factory=list, description="1-based part numbers to sign (one batch)"
+    )
+    include_uploaded: bool = Field(
+        False, description="Also return the parts already stored — used when resuming"
+    )
+
+
+def _load_pending_file(db: Session, file_id: str, user: User) -> MediaFile:
+    """Resolve the caller's prepared MediaFile or raise 404.
+
+    Ownership is the whole authorization story here: a signed part URL writes
+    into the object key of that row, so handing one out for someone else's row
+    would let a caller overwrite another user's media.
+    """
+    db_file = (
+        db.query(MediaFile).filter(MediaFile.uuid == file_id, MediaFile.user_id == user.id).first()
+    )
+    if not db_file or not db_file.storage_path:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No prepared upload {file_id} for this user",
+        )
+    return db_file  # type: ignore[return-value]
+
+
+@router.post("/multipart/parts", response_model=dict[str, Any])
+async def sign_upload_parts(
+    request: PartUrlRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> dict[str, Any]:
+    """Sign the next batch of part URLs, optionally listing parts already stored."""
+    db_file = _load_pending_file(db, request.file_id, current_user)
+    object_name = str(db_file.storage_path)
+
+    wanted = sorted({n for n in request.part_numbers if n >= 1})
+    if len(wanted) > MAX_PARTS_PER_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"At most {MAX_PARTS_PER_REQUEST} part URLs may be signed per request",
+        )
+
+    urls: dict[int, str] = {}
+    expires_in = 0
+    if wanted:
+        try:
+            urls, expires_in = await run_in_threadpool(
+                multipart_upload.presign_parts, object_name, request.upload_id, wanted
+            )
+        except Exception as e:
+            logger.warning(f"Could not sign parts for {object_name}: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Multipart upload is no longer available; restart the upload",
+            ) from e
+
+    response: dict[str, Any] = {
+        "urls": {str(number): url for number, url in urls.items()},
+        "expires_in": expires_in,
+    }
+
+    if request.include_uploaded:
+        try:
+            response["uploaded_parts"] = await run_in_threadpool(
+                multipart_upload.list_uploaded_parts, object_name, request.upload_id
+            )
+        except Exception as e:
+            # A vanished upload cannot be resumed; say so instead of returning an
+            # empty list, which the client would read as "nothing uploaded yet"
+            # and silently re-send every part into a dead upload_id.
+            logger.warning(f"Could not list parts for {object_name}: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Multipart upload is no longer available; restart the upload",
+            ) from e
+
+    return response

--- a/backend/app/api/endpoints/files/prepare_upload.py
+++ b/backend/app/api/endpoints/files/prepare_upload.py
@@ -328,48 +328,42 @@ async def prepare_upload(
 
         response: dict[str, Any] = {"file_id": str(db_file.uuid), "is_duplicate": 0}
 
-        # Optional: emit a presigned PUT URL so the browser can upload bytes
-        # directly to MinIO. The caller follows up with POST /files/complete
-        # once the PUT succeeds. We mint the application task_id here so all
-        # HTTP-phase markers share the benchmark:{task_id} Redis hash with
-        # the downstream pipeline.
-        # AWS S3 rejects a single PUT above 5 GiB with EntityTooLarge — after the
-        # browser has already streamed the whole body. Withholding the URL makes the
-        # client fall back to POST /files, which spools to disk and writes through
-        # minio-py's multipart uploader (issue #284 A1.11). MinIO's single-PUT ceiling
-        # is 5 TiB, so this never fires on the default self-hosted backend.
-        from app.services.storage_backend import supports_single_put
+        # Optional: set the browser up to write bytes straight to object storage,
+        # bypassing the API container. The backend picks the transport — one
+        # presigned PUT, or a presigned multipart upload when the object is large
+        # enough to need resume (or too large for a single PUT: AWS rejects one
+        # above 5 GiB with EntityTooLarge, after the browser has already streamed
+        # the whole body). The client only executes the plan; see
+        # ``services/multipart_upload.build_upload_plan``. A None plan means
+        # neither transport is available, and the client falls back to POST /files.
+        #
+        # The application task_id is minted here so every HTTP-phase marker shares
+        # the benchmark:{task_id} Redis hash with the downstream pipeline.
+        if request.use_presigned:
+            from app.services.multipart_upload import build_upload_plan
 
-        can_presign = supports_single_put(request.file_size)
-        if request.use_presigned and not can_presign:
-            logger.info(
-                f"Skipping presigned PUT for {request.filename}: {request.file_size} bytes "
-                "exceeds the backend's single-PUT limit; using multipart upload via the API"
+            plan = await run_in_threadpool(
+                build_upload_plan, storage_path, request.content_type, request.file_size
             )
-
-        if request.use_presigned and can_presign:
-            from app.services.minio_service import presigned_put_url
-
-            task_id = str(uuid_lib.uuid4())
-            put_url = await run_in_threadpool(presigned_put_url, storage_path)
-            benchmark_timing.mark(task_id, "prepare_upload_end")
-            benchmark_timing.set_context(
-                task_id,
-                {
-                    "file_size_bytes": int(request.file_size or 0),
-                    "content_type": request.content_type or "",
-                    "http_flow": "presigned",
-                },
-            )
-            response.update(
-                {
-                    "task_id": task_id,
-                    "upload_url": put_url,
-                    "upload_method": "PUT",
-                    "http_flow": "presigned",
-                    "storage_path": storage_path,
-                }
-            )
+            if plan is None:
+                logger.info(
+                    f"No browser-direct upload plan for {request.filename} "
+                    f"({request.file_size} bytes); falling back to POST /files"
+                )
+            else:
+                task_id = str(uuid_lib.uuid4())
+                benchmark_timing.mark(task_id, "prepare_upload_end")
+                benchmark_timing.set_context(
+                    task_id,
+                    {
+                        "file_size_bytes": int(request.file_size or 0),
+                        "content_type": request.content_type or "",
+                        "http_flow": plan["http_flow"],
+                    },
+                )
+                response.update(plan)
+                response["task_id"] = task_id
+                response["storage_path"] = storage_path
 
         logger.info(f"Prepared upload for file {request.filename} (ID: {db_file.id})")
         return response

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -413,6 +413,13 @@ class Settings(BaseSettings):
     # safe common denominator — so a 24 h URL would 403 long before it "expires".
     # Requests above the ceiling are clamped and logged, never rejected.
     PRESIGNED_URL_MAX_SECONDS: int = _int_env("PRESIGNED_URL_MAX_SECONDS", 21600)
+    # Object size (MB) at or above which the browser uploads via presigned multipart
+    # instead of one presigned PUT (issue #327). Above the backend's single-PUT ceiling
+    # multipart is mandatory — 5 GiB on native S3 — and this knob cannot raise the
+    # threshold past it. Below the ceiling multipart is what makes an interrupted upload
+    # resumable, so the default sits far under it. Raise it to keep more uploads on the
+    # single-PUT path; it can never disable multipart for objects that need it.
+    MULTIPART_THRESHOLD_MB: int = _int_env("MULTIPART_THRESHOLD_MB", 512)
 
     # Redis settings (for Celery)
     REDIS_HOST: str = os.getenv("REDIS_HOST", "localhost")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -195,6 +195,15 @@ def _setup_minio():
         # origin already). Opt-in and best-effort; never blocks startup.
         storage_backend.ensure_bucket_cors(bucket_name)
 
+        # Backstop for browser-side multipart uploads the user never finished:
+        # the parts of an abandoned upload are billable and invisible in a normal
+        # object listing. S3 needs an explicit lifecycle rule; MinIO expires them
+        # itself and refuses the rule, so this is a no-op there. Either way the
+        # explicit abort on cancel/delete is the primary path.
+        from app.services.multipart_upload import ensure_abort_incomplete_lifecycle
+
+        ensure_abort_incomplete_lifecycle(bucket_name)
+
         if native_s3:
             return
 

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -46,6 +46,7 @@ every difference between the two backends (issue #284 A1.11/A1.12):
 | Addressing | path-style | virtual-host (minio-py switches on AWS hostnames) |
 | Presigned host | rewritten to `STORAGE_PUBLIC_URL`/`MINIO_PUBLIC_URL`, else `/s3` | **not rewritten** |
 | Single-PUT ceiling | 5 TiB | 5 GiB (`supports_single_put`) |
+| Abandoned-multipart expiry | MinIO's own scan (24 h) | lifecycle rule (`ensure_abort_incomplete_lifecycle`) |
 | Bucket CORS | implicit | opt-in `S3_CONFIGURE_BUCKET_CORS` (boto3 — minio-py has no CORS API) |
 
 - **One SDK for both.** The client is always `minio.Minio`; minio-py is a generic S3 SDK,
@@ -55,10 +56,28 @@ every difference between the two backends (issue #284 A1.11/A1.12):
   6 h). A presigned URL cannot outlive the credentials that signed it, and IAM-role STS
   sessions expire well inside 24 h, so a longer URL just starts 403-ing. `get_file_url`'s
   old 24 h default arg is gone.
-- **>5 GiB uploads on `s3` skip the presigned path.** `files/prepare_upload.py` checks
-  `supports_single_put` before minting a URL; the browser then falls back to
-  `POST /files`, which spools to disk and writes multipart (64 MiB parts). Browser-side
-  presigned *multipart* is not implemented — that is the remaining native-S3 gap.
+- **Large uploads go browser-side multipart** (`multipart_upload.py`, issue #327).
+  `build_upload_plan` is the single decision point `/files/prepare` calls: multipart at or
+  above `multipart_threshold_bytes()` (`MULTIPART_THRESHOLD_MB`, 512 MB, clamped to the
+  single-PUT ceiling so >5 GiB on `s3` is *always* multipart), one presigned PUT below it,
+  `None` → the client falls back to `POST /files`. Part URLs are signed **8 at a time**
+  (`PART_URL_BATCH`), not once for the whole object: they take the same
+  `clamp_presigned_expiry` as everything else and a 15 GB upload can outlive a 6 h clamp.
+  `/files/multipart/parts` signs the next batch and, on resume, lists the parts storage
+  already holds. `/files/complete` assembles them (client ETags, else read back).
+- **Abandoned multipart uploads must be aborted** — S3 and MinIO both bill for the parts,
+  and they never appear in an object listing. `cancel_upload` (`DELETE /files/{uuid}`) calls
+  `abort_uploads_for_object`, which finds the uploads by key because the `upload_id` is
+  client state. `ensure_abort_incomplete_lifecycle` adds the storage-side backstop and is
+  **native-S3 only**: MinIO's ILM rejects an `AbortIncompleteMultipartUpload` rule
+  (`InvalidArgument`; it silently drops the action from a mixed rule) and does not need one —
+  it purges stale uploads itself via `api.stale_uploads_expiry` (24 h).
+- **minio-py's multipart primitives are underscore-prefixed** (`_create_multipart_upload`,
+  `_complete_multipart_upload`, `_abort_multipart_upload`, `_list_parts`,
+  `_list_multipart_uploads`). Driving them keeps the one-SDK rule above; boto3 would mean a
+  second client with its own copy of the endpoint/credential policy.
+  `tests/unit/test_multipart_upload.py` asserts they still exist so an SDK bump fails in CI.
+  Part *signing* is the public `get_presigned_url(..., extra_query_params=...)`.
 - Don't reintroduce a second host-rewrite. `MinIOService.get_presigned_url` used to
   hardcode `http://minio:9000` → `localhost:5178`/`EXTERNAL_MINIO_URL`; it now shares
   `rewrite_public_host` like everything else.

--- a/backend/app/services/multipart_upload.py
+++ b/backend/app/services/multipart_upload.py
@@ -1,0 +1,294 @@
+"""Browser-side presigned multipart upload (issue #327).
+
+The single presigned PUT in ``minio_service.presigned_put_url`` is rejected by
+AWS S3 above 5 GiB, and a PUT that fails at 90% of 10 GB restarts at zero on any
+backend. This module splits the object into parts the browser uploads
+independently: the API creates the upload, signs a *batch* of part URLs at a
+time, and completes or aborts it. Bytes never enter the API container.
+
+Only the control plane lives here. The browser holds no credentials and never
+parses S3 XML — it PUTs opaque URLs and reports the ETags it got back.
+
+**Part URLs are minted per batch, not per upload.** Every presigned URL is
+clamped to ``PRESIGNED_URL_MAX_SECONDS`` (6 h) because it cannot outlive the STS
+credentials that signed it, and a 15 GB upload on a slow line can easily run
+longer than that. Signing ~8 parts at a time means a URL only has to survive its
+own batch, and the client re-asks for the next one.
+
+minio-py's multipart primitives (``_create_multipart_upload`` and friends) are
+underscore-prefixed but are the whole of its multipart implementation and are
+stable across 7.x, which ``requirements.txt`` pins. Using them keeps the single
+``minio.Minio`` client that ``storage_backend`` exists to guarantee; the
+alternative — boto3 — would mean a second SDK with its own duplicate copy of the
+endpoint/credential/region policy. ``tests/unit/test_multipart_upload.py``
+asserts the primitives still exist so an SDK bump fails in CI, not in a user's
+10 GB upload.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+from app.core.config import settings
+from app.services import storage_backend
+from app.services.minio_service import ensure_bucket_exists
+from app.services.minio_service import minio_client
+from app.services.storage_backend import clamp_presigned_expiry
+from app.services.storage_backend import rewrite_public_host
+
+logger = logging.getLogger(__name__)
+
+#: How many part URLs to hand the browser per signing round trip. Small enough
+#: that a batch finishes long before its URLs expire, large enough to keep the
+#: part-upload pipeline full at the client's concurrency.
+PART_URL_BATCH = 8
+
+#: Lifetime requested for part URLs. Clamped like every other presigned URL; the
+#: batch design means the effective ceiling is never the binding constraint.
+PART_URL_EXPIRE_SECONDS = 3600
+
+#: Storage-side backstop for uploads the browser never finished (tab closed, laptop
+#: shut). S3 and MinIO both bill for the parts of an incomplete upload until it is
+#: aborted, and neither expires one on its own by default.
+ABORT_INCOMPLETE_AFTER_DAYS = 7
+
+_LIFECYCLE_RULE_ID = "abort-incomplete-multipart"
+
+
+def _bucket() -> str:
+    return settings.MEDIA_BUCKET_NAME
+
+
+def _clean_etag(etag: str) -> str:
+    """Strip the transport quoting S3 puts around an ETag header value."""
+    return str(etag).strip().strip('"')
+
+
+def create_upload(object_name: str, content_type: str | None) -> str:
+    """Start a multipart upload and return its ``upload_id``.
+
+    ``content_type`` is fixed here, not at completion: S3 stores the object
+    metadata from the create call, so omitting it yields an
+    ``application/octet-stream`` object the media player will refuse to stream.
+    """
+    ensure_bucket_exists()
+    headers: dict[str, str] = {"Content-Type": content_type or "application/octet-stream"}
+    upload_id = minio_client._create_multipart_upload(_bucket(), object_name, headers)  # noqa: SLF001
+    logger.info(f"Created multipart upload {upload_id} for {object_name}")
+    return str(upload_id)
+
+
+def presign_parts(
+    object_name: str, upload_id: str, part_numbers: list[int]
+) -> tuple[dict[int, str], int]:
+    """Sign PUT URLs for *part_numbers* of an existing multipart upload.
+
+    Returns:
+        ``(urls_by_part_number, expires_in_seconds)``. The lifetime is the
+        clamped value actually signed, so the client can re-ask before it lapses
+        rather than discovering the expiry as a 403 half-way through a part.
+    """
+    expires = clamp_presigned_expiry(PART_URL_EXPIRE_SECONDS)
+    delta = datetime.timedelta(seconds=expires)
+    urls: dict[int, str] = {}
+    for number in part_numbers:
+        url = minio_client.get_presigned_url(
+            "PUT",
+            _bucket(),
+            object_name,
+            expires=delta,
+            extra_query_params={"partNumber": str(number), "uploadId": upload_id},
+        )
+        urls[number] = rewrite_public_host(str(url))
+    return urls, expires
+
+
+def list_uploaded_parts(object_name: str, upload_id: str) -> list[dict[str, Any]]:
+    """List the parts the backend has already stored, oldest part number first.
+
+    This is what makes resume authoritative: the client's idea of what it sent
+    is a guess (a PUT can succeed with the response lost), the bucket's is not.
+    """
+    parts: list[dict[str, Any]] = []
+    marker: str | None = None
+    while True:
+        result = minio_client._list_parts(  # noqa: SLF001
+            _bucket(), object_name, upload_id, part_number_marker=marker
+        )
+        for part in result.parts:
+            parts.append(
+                {
+                    "part_number": int(part.part_number),
+                    "etag": _clean_etag(part.etag),
+                    "size": int(part.size or 0),
+                }
+            )
+        if not result.is_truncated:
+            break
+        marker = str(result.next_part_number_marker)
+    parts.sort(key=lambda p: p["part_number"])
+    return parts
+
+
+def complete_upload(object_name: str, upload_id: str, parts: list[dict[str, Any]]) -> None:
+    """Assemble the uploaded parts into the final object.
+
+    Args:
+        object_name: Target object key.
+        upload_id: The upload to complete.
+        parts: ``{"part_number": int, "etag": str}`` entries. Sorted here because
+            S3 rejects an out-of-order part list, and the browser uploads parts
+            concurrently so its natural order is completion order.
+    """
+    from minio.datatypes import Part
+
+    ordered = sorted(parts, key=lambda p: int(p["part_number"]))
+    payload = [Part(int(p["part_number"]), _clean_etag(p["etag"])) for p in ordered]
+    minio_client._complete_multipart_upload(_bucket(), object_name, upload_id, payload)  # noqa: SLF001
+    logger.info(f"Completed multipart upload {upload_id} for {object_name} ({len(payload)} parts)")
+
+
+def abort_upload(object_name: str, upload_id: str) -> bool:
+    """Abort one multipart upload, discarding its parts. Best-effort."""
+    try:
+        minio_client._abort_multipart_upload(_bucket(), object_name, upload_id)  # noqa: SLF001
+        logger.info(f"Aborted multipart upload {upload_id} for {object_name}")
+        return True
+    except Exception as e:  # noqa: BLE001 — cleanup must never fail the caller
+        logger.warning(f"Could not abort multipart upload {upload_id} for {object_name}: {e}")
+        return False
+
+
+def abort_uploads_for_object(object_name: str) -> int:
+    """Abort every in-progress multipart upload for *object_name*.
+
+    The cancel/delete path knows the object key but not the ``upload_id`` (it is
+    client state), so the uploads are discovered by listing. Without this a
+    cancelled 10 GB upload keeps billing for its parts indefinitely.
+
+    Returns:
+        Number of uploads aborted. Never raises.
+    """
+    aborted = 0
+    try:
+        result = minio_client._list_multipart_uploads(  # noqa: SLF001
+            _bucket(), prefix=object_name
+        )
+        for upload in result.uploads or []:
+            if upload.object_name != object_name:
+                continue
+            if abort_upload(object_name, str(upload.upload_id)):
+                aborted += 1
+    except Exception as e:  # noqa: BLE001 — cleanup must never fail the caller
+        logger.warning(f"Could not list multipart uploads for {object_name}: {e}")
+    return aborted
+
+
+def ensure_abort_incomplete_lifecycle(
+    bucket_name: str, days: int = ABORT_INCOMPLETE_AFTER_DAYS
+) -> bool:
+    """Install the bucket rule that expires abandoned multipart uploads.
+
+    The explicit abort in :func:`abort_uploads_for_object` covers cancel and
+    delete; nothing covers a browser that simply goes away mid-upload. Existing
+    lifecycle rules (bulk-export and derived-cache expiry) are preserved by id.
+
+    **Native S3 only.** MinIO's ILM engine rejects an
+    ``AbortIncompleteMultipartUpload`` rule outright (``InvalidArgument``, and it
+    silently drops the action from a mixed rule) — verified against
+    RELEASE.2025-09-07. It does not need one: MinIO purges stale multipart
+    uploads itself on a background scan, ``api.stale_uploads_expiry``, 24 h by
+    default. Attempting it anyway would log a warning on every MinIO startup.
+
+    Returns:
+        True if the rule is present after the call, False if it was skipped or
+        could not be set. Best-effort — never raises, so it cannot block startup.
+    """
+    from minio.commonconfig import ENABLED
+    from minio.commonconfig import Filter
+    from minio.lifecycleconfig import AbortIncompleteMultipartUpload
+    from minio.lifecycleconfig import LifecycleConfig
+    from minio.lifecycleconfig import Rule
+
+    if not storage_backend.is_native_s3():
+        return False
+
+    try:
+        others = []
+        try:
+            current = minio_client.get_bucket_lifecycle(bucket_name)
+            for rule in current.rules if current and current.rules else []:
+                if rule.rule_id == _LIFECYCLE_RULE_ID:
+                    existing = rule.abort_incomplete_multipart_upload
+                    if existing and existing.days_after_initiation == days:
+                        return True
+                else:
+                    others.append(rule)
+        except Exception:
+            others = []
+
+        rule = Rule(
+            ENABLED,
+            rule_filter=Filter(prefix=""),
+            rule_id=_LIFECYCLE_RULE_ID,
+            abort_incomplete_multipart_upload=AbortIncompleteMultipartUpload(
+                days_after_initiation=days
+            ),
+        )
+        minio_client.set_bucket_lifecycle(bucket_name, LifecycleConfig([*others, rule]))
+        logger.info(f"Abandoned multipart uploads on {bucket_name} expire after {days}d")
+        return True
+    except Exception as e:  # noqa: BLE001 — best-effort housekeeping
+        logger.warning(f"Could not set multipart-abort lifecycle on {bucket_name}: {e}")
+        return False
+
+
+def build_upload_plan(
+    object_name: str, content_type: str | None, file_size: int | None
+) -> dict[str, Any] | None:
+    """Decide how the browser should deliver *object_name* and set it up.
+
+    The backend owns this decision so the client only executes it: multipart
+    above :func:`storage_backend.multipart_threshold_bytes`, one presigned PUT
+    below it, and ``None`` when neither is possible so the caller falls back to
+    the API-mediated ``POST /files``.
+
+    Returns:
+        A dict merged into the ``/files/prepare`` response, or ``None``.
+    """
+    from app.services.minio_service import presigned_put_url
+
+    if storage_backend.use_multipart_upload(file_size):
+        size = int(file_size or 0)
+        part_size = storage_backend.multipart_part_size(size)
+        part_count = storage_backend.multipart_part_count(size, part_size)
+        try:
+            upload_id = create_upload(object_name, content_type)
+            first_batch = list(range(1, min(PART_URL_BATCH, part_count) + 1))
+            urls, expires_in = presign_parts(object_name, upload_id, first_batch)
+        except Exception as e:  # noqa: BLE001 — degrade to the API-mediated path
+            logger.warning(f"Multipart setup failed for {object_name}, falling back: {e}")
+            return None
+        return {
+            "upload_method": "MULTIPART",
+            "http_flow": "presigned-multipart",
+            "multipart": {
+                "upload_id": upload_id,
+                "part_size": part_size,
+                "part_count": part_count,
+                "batch_size": PART_URL_BATCH,
+                "expires_in": expires_in,
+                "urls": {str(number): url for number, url in urls.items()},
+            },
+        }
+
+    if not storage_backend.supports_single_put(file_size):
+        return None
+
+    return {
+        "upload_method": "PUT",
+        "http_flow": "presigned",
+        "upload_url": presigned_put_url(object_name),
+    }

--- a/backend/app/services/storage_backend.py
+++ b/backend/app/services/storage_backend.py
@@ -44,6 +44,16 @@ MINIO_SINGLE_PUT_MAX_BYTES = 5 * 1024**4
 #: Presigned URLs shorter than this are pointless and usually a caller bug.
 MIN_PRESIGNED_SECONDS = 60
 
+#: S3 multipart limits, identical on MinIO: every part except the last must be at
+#: least 5 MiB, and one upload may not exceed 10 000 parts.
+MULTIPART_MIN_PART_BYTES = 5 * 1024**2
+MULTIPART_MAX_PARTS = 10000
+
+#: Default part size for browser-side multipart. Matches the server-side
+#: ``PRESIGNED_PUT_PART_SIZE``: 64 MiB is ~160 parts for a 10 GB file, where the
+#: 5 MiB minimum would need 2 000.
+MULTIPART_PART_BYTES = 64 * 1024**2
+
 # Clamp warnings are logged once per requested value — a hot read path would
 # otherwise emit one line per presigned URL.
 _clamp_warned: set[int] = set()
@@ -235,6 +245,56 @@ def supports_single_put(size_bytes: int | None) -> bool:
         return int(size_bytes) <= single_put_max_bytes()
     except (TypeError, ValueError):
         return True
+
+
+def multipart_threshold_bytes() -> int:
+    """Object size at or above which the browser uploads in parts.
+
+    Never above the backend's single-PUT ceiling: on native S3 an object over
+    5 GiB has no single-PUT option at all, so the threshold collapses to that
+    ceiling however ``MULTIPART_THRESHOLD_MB`` is configured.
+    """
+    configured = max(1, settings.MULTIPART_THRESHOLD_MB) * 1024**2
+    return min(configured, single_put_max_bytes())
+
+
+def use_multipart_upload(size_bytes: int | None) -> bool:
+    """Whether an object of *size_bytes* should be uploaded as presigned parts.
+
+    Two reasons to say yes, and the first is not optional: above
+    :func:`single_put_max_bytes` a single PUT is simply rejected. Below it,
+    multipart still buys resume — a part that fails is one part re-sent, not the
+    whole object — which is why the threshold sits well under the ceiling.
+
+    An unknown size takes the single-PUT path; ``/files/complete`` re-checks the
+    size the backend actually observed.
+    """
+    if size_bytes is None:
+        return False
+    try:
+        return int(size_bytes) >= multipart_threshold_bytes()
+    except (TypeError, ValueError):
+        return False
+
+
+def multipart_part_size(size_bytes: int) -> int:
+    """Part size to split *size_bytes* into, honouring the 10 000-part cap.
+
+    Returns :data:`MULTIPART_PART_BYTES` for anything up to 640 GB (far past the
+    15 GB application ceiling) and grows it only when the default would exceed
+    the part-count limit, rounding up to a whole MiB so parts stay aligned.
+    """
+    size = max(1, int(size_bytes))
+    part = MULTIPART_PART_BYTES
+    if -(-size // part) > MULTIPART_MAX_PARTS:
+        needed = -(-size // MULTIPART_MAX_PARTS)
+        part = -(-needed // (1024**2)) * 1024**2
+    return max(MULTIPART_MIN_PART_BYTES, part)
+
+
+def multipart_part_count(size_bytes: int, part_size: int) -> int:
+    """Number of parts *size_bytes* splits into at *part_size* (at least one)."""
+    return max(1, -(-max(1, int(size_bytes)) // max(1, int(part_size))))
 
 
 def cors_allowed_origins() -> list[str]:

--- a/backend/tests/api/test_files_multipart_parts.py
+++ b/backend/tests/api/test_files_multipart_parts.py
@@ -1,0 +1,145 @@
+"""``POST /api/files/multipart/parts`` — the part-signing endpoint (issue #327).
+
+The browser calls this between ``/files/prepare`` and ``/files/complete`` to get
+the next batch of signed part URLs, and to ask which parts already landed when
+resuming. Everything here is a DB/authorization branch and runs ungated; the
+genuine sign → PUT → complete round trip lives in
+``tests/unit/test_multipart_upload.py`` behind the MinIO gate.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import status
+
+from app.models.media import MediaFile
+from app.services import multipart_upload
+
+ENDPOINT = "/api/files/multipart/parts"
+
+S3_LIVE = os.environ.get("SKIP_S3", "True").lower() != "true"
+
+
+def _seed_prepared_file(db_session, owner) -> MediaFile:
+    """A prepared (PENDING, storage_path set) row, as /prepare would leave it."""
+    file_uuid = str(uuid.uuid4())
+    media_file = MediaFile(
+        uuid=file_uuid,
+        filename="big.mp4",
+        title="big",
+        storage_path=f"media/test/{file_uuid}.mp4",
+        content_type="video/mp4",
+        file_size=8 * 1024**3,
+        status="pending",
+        is_public=False,
+        user_id=owner.id,
+    )
+    db_session.add(media_file)
+    db_session.commit()
+    db_session.refresh(media_file)
+    return media_file
+
+
+def _payload(file_id: str, **overrides) -> dict:
+    body = {"file_id": file_id, "upload_id": "upload-1", "part_numbers": [1, 2]}
+    body.update(overrides)
+    return body
+
+
+def test_unauthorized(client):
+    response = client.post(ENDPOINT, json=_payload(str(uuid.uuid4())))
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_unknown_file_404(client, user_token_headers):
+    response = client.post(ENDPOINT, headers=user_token_headers, json=_payload(str(uuid.uuid4())))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_other_users_file_404(client, user_token_headers, other_user, db_session):
+    """A signed part URL writes into that row's object key.
+
+    Handing one out for someone else's row would let a caller overwrite another
+    user's media, so a foreign row must be indistinguishable from a missing one.
+    """
+    foreign = _seed_prepared_file(db_session, other_user)
+    response = client.post(ENDPOINT, headers=user_token_headers, json=_payload(str(foreign.uuid)))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_oversized_batch_rejected(client, user_token_headers, normal_user, db_session):
+    """One batch per call — not a wholesale mint of long-lived signed URLs."""
+    prepared = _seed_prepared_file(db_session, normal_user)
+    response = client.post(
+        ENDPOINT,
+        headers=user_token_headers,
+        json=_payload(str(prepared.uuid), part_numbers=list(range(1, 200))),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_empty_batch_signs_nothing(client, user_token_headers, normal_user, db_session):
+    """An empty request is how the client asks only for resume state."""
+    prepared = _seed_prepared_file(db_session, normal_user)
+    response = client.post(
+        ENDPOINT, headers=user_token_headers, json=_payload(str(prepared.uuid), part_numbers=[])
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["urls"] == {}
+
+
+def test_one_url_per_requested_part(
+    client, user_token_headers, normal_user, db_session, monkeypatch
+):
+    """Response shape. Signing itself is stubbed — minio-py resolves the bucket
+    region over the network the first time, so real signing needs the stack."""
+    monkeypatch.setattr(
+        multipart_upload,
+        "presign_parts",
+        lambda name, upload_id, parts: (
+            {n: f"https://example/{name}?partNumber={n}" for n in parts},
+            3600,
+        ),
+    )
+    prepared = _seed_prepared_file(db_session, normal_user)
+    response = client.post(ENDPOINT, headers=user_token_headers, json=_payload(str(prepared.uuid)))
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert sorted(body["urls"]) == ["1", "2"]
+    # The lifetime is the clamped value actually signed, so the client can
+    # re-ask before it lapses instead of discovering expiry as a 403.
+    assert 0 < body["expires_in"] <= 21600
+
+
+def test_dead_upload_is_a_409_not_an_empty_resume_list(
+    client, user_token_headers, normal_user, db_session, monkeypatch
+):
+    """An empty list would read as "nothing uploaded yet" and make the client
+    re-send every part into an upload_id that no longer exists."""
+
+    def gone(*_args, **_kwargs):
+        raise RuntimeError("NoSuchUpload")
+
+    monkeypatch.setattr(multipart_upload, "list_uploaded_parts", gone)
+    prepared = _seed_prepared_file(db_session, normal_user)
+    response = client.post(
+        ENDPOINT,
+        headers=user_token_headers,
+        json=_payload(str(prepared.uuid), part_numbers=[], include_uploaded=True),
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="minio-py resolves the bucket region over the network")
+def test_real_signed_urls_carry_the_part_and_upload_id(
+    client, user_token_headers, normal_user, db_session
+):
+    prepared = _seed_prepared_file(db_session, normal_user)
+    response = client.post(ENDPOINT, headers=user_token_headers, json=_payload(str(prepared.uuid)))
+    assert response.status_code == status.HTTP_200_OK
+    for number, url in response.json()["urls"].items():
+        assert f"partNumber={number}" in url
+        assert "uploadId=upload-1" in url

--- a/backend/tests/api/test_files_prepare_complete_upload.py
+++ b/backend/tests/api/test_files_prepare_complete_upload.py
@@ -176,15 +176,28 @@ def test_prepare_presigned_returns_upload_url(client, user_token_headers):
     assert body["task_id"]
 
 
-def test_prepare_withholds_presigned_url_above_the_s3_single_put_limit(
+def _abort(body: dict) -> None:
+    """Release the multipart upload /prepare just created.
+
+    Storage bills for the parts of an incomplete upload, and these tests run
+    against the live dev MinIO — leaving one behind would be leaving litter in
+    real storage.
+    """
+    from app.services.multipart_upload import abort_upload
+
+    abort_upload(body["storage_path"], body["multipart"]["upload_id"])
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="creating a multipart upload requires MinIO")
+def test_prepare_uses_multipart_above_the_s3_single_put_limit(
     client, user_token_headers, monkeypatch
 ):
     """On native S3 a >5 GiB object cannot be uploaded with one PUT (issue #284 A1.11).
 
-    S3 answers ``EntityTooLarge`` only after the browser has streamed the whole body,
-    so /prepare withholds the URL instead. The client then falls back to POST /files,
-    which spools to disk and writes through minio-py's multipart uploader. No storage
-    round-trip happens here: the point is that no presigned URL is minted.
+    S3 answers ``EntityTooLarge`` only after the browser has streamed the whole body.
+    /prepare used to withhold the URL and let the client fall back to ``POST /files``,
+    pushing the whole body through the API container; since #327 it hands out a
+    presigned *multipart* plan instead.
     """
     from app.core.config import settings as app_settings
 
@@ -204,12 +217,19 @@ def test_prepare_withholds_presigned_url_above_the_s3_single_put_limit(
     body = response.json()
     assert body["is_duplicate"] == 0
     assert "upload_url" not in body
-    assert "upload_method" not in body
+    assert body["upload_method"] == "MULTIPART"
+    assert body["multipart"]["part_count"] == 96  # 6 GiB / 64 MiB
+    assert body["multipart"]["upload_id"]
+    _abort(body)
 
 
-@pytest.mark.skipif(not S3_LIVE, reason="presigned PUT URL requires MinIO (SKIP_S3=False)")
-def test_prepare_still_presigns_large_files_on_minio(client, user_token_headers):
-    """MinIO's single-PUT ceiling is 5 TiB, so the S3 guard must not fire on it."""
+@pytest.mark.skipif(not S3_LIVE, reason="creating a multipart upload requires MinIO")
+def test_prepare_uses_multipart_for_large_files_on_minio(client, user_token_headers):
+    """MinIO's 5 TiB single-PUT ceiling means multipart here is about resume, not size.
+
+    A 6 GiB single PUT that dies at 90% restarts at zero; the same upload in 64 MiB
+    parts loses one part.
+    """
     response = client.post(
         "/api/files/prepare",
         headers=user_token_headers,
@@ -221,7 +241,29 @@ def test_prepare_still_presigns_large_files_on_minio(client, user_token_headers)
         ),
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["upload_method"] == "PUT"
+    body = response.json()
+    assert body["upload_method"] == "MULTIPART"
+    assert body["http_flow"] == "presigned-multipart"
+    _abort(body)
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="presigned PUT URL requires MinIO (SKIP_S3=False)")
+def test_prepare_keeps_the_single_put_path_below_the_threshold(client, user_token_headers):
+    """Small uploads must not get more complicated: one PUT, no plan to execute."""
+    response = client.post(
+        "/api/files/prepare",
+        headers=user_token_headers,
+        json=_prepare_payload(
+            filename="small.mp4",
+            file_size=32 * 1024**2,
+            content_type="video/mp4",
+            use_presigned=True,
+        ),
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["upload_method"] == "PUT"
+    assert "multipart" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_multipart_upload.py
+++ b/backend/tests/unit/test_multipart_upload.py
@@ -1,0 +1,265 @@
+"""Browser-side presigned multipart upload (issue #327).
+
+Three things are pinned here.
+
+**The sizing policy.** Which transport an object gets, how many parts it splits
+into, and that the threshold can never be configured above the backend's
+single-PUT ceiling — the case the whole feature exists for.
+
+**The minio-py primitives we depend on.** ``multipart_upload`` drives minio-py's
+underscore-prefixed multipart methods rather than adding boto3 as a second SDK
+with its own copy of the endpoint/credential policy. That is a deliberate
+coupling, so a version bump that removes one must fail here, in CI, and not in a
+user's 10 GB upload.
+
+**A genuine round trip**, when the dev stack's MinIO is reachable
+(``SKIP_S3=False``, auto-detected by conftest): create → sign → PUT parts →
+complete → verify bytes → abort/cleanup. Everything it writes lives under a
+``tests/multipart/`` prefix and is deleted again.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from app.core.config import settings
+from app.services import multipart_upload as mp
+from app.services import storage_backend as sb
+
+S3_LIVE = os.environ.get("SKIP_S3", "True").lower() != "true"
+
+pytestmark = pytest.mark.xdist_group("storage_backend")
+
+MIB = 1024**2
+GIB = 1024**3
+
+
+@pytest.fixture
+def minio_backend(monkeypatch):
+    monkeypatch.setattr(settings, "STORAGE_BACKEND", "minio")
+    monkeypatch.setattr(settings, "MULTIPART_THRESHOLD_MB", 512)
+
+
+@pytest.fixture
+def s3_backend(monkeypatch):
+    monkeypatch.setattr(settings, "STORAGE_BACKEND", "s3")
+    monkeypatch.setattr(settings, "MULTIPART_THRESHOLD_MB", 512)
+
+
+# --------------------------------------------------------------------------
+# Transport choice
+# --------------------------------------------------------------------------
+
+
+def test_small_object_keeps_the_single_put_path(minio_backend):
+    assert sb.use_multipart_upload(64 * MIB) is False
+    assert sb.supports_single_put(64 * MIB) is True
+
+
+def test_unknown_size_is_not_forced_into_multipart(minio_backend):
+    # /files/complete re-checks the size storage actually observed; guessing
+    # multipart here would break every upload that omits a size.
+    assert sb.use_multipart_upload(None) is False
+
+
+def test_threshold_switches_to_multipart(minio_backend):
+    assert sb.use_multipart_upload(512 * MIB - 1) is False
+    assert sb.use_multipart_upload(512 * MIB) is True
+
+
+def test_threshold_is_configurable(minio_backend, monkeypatch):
+    monkeypatch.setattr(settings, "MULTIPART_THRESHOLD_MB", 2048)
+    assert sb.use_multipart_upload(1 * GIB) is False
+    assert sb.use_multipart_upload(2 * GIB) is True
+
+
+def test_threshold_cannot_be_raised_past_the_s3_single_put_ceiling(s3_backend, monkeypatch):
+    """The 5 GiB case is not optional: a single PUT above it is simply rejected."""
+    monkeypatch.setattr(settings, "MULTIPART_THRESHOLD_MB", 1024 * 1024)  # 1 TiB
+    assert sb.multipart_threshold_bytes() == sb.S3_SINGLE_PUT_MAX_BYTES
+    assert sb.use_multipart_upload(6 * GIB) is True
+    assert sb.supports_single_put(6 * GIB) is False
+
+
+def test_minio_ceiling_is_still_5_tib(minio_backend, monkeypatch):
+    monkeypatch.setattr(settings, "MULTIPART_THRESHOLD_MB", 1024 * 1024)
+    assert sb.multipart_threshold_bytes() == 1024 * 1024 * MIB
+    assert sb.supports_single_put(6 * GIB) is True
+
+
+# --------------------------------------------------------------------------
+# Part sizing
+# --------------------------------------------------------------------------
+
+
+def test_default_part_size_for_realistic_files():
+    assert sb.multipart_part_size(10 * GIB) == 64 * MIB
+    assert sb.multipart_part_count(10 * GIB, 64 * MIB) == 160
+
+
+def test_last_part_is_counted():
+    assert sb.multipart_part_count(64 * MIB + 1, 64 * MIB) == 2
+    assert sb.multipart_part_count(1, 64 * MIB) == 1
+
+
+def test_part_size_grows_to_stay_under_the_10000_part_cap():
+    huge = 900 * GIB  # 14 400 parts at 64 MiB
+    part_size = sb.multipart_part_size(huge)
+    assert part_size > 64 * MIB
+    assert part_size % MIB == 0
+    assert sb.multipart_part_count(huge, part_size) <= sb.MULTIPART_MAX_PARTS
+
+
+def test_part_size_never_drops_below_the_5_mib_minimum():
+    assert sb.multipart_part_size(1024) >= sb.MULTIPART_MIN_PART_BYTES
+
+
+# --------------------------------------------------------------------------
+# SDK coupling
+# --------------------------------------------------------------------------
+
+
+def test_minio_py_multipart_primitives_exist():
+    """Guard the underscore-prefixed methods this module drives."""
+    from minio import Minio
+
+    for name in (
+        "_create_multipart_upload",
+        "_complete_multipart_upload",
+        "_abort_multipart_upload",
+        "_list_parts",
+        "_list_multipart_uploads",
+    ):
+        assert callable(getattr(Minio, name, None)), f"minio-py no longer exposes {name}"
+
+
+def test_abort_lifecycle_rule_is_s3_only(minio_backend):
+    """MinIO's ILM rejects an AbortIncompleteMultipartUpload rule and does not
+    need one — it expires stale uploads on its own background scan."""
+    assert mp.ensure_abort_incomplete_lifecycle("any-bucket") is False
+
+
+def test_etag_quoting_is_stripped():
+    assert (
+        mp._clean_etag('"d41d8cd98f00b204e9800998ecf8427e"') == "d41d8cd98f00b204e9800998ecf8427e"
+    )
+    assert mp._clean_etag(" abc ") == "abc"
+
+
+# --------------------------------------------------------------------------
+# Upload plan
+# --------------------------------------------------------------------------
+
+
+def test_plan_below_threshold_is_a_single_put(minio_backend, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.minio_service.presigned_put_url", lambda name: f"https://example/{name}"
+    )
+    plan = mp.build_upload_plan("media/x.wav", "audio/wav", 1024)
+    assert plan is not None
+    assert plan["upload_method"] == "PUT"
+    assert "multipart" not in plan
+
+
+def test_plan_above_s3_ceiling_is_never_a_single_put(s3_backend, monkeypatch):
+    monkeypatch.setattr(mp, "create_upload", lambda name, ct: "upl-1")
+    monkeypatch.setattr(
+        mp, "presign_parts", lambda name, upl, parts: ({n: "u" for n in parts}, 900)
+    )
+    plan = mp.build_upload_plan("media/big.mp4", "video/mp4", 6 * GIB)
+    assert plan is not None
+    assert plan["upload_method"] == "MULTIPART"
+    assert plan["multipart"]["part_size"] == 64 * MIB
+    assert plan["multipart"]["part_count"] == 96
+    # Only the first batch is signed up front — part URLs are clamped to
+    # PRESIGNED_URL_MAX_SECONDS and a 6 GiB upload can outlive that.
+    assert len(plan["multipart"]["urls"]) == mp.PART_URL_BATCH
+
+
+def test_plan_falls_back_when_multipart_setup_fails(s3_backend, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("bucket unreachable")
+
+    monkeypatch.setattr(mp, "create_upload", boom)
+    # None makes /files/prepare withhold a URL, which sends the browser to the
+    # API-mediated POST /files instead of failing the upload outright.
+    assert mp.build_upload_plan("media/big.mp4", "video/mp4", 6 * GIB) is None
+
+
+# --------------------------------------------------------------------------
+# Live round trip
+# --------------------------------------------------------------------------
+
+
+def _direct(url: str) -> str:
+    """Undo the browser-facing host rewrite so a test process can PUT the part.
+
+    ``rewrite_public_host`` maps MinIO onto the ``/s3`` proxy path, which only
+    exists inside the SPA's origin.
+    """
+    if url.startswith("http"):
+        return url
+    base = f"http://{settings.MINIO_HOST}:{settings.MINIO_PORT}"
+    return base + (url[3:] if url.startswith("/s3/") else url)
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="requires the dev stack's MinIO")
+def test_multipart_round_trip_against_real_storage(minio_backend):
+    """create → sign → PUT two parts → complete → verify → delete."""
+    import requests
+
+    from app.services.minio_service import delete_file
+    from app.services.minio_service import object_exists_and_size
+
+    object_name = f"tests/multipart/{uuid.uuid4()}.bin"
+    part_size = sb.MULTIPART_MIN_PART_BYTES
+    bodies = [os.urandom(part_size), os.urandom(1024)]
+
+    upload_id = mp.create_upload(object_name, "application/octet-stream")
+    try:
+        urls, expires_in = mp.presign_parts(object_name, upload_id, [1, 2])
+        assert expires_in <= sb.max_presigned_seconds()
+
+        etags = []
+        for number, body in enumerate(bodies, start=1):
+            url = _direct(urls[number])
+            response = requests.put(url, data=body, timeout=60)
+            assert response.status_code == 200, response.text
+            etags.append(mp._clean_etag(response.headers["ETag"]))
+
+        listed = mp.list_uploaded_parts(object_name, upload_id)
+        assert [p["part_number"] for p in listed] == [1, 2]
+        assert [p["size"] for p in listed] == [len(bodies[0]), len(bodies[1])]
+
+        mp.complete_upload(
+            object_name,
+            upload_id,
+            [{"part_number": n, "etag": e} for n, e in enumerate(etags, start=1)],
+        )
+        assert object_exists_and_size(object_name) == sum(len(b) for b in bodies)
+    finally:
+        mp.abort_uploads_for_object(object_name)
+        try:
+            delete_file(object_name)
+        except Exception:  # noqa: BLE001 — cleanup only
+            pass
+    assert object_exists_and_size(object_name) is None
+
+
+@pytest.mark.skipif(not S3_LIVE, reason="requires the dev stack's MinIO")
+def test_abort_releases_an_unfinished_upload(minio_backend):
+    """An abandoned upload keeps billing for its parts until it is aborted."""
+    import requests
+
+    object_name = f"tests/multipart/{uuid.uuid4()}.bin"
+    upload_id = mp.create_upload(object_name, "application/octet-stream")
+    urls, _ = mp.presign_parts(object_name, upload_id, [1])
+    body = os.urandom(sb.MULTIPART_MIN_PART_BYTES)
+    assert requests.put(_direct(urls[1]), data=body, timeout=60).ok
+
+    assert mp.list_uploaded_parts(object_name, upload_id)
+    assert mp.abort_uploads_for_object(object_name) == 1
+    assert mp.abort_uploads_for_object(object_name) == 0

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "Keine Nachricht vorhanden",
   "upload.statusUploading": "Wird hochgeladen...",
   "upload.statusUploadingExtracted": "Extrahiertes Audio wird hochgeladen...",
+  "upload.resuming": "Upload wird fortgesetzt...",
   "upload.cancelledByUser": "Vom Benutzer abgebrochen",
   "upload.cancelled": "Upload abgebrochen",
   "upload.youtubeVideo": "YouTube-Video",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "No message provided",
   "upload.statusUploading": "Uploading...",
   "upload.statusUploadingExtracted": "Uploading extracted audio...",
+  "upload.resuming": "Resuming upload...",
   "upload.cancelledByUser": "Cancelled by user",
   "upload.cancelled": "Upload cancelled",
   "upload.youtubeVideo": "YouTube Video",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "No se proporcionó ningún mensaje",
   "upload.statusUploading": "Subiendo...",
   "upload.statusUploadingExtracted": "Subiendo el audio extraído...",
+  "upload.resuming": "Reanudando la subida...",
   "upload.cancelledByUser": "Cancelado por el usuario",
   "upload.cancelled": "Carga cancelada",
   "upload.youtubeVideo": "Vídeo de YouTube",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "Aucun message fourni",
   "upload.statusUploading": "Téléversement...",
   "upload.statusUploadingExtracted": "Téléversement de l'audio extrait...",
+  "upload.resuming": "Reprise du téléversement...",
   "upload.cancelledByUser": "Annulé par l'utilisateur",
   "upload.cancelled": "Téléversement annulé",
   "upload.youtubeVideo": "Vidéo YouTube",

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "メッセージはありません",
   "upload.statusUploading": "アップロード中...",
   "upload.statusUploadingExtracted": "抽出した音声をアップロード中...",
+  "upload.resuming": "アップロードを再開しています...",
   "upload.cancelledByUser": "ユーザーによってキャンセルされました",
   "upload.cancelled": "アップロードをキャンセルしました",
   "upload.youtubeVideo": "YouTube 動画",

--- a/frontend/src/lib/i18n/locales/pt.json
+++ b/frontend/src/lib/i18n/locales/pt.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "Nenhuma mensagem fornecida",
   "upload.statusUploading": "Enviando...",
   "upload.statusUploadingExtracted": "Enviando o áudio extraído...",
+  "upload.resuming": "Retomando o envio...",
   "upload.cancelledByUser": "Cancelado pelo usuário",
   "upload.cancelled": "Upload cancelado",
   "upload.youtubeVideo": "Vídeo do YouTube",

--- a/frontend/src/lib/i18n/locales/ru.json
+++ b/frontend/src/lib/i18n/locales/ru.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "Сообщение отсутствует",
   "upload.statusUploading": "Загрузка...",
   "upload.statusUploadingExtracted": "Загрузка извлечённого аудио...",
+  "upload.resuming": "Возобновление загрузки...",
   "upload.cancelledByUser": "Отменено пользователем",
   "upload.cancelled": "Загрузка отменена",
   "upload.youtubeVideo": "Видео с YouTube",

--- a/frontend/src/lib/i18n/locales/zh.json
+++ b/frontend/src/lib/i18n/locales/zh.json
@@ -3980,6 +3980,7 @@
   "notifications.noMessage": "没有提供消息",
   "upload.statusUploading": "正在上传...",
   "upload.statusUploadingExtracted": "正在上传提取的音频...",
+  "upload.resuming": "正在恢复上传...",
   "upload.cancelledByUser": "已由用户取消",
   "upload.cancelled": "上传已取消",
   "upload.youtubeVideo": "YouTube 视频",

--- a/frontend/src/lib/services/CLAUDE.md
+++ b/frontend/src/lib/services/CLAUDE.md
@@ -22,6 +22,9 @@ a second one in a component. (`AudioExtractionService` is also exported as a cla
 - `uploadService.ts` — the upload queue singleton: max 3 concurrent, 3 retries with exponential
   backoff, persisted to `localStorage['upload_queue']`. Tries a **presigned PUT
   straight to MinIO, then silently falls back** to the legacy multipart `POST /files`.
+- `multipartUploader.ts` — `uploadInParts()`: executes the presigned **multipart** plan the
+  backend returns for large objects (issue #327). A per-upload factory, not a singleton, like
+  `stallWatchdog`. See gotchas.
 - `stallWatchdog.ts` — `createStallWatchdog()`: the timeout control for file bodies. See gotchas.
 - `audioExtractionService.ts` — in-browser video→audio via FFmpeg.wasm (`-c:a copy`, no re-encode),
   core loaded from `frontend/static/ffmpeg/` (gitignored, ~31 MB — fetched by the
@@ -67,6 +70,18 @@ a second one in a component. (`AudioExtractionService` is also exported as a cla
 - The presigned→legacy fallback swallows the error with no log; a broken presign looks like a slow
   upload. `configService` likewise swallows its fetch error and marks itself loaded, so "config
   failed" is indistinguishable from "no protected hosts".
+- **The multipart path deliberately has no legacy fallback.** It is chosen for objects too large
+  to push through the API container, so falling back would do the exact thing it exists to avoid —
+  and a mid-transfer failure is _resumable_, which re-sending from zero is not. `uploadService`
+  parks a `MultipartSession` on the `UploadItem` for the whole transfer; the queue's normal retry
+  then resumes from the parts the bucket already holds instead of re-hashing and re-preparing.
+  The session is in-memory only (a `File` cannot be persisted), so resume covers retries within
+  the session, not a page reload. A 404/409 from `/files/multipart/parts` means the upload is
+  gone server-side and is the one case that restarts from `/prepare`.
+- **Giving up on a multipart upload must abort it** — object storage bills for the parts of an
+  incomplete upload. `cancelUpload`, the out-of-retries branch, and `reset()` (logout, before the
+  cookie goes away) all fire `DELETE /files/{fileId}`. `part_size`, `part_count` and the batch
+  size are all backend decisions; `multipartUploader` only executes them.
 - Persistence only restores `url`-type uploads — File/Blob sources can't survive a reload (by design).
 - `audioExtractionService` is a **deliberate** exception to the thin-frontend rule (it avoids uploading
   multi-GB video), like `$lib/export/`. Don't extend the precedent to business logic.

--- a/frontend/src/lib/services/multipartUploader.ts
+++ b/frontend/src/lib/services/multipartUploader.ts
@@ -1,0 +1,269 @@
+import axios from 'axios';
+import axiosInstance from '$lib/axios';
+
+/**
+ * Executes a presigned multipart upload planned by the backend (issue #327).
+ *
+ * A per-upload factory rather than a singleton, like `stallWatchdog`. It owns no
+ * policy: part size, part count and batch size all come from `/files/prepare`,
+ * and the part bodies are sent by a `putPart` callback that `uploadService`
+ * supplies so the stall watchdog and cancel token stay in one place.
+ *
+ * What it does own is the part pipeline — concurrency, per-part retry, fetching
+ * the next batch of signed URLs before it is needed, and resuming from the parts
+ * the bucket already holds.
+ */
+
+/** Upload plan returned by `/files/prepare` when the object needs multipart. */
+export interface MultipartPlan {
+  upload_id: string;
+  part_size: number;
+  part_count: number;
+  batch_size: number;
+  expires_in: number;
+  urls: Record<string, string>;
+}
+
+/** A part the backend has confirmed, as reported to `/files/complete`. */
+export interface CompletedPart {
+  part_number: number;
+  etag: string;
+}
+
+interface UploadedPartInfo {
+  part_number: number;
+  etag: string;
+  size: number;
+}
+
+/** Sends one part body and resolves with its ETag, or null if unreadable. */
+export type PutPart = (
+  url: string,
+  body: Blob,
+  onProgress: (loaded: number) => void
+) => Promise<string | null>;
+
+export interface MultipartUploadOptions {
+  /** MediaFile UUID from `/files/prepare` — authorizes the part signing. */
+  fileId: string;
+  body: Blob;
+  plan: MultipartPlan;
+  /** Ask storage which parts already landed before sending anything. */
+  resume?: boolean;
+  putPart: PutPart;
+  onProgress: (loadedBytes: number) => void;
+}
+
+export interface MultipartUploadResult {
+  /** Null when any ETag was unreadable — `/files/complete` reads them back instead. */
+  parts: CompletedPart[] | null;
+}
+
+/** Parts in flight at once. Uploads themselves already run 3-wide. */
+const PART_CONCURRENCY = 3;
+
+/** Attempts per part before the whole upload fails and the queue retries it. */
+const PART_MAX_ATTEMPTS = 3;
+
+const PART_RETRY_BASE_DELAY_MS = 500;
+
+/**
+ * Treat a signed URL as spent this long before it actually lapses, so a part is
+ * never started with a URL that will expire mid-transfer.
+ */
+const URL_EXPIRY_MARGIN_MS = 120000;
+
+interface SignedUrl {
+  url: string;
+  expiresAt: number;
+}
+
+/** Client for the part-signing endpoint. */
+async function requestParts(
+  fileId: string,
+  uploadId: string,
+  partNumbers: number[],
+  includeUploaded: boolean
+): Promise<{
+  urls: Record<string, string>;
+  expires_in: number;
+  uploaded_parts?: UploadedPartInfo[];
+}> {
+  const response = await axiosInstance.post('/files/multipart/parts', {
+    file_id: fileId,
+    upload_id: uploadId,
+    part_numbers: partNumbers,
+    include_uploaded: includeUploaded,
+  });
+  return response.data;
+}
+
+export async function uploadInParts(
+  options: MultipartUploadOptions
+): Promise<MultipartUploadResult> {
+  const { fileId, body, plan, putPart, onProgress } = options;
+  const partSize = plan.part_size;
+  const partCount = plan.part_count;
+  const batchSize = Math.max(1, plan.batch_size || 1);
+
+  /** Byte length of a given 1-based part; the last one is short. */
+  const sizeOfPart = (n: number) => Math.min(partSize, body.size - (n - 1) * partSize);
+
+  const etags = new Map<number, string | null>();
+  const loaded = new Map<number, number>();
+  const urls = new Map<number, SignedUrl>();
+
+  const seedUrls = (map: Record<string, string>, expiresIn: number) => {
+    const expiresAt = Date.now() + Math.max(0, expiresIn) * 1000;
+    for (const [number, url] of Object.entries(map || {})) {
+      urls.set(Number(number), { url, expiresAt });
+    }
+  };
+  seedUrls(plan.urls, plan.expires_in);
+
+  const pending: number[] = [];
+  for (let n = 1; n <= partCount; n++) pending.push(n);
+
+  if (options.resume) {
+    const state = await requestParts(fileId, plan.upload_id, [], true);
+    for (const part of state.uploaded_parts || []) {
+      // A part whose stored length differs from what we would send is a
+      // truncated write; re-send it rather than assembling a corrupt object.
+      if (part.size !== sizeOfPart(part.part_number)) continue;
+      etags.set(part.part_number, part.etag);
+      loaded.set(part.part_number, part.size);
+      const index = pending.indexOf(part.part_number);
+      if (index > -1) pending.splice(index, 1);
+    }
+  }
+
+  const reportProgress = () => {
+    let total = 0;
+    for (const value of loaded.values()) total += value;
+    onProgress(total);
+  };
+  reportProgress();
+
+  let signing: Promise<void> | null = null;
+
+  /**
+   * Resolve a usable URL for a part, signing the next batch when the cache has
+   * none or the cached one is close enough to expiry to be risky.
+   *
+   * Expiry is the reason URLs are minted a batch at a time: every presigned URL
+   * is clamped to `PRESIGNED_URL_MAX_SECONDS` server-side, and a multi-gigabyte
+   * upload can easily outlive that clamp.
+   */
+  const urlFor = async (part: number, forceRefresh: boolean): Promise<string> => {
+    const cached = urls.get(part);
+    if (!forceRefresh && cached && cached.expiresAt - URL_EXPIRY_MARGIN_MS > Date.now()) {
+      return cached.url;
+    }
+    if (forceRefresh) urls.delete(part);
+
+    while (signing) {
+      await signing;
+      const refreshed = urls.get(part);
+      if (refreshed && refreshed.expiresAt - URL_EXPIRY_MARGIN_MS > Date.now()) {
+        return refreshed.url;
+      }
+    }
+
+    const wanted = [part];
+    for (const candidate of pending) {
+      if (wanted.length >= batchSize) break;
+      if (candidate !== part && !urls.has(candidate)) wanted.push(candidate);
+    }
+    signing = (async () => {
+      const batch = await requestParts(
+        fileId,
+        plan.upload_id,
+        wanted.sort((a, b) => a - b),
+        false
+      );
+      seedUrls(batch.urls, batch.expires_in);
+    })();
+    try {
+      await signing;
+    } finally {
+      signing = null;
+    }
+
+    const signed = urls.get(part);
+    if (!signed) throw new Error(`No signed URL for part ${part}`);
+    return signed.url;
+  };
+
+  const sendPart = async (part: number) => {
+    const start = (part - 1) * partSize;
+    const chunk = body.slice(start, start + sizeOfPart(part));
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < PART_MAX_ATTEMPTS; attempt++) {
+      try {
+        // Re-sign from the second attempt on: an expired URL is the most likely
+        // reason a part that was fine a moment ago suddenly 403s.
+        const url = await urlFor(part, attempt > 0);
+        const etag = await putPart(url, chunk, (bytes) => {
+          loaded.set(part, bytes);
+          reportProgress();
+        });
+        etags.set(part, etag);
+        loaded.set(part, chunk.size);
+        reportProgress();
+        return;
+      } catch (error: unknown) {
+        lastError = error;
+        loaded.set(part, 0);
+        reportProgress();
+        // Cancellation and stalls are the caller's to interpret — a stalled
+        // link will stall the retry too, and the queue owns that decision.
+        if (isTerminal(error)) throw error;
+        if (attempt < PART_MAX_ATTEMPTS - 1) {
+          await delay(PART_RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
+        }
+      }
+    }
+    throw lastError;
+  };
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < Math.min(PART_CONCURRENCY, pending.length); i++) {
+    workers.push(
+      (async () => {
+        for (;;) {
+          const part = pending.shift();
+          if (part === undefined) return;
+          await sendPart(part);
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
+
+  const collected: CompletedPart[] = [];
+  for (let n = 1; n <= partCount; n++) {
+    const etag = etags.get(n);
+    // One unreadable ETag (a bucket that does not expose the header
+    // cross-origin) makes the whole client-side list useless; the backend
+    // reads the authoritative list from storage instead.
+    if (!etag) return { parts: null };
+    collected.push({ part_number: n, etag });
+  }
+  return { parts: collected };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Errors a part-level retry cannot help with.
+ *
+ * `UploadStalledError` is matched by name rather than `instanceof`: it is
+ * declared in `uploadService`, which imports this module, and importing it back
+ * would make the cycle real.
+ */
+function isTerminal(error: unknown): boolean {
+  return axios.isCancel(error) || (error as { name?: string })?.name === 'UploadStalledError';
+}

--- a/frontend/src/lib/services/uploadService.ts
+++ b/frontend/src/lib/services/uploadService.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_STALL_TIMEOUT_MS,
   type StallWatchdog,
 } from '$lib/services/stallWatchdog';
+import { uploadInParts, type MultipartPlan, type PutPart } from '$lib/services/multipartUploader';
 
 // Upload item types
 export type UploadType = 'file' | 'url' | 'recording' | 'extracted-audio';
@@ -51,6 +52,22 @@ export interface UploadItem {
   tagNames?: string[];
   // Batch grouping
   uploadBatchId?: string;
+  // Live multipart upload, kept so a retry resumes instead of restarting
+  multipart?: MultipartSession;
+}
+
+/**
+ * Everything needed to pick an interrupted multipart upload back up.
+ *
+ * Survives on the in-memory `UploadItem` only: the File it refers to cannot be
+ * persisted (see `loadPersistedUploads`), so resume covers retries within the
+ * session — which is where a 10 GB upload actually dies — not a page reload.
+ */
+interface MultipartSession {
+  fileId: string;
+  taskId: string;
+  fileHash: string | null;
+  plan: MultipartPlan;
 }
 
 // Upload configuration constants
@@ -333,6 +350,12 @@ class UploadService {
           RETRY_BASE_DELAY_MS * Math.pow(2, upload.retryCount)
         );
       } else {
+        // Out of retries: release the parts of an unfinished multipart upload
+        // rather than leaving the user paying for gigabytes nothing will claim.
+        if (upload.multipart) {
+          this.abortMultipart(upload.multipart.fileId);
+          this.updateUpload(uploadId, { multipart: undefined });
+        }
         toastStore.error(
           get(t)('upload.uploadFailed', {
             name: upload.name,
@@ -394,12 +417,153 @@ class UploadService {
     };
   }
 
+  /**
+   * Send one multipart part body under the shared stall watchdog.
+   *
+   * Resolves with the part's ETag, or null when the header is unreadable — a
+   * bucket that does not expose `ETag` cross-origin. `/files/complete` then
+   * reads the authoritative part list back from storage instead.
+   */
+  private makePutPart(cancelToken: CancelTokenSource): PutPart {
+    return (url, body, onProgress) =>
+      this.sendBody(async (watchdog) => {
+        const response = await axios.put(url, body, {
+          maxContentLength: Infinity,
+          maxBodyLength: Infinity,
+          cancelToken: cancelToken.token,
+          signal: watchdog.signal,
+          onUploadProgress: (progressEvent: AxiosProgressEvent) => {
+            watchdog.notifyProgress(progressEvent.loaded, progressEvent.total);
+            onProgress(progressEvent.loaded);
+          },
+        });
+        const etag = response.headers?.etag ?? response.headers?.ETag;
+        return etag ? String(etag).replace(/"/g, '') : null;
+      });
+  }
+
+  /** Percentage + ETA from a running byte count (the multipart equivalent of `makeProgressHandler`). */
+  private reportBytes(uploadId: string, loaded: number, total: number, startedAt: number) {
+    if (!total) return;
+    const progress = Math.min(Math.round((loaded * 100) / total), 99);
+    this.updateUpload(uploadId, { progress });
+    this.emit('progress', uploadId, { progress });
+    const elapsed = Date.now() - startedAt;
+    if (elapsed > 0 && loaded > 0) {
+      const remaining = ((total - loaded) * elapsed) / loaded;
+      this.updateUpload(uploadId, { estimatedTime: this.formatTimeRemaining(remaining) });
+    }
+  }
+
+  /**
+   * Run a presigned multipart upload to completion.
+   *
+   * The session is parked on the `UploadItem` for the whole transfer so a queue
+   * retry resumes it; it is cleared only once `/files/complete` has assembled
+   * the object.
+   */
+  private async runMultipart(
+    uploadId: string,
+    file: File | Blob,
+    session: MultipartSession,
+    cancelToken: CancelTokenSource,
+    resume: boolean
+  ): Promise<UploadResult> {
+    const upload = this.uploads.get(uploadId)!;
+    this.updateUpload(uploadId, {
+      status: 'uploading',
+      fileId: session.fileId,
+      multipart: session,
+      estimatedTime: get(t)(resume ? 'upload.resuming' : 'upload.statusUploading'),
+    });
+
+    const clientPutStartMs = Date.now();
+    const { parts } = await uploadInParts({
+      fileId: session.fileId,
+      body: file,
+      plan: session.plan,
+      resume,
+      putPart: this.makePutPart(cancelToken),
+      onProgress: (loadedBytes) =>
+        this.reportBytes(uploadId, loadedBytes, file.size, clientPutStartMs),
+    });
+    const clientPutEndMs = Date.now();
+
+    await axiosInstance.post(
+      '/files/complete',
+      {
+        file_id: session.fileId,
+        task_id: session.taskId,
+        file_hash: session.fileHash,
+        file_size: file.size,
+        upload_id: session.plan.upload_id,
+        parts,
+        client_put_start_ms: clientPutStartMs,
+        client_put_end_ms: clientPutEndMs,
+        min_speakers: upload.minSpeakers ?? null,
+        max_speakers: upload.maxSpeakers ?? null,
+        num_speakers: upload.numSpeakers ?? null,
+      },
+      // Assembling hundreds of parts is more than the 60 s default allows for.
+      { timeout: CONTROL_REQUEST_TIMEOUT_MS }
+    );
+
+    this.updateUpload(uploadId, { multipart: undefined });
+    return { uuid: session.fileId, isDuplicate: false };
+  }
+
+  /**
+   * Resume a parked multipart session, or report that it is gone.
+   *
+   * Returns null when the backend no longer knows the upload (404/409), which
+   * means starting over from `/prepare` is the only option. Any other failure
+   * is rethrown so the queue retries the resume rather than re-sending
+   * gigabytes that are already in the bucket.
+   */
+  private async resumeMultipart(
+    uploadId: string,
+    file: File | Blob,
+    session: MultipartSession,
+    cancelToken: CancelTokenSource
+  ): Promise<UploadResult | null> {
+    try {
+      return await this.runMultipart(uploadId, file, session, cancelToken, true);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404 || status === 409) {
+        this.updateUpload(uploadId, { multipart: undefined });
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Discard a multipart upload the client has given up on.
+   *
+   * Object storage bills for the parts of an incomplete upload until it is
+   * aborted, and they do not show up in a normal object listing. Fire-and-forget:
+   * the bucket's abort-incomplete lifecycle rule is the backstop.
+   */
+  private abortMultipart(fileId: string) {
+    axiosInstance.delete(`/files/${fileId}`).catch(() => {
+      /* best-effort */
+    });
+  }
+
   private async uploadFile(uploadId: string, file: File | Blob): Promise<UploadResult> {
     const upload = this.uploads.get(uploadId)!;
 
     // Create cancel token
     const cancelToken = axios.CancelToken.source();
     this.updateUpload(uploadId, { cancelToken });
+
+    // A parked session means a previous attempt died mid-transfer. Pick up the
+    // parts already in the bucket instead of re-hashing and re-sending them.
+    if (upload.multipart) {
+      const resumed = await this.resumeMultipart(uploadId, file, upload.multipart, cancelToken);
+      if (resumed) return resumed;
+    }
 
     // Calculate file hash for duplicate detection (SHA-256 via Web Worker).
     let fileHash: string | null = null;
@@ -438,6 +602,7 @@ class UploadService {
       task_id: taskId,
       upload_url: uploadUrl,
       upload_method: uploadMethod,
+      multipart: multipartPlan,
     } = prepareResponse.data;
 
     if (is_duplicate) {
@@ -450,6 +615,21 @@ class UploadService {
       progress: 0,
       estimatedTime: get(t)('upload.statusUploading'),
     });
+
+    // --- Presigned multipart flow ----------------------------------------
+    // Chosen by the backend for objects large enough to need resume, or too
+    // large for one PUT. No fallback to the legacy POST: the whole point is to
+    // keep multi-GB bodies out of the API container, and a failure here is
+    // resumable on retry, which re-sending the object from zero is not.
+    if (uploadMethod === 'MULTIPART' && multipartPlan && taskId) {
+      return await this.runMultipart(
+        uploadId,
+        file,
+        { fileId, taskId, fileHash, plan: multipartPlan as MultipartPlan },
+        cancelToken,
+        false
+      );
+    }
 
     const progressHandler = this.makeProgressHandler(uploadId, upload);
 
@@ -703,9 +883,14 @@ class UploadService {
       upload.cancelToken.cancel('Upload cancelled by user');
     }
 
+    if (upload.multipart) {
+      this.abortMultipart(upload.multipart.fileId);
+    }
+
     this.updateUpload(uploadId, {
       status: 'cancelled',
       error: get(t)('upload.cancelledByUser'),
+      multipart: undefined,
     });
 
     // Remove from active uploads and queue
@@ -751,13 +936,17 @@ class UploadService {
    */
   reset() {
     // Cancel any in-flight uploads
-    for (const [id, upload] of this.uploads.entries()) {
+    for (const [, upload] of this.uploads.entries()) {
       if (upload.cancelToken) {
         try {
           upload.cancelToken.cancel('User logged out');
         } catch {
           /* ignore */
         }
+      }
+      // Abort before the session cookie goes away — afterwards nothing can.
+      if (upload.multipart) {
+        this.abortMultipart(upload.multipart.fileId);
       }
     }
     this.uploads.clear();
@@ -867,9 +1056,11 @@ class UploadService {
         id,
         {
           ...upload,
-          // Don't persist source data or cancel tokens
+          // Don't persist source data, cancel tokens, or a multipart session:
+          // resuming one needs the File, which cannot survive a reload.
           source: upload.type === 'url' ? upload.source : null,
           cancelToken: undefined,
+          multipart: undefined,
         },
       ]);
       localStorage.setItem('upload_queue', JSON.stringify(uploadsData));


### PR DESCRIPTION
Closes #327.

## The gap

`/files/prepare` checked `supports_single_put` and, above the backend's ceiling, minted no URL at all — so the browser fell back to `POST /files`, spooling a multi-GB body to disk inside the API container. On `STORAGE_BACKEND=s3` that ceiling is **5 GiB**, which is the remaining native-S3 gap after #284 A1.11. And with no multipart there was no resume: a 10 GB upload that died at 90% started over, on either backend.

## The flow

```
POST /files/prepare        → creates the multipart upload, returns the plan + first 8 part URLs
PUT  <presigned part URL>  → browser sends parts, 3 in flight            (bytes never touch the API)
POST /files/multipart/parts→ next batch of signed URLs; on resume, the parts storage already holds
POST /files/complete       → assembles the parts, then the existing verify/fingerprint/dispatch tail
DELETE /files/{uuid}       → aborts an upload the client gave up on
```

## Decisions worth reviewing

**Part size and threshold are backend policy**, in `storage_backend.py` beside `supports_single_put` — no call site branches on backend name. 64 MiB parts (matching the existing server-side `PRESIGNED_PUT_PART_SIZE`), grown only if the default would exceed the 10 000-part cap. `MULTIPART_THRESHOLD_MB` (512 MB) is **clamped to the single-PUT ceiling**, so it can never be configured high enough to put a >5 GiB object back on a path S3 rejects. Below the ceiling the threshold is about resume, not size; small uploads keep the unchanged single-PUT path.

**Part URLs are signed a batch at a time, not once per object.** They take the same `clamp_presigned_expiry` as every other presigned URL (6 h) because a signed URL cannot outlive the STS credentials behind it — and a 15 GB upload on a slow line can outlive that clamp. Eight 64 MiB parts cannot, so each batch is signed just before it is needed. The client also re-signs on a part's second attempt, since an expired URL is the likeliest reason a part suddenly 403s.

**One SDK, still.** minio-py's multipart primitives are underscore-prefixed (`_create_multipart_upload`, `_complete_multipart_upload`, `_abort_multipart_upload`, `_list_parts`, `_list_multipart_uploads`); part *signing* uses the public `get_presigned_url(..., extra_query_params=...)`. Adding boto3 instead would mean a second client with its own duplicate of the endpoint/credential/region policy that `storage_backend` exists to centralise. `tests/unit/test_multipart_upload.py` asserts the primitives still exist, so an SDK bump fails in CI rather than in a user's 10 GB upload.

**Abandoned uploads are aborted, not left to bill.** S3 and MinIO both charge for the parts of an incomplete upload and neither shows them in an object listing. `DELETE /files/{uuid}` aborts them (discovered by object key — the `upload_id` is client state), and the browser fires it on cancel, on out-of-retries, and on logout before the cookie goes away. The lifecycle-rule backstop is **native-S3 only**: MinIO's ILM rejects an `AbortIncompleteMultipartUpload` rule outright (`InvalidArgument`, verified against RELEASE.2025-09-07) and does not need one — it purges stale uploads on its own scan (`api.stale_uploads_expiry`, 24 h).

**Resume is server-authoritative.** The client asks storage which parts landed rather than trusting its own record (a PUT can succeed with the response lost), and a part whose stored length differs from what would be sent is re-sent rather than assembled. A dead `upload_id` answers **409**, not an empty list the client would read as "nothing uploaded yet".

**No legacy fallback on the multipart path** — deliberately. Multipart is chosen precisely to keep the body out of the API container, and a mid-transfer failure is *resumable*, which re-sending from zero is not. `/prepare` still degrades to `POST /files` if multipart *setup* fails.

## Verification

Full suite green (`pytest backend/tests/unit backend/tests/api`, 2116 tests, live-MinIO gates enabled), `import app.main` OK, `pre-commit run --all-files` green, frontend lint / svelte-check (0 errors) / build / vitest / `check:i18n` green.

Real uploads through the browser (Playwright, isolated throwaway stack, never the dev stack):

| file | transport | result |
|---|---|---|
| **6.44 GiB** (6 912 040 738 B) | MULTIPART, 64 MiB × 103 parts | assembled object SHA-256 **byte-identical** to source; ~40 s |
| 1.45 GiB | MULTIPART, 24 parts | byte-identical |
| 700 MB (abort probe) | MULTIPART | `DELETE /files/{uuid}` left **0** in-flight uploads |

**Resume was genuinely exercised**, not simulated: the browser was taken offline mid-transfer of the 6.44 GiB upload after 6 parts. Result — 105 part PUTs for 103 parts, i.e. **only the 2 in-flight parts were re-sent**; exactly one signing call carried `include_uploaded`; the completed object was still byte-exact.

**Not verified:** the >5 GiB path against *real AWS S3*. There is no AWS account here. It was exercised at 6.44 GiB against MinIO, and with `STORAGE_BACKEND=s3` forced so the 5 GiB policy branch is the one under test — but the assertion "AWS accepts these part uploads" rests on the S3 API contract, not on an observed AWS response.

## Route digest

410 routes (master: 409). One added: `POST /api/files/multipart/parts`.

## Found, not fixed (out of scope, filed separately)

- **Client-side SHA-256 is capped at ~4 GB.** `sha256Worker` does `file.arrayBuffer()`; Chrome answers `NotReadableError` for a 6.44 GiB file. The hash is optional (duplicate detection) and `uploadFile` swallows the error, so uploads still succeed — but files above ~4 GB silently skip dedup, against a UI advertising 15 GB.
- **`opentr.sh start --fresh --port-offset N` does not actually offset.** The generated `.fresh/<name>-ports.yml` adds a second `ports:` entry; Compose *appends* port lists rather than replacing them, so the base `${REDIS_PORT:-5177}` mapping is still published and the fresh stack collides with the main one. Setting the `*_PORT` env vars the base file already reads works.
