### PR TITLE
security(auth-config): treat an undecryptable secret as unset, never return ciphertext

### DIFF
--- a/backend/app/services/auth_config_service.py
+++ b/backend/app/services/auth_config_service.py
@@ -320,13 +320,38 @@ class AuthConfigService:
 
         value: str | None = config.config_value  # type: ignore[assignment]
         if config.is_sensitive and decrypt and value:
+            # Undecryptable means UNSET, never "hand back the ciphertext".
+            #
+            # This used to return the stored ciphertext on failure, and returned it
+            # silently when decrypt_api_key merely returned falsy without raising
+            # (issue #324). Callers use these values as real credentials — an LDAP
+            # bind password, an OIDC client secret — so ciphertext is at best a
+            # baffling auth failure and at worst an encrypted blob shipped to an
+            # external IdP or rendered in the admin UI.
+            #
+            # Returning None makes the sole caller (`_get_effective`, which tests
+            # `if db_value is not None`) fall through to the env value and then the
+            # coded default: a known source instead of garbage.
             try:
                 decrypted = decrypt_api_key(value)
-                if decrypted:
-                    value = decrypted
-            except Exception as e:
-                logger.warning(f"Failed to decrypt config value for {key}: {e}")
-                # Return encrypted value if decryption fails
+            except Exception:
+                logger.exception(
+                    "Failed to decrypt sensitive auth config %s; treating it as unset. "
+                    "Check ENCRYPTION_KEY — a rotated or lost key makes stored secrets "
+                    "unrecoverable and they must be re-entered.",
+                    key,
+                )
+                return None
+
+            if not decrypted:
+                logger.error(
+                    "Decrypting sensitive auth config %s produced an empty value; "
+                    "treating it as unset rather than returning the stored ciphertext.",
+                    key,
+                )
+                return None
+
+            value = decrypted
 
         return value
 
@@ -380,8 +405,24 @@ class AuthConfigService:
             if config.is_sensitive and decrypt and value:
                 try:
                     decrypted = decrypt_api_key(value)  # type: ignore[call-overload]
+                    if not decrypted:
+                        logger.error(
+                            "Decrypting sensitive auth config %s produced an empty value; "
+                            "masking it. Check ENCRYPTION_KEY.",
+                            config.config_key,
+                        )
+                    # Masked, not the ciphertext. This surface feeds the admin UI, so
+                    # the placeholder is deliberate — but it must never be usable as a
+                    # credential, and the failure must be visible (issue #324): both
+                    # branches previously masked in silence.
                     value = decrypted or "***ENCRYPTED***"  # type: ignore[assignment]
                 except Exception:
+                    logger.exception(
+                        "Failed to decrypt sensitive auth config %s; masking it. "
+                        "Check ENCRYPTION_KEY — a rotated or lost key makes stored "
+                        "secrets unrecoverable and they must be re-entered.",
+                        config.config_key,
+                    )
                     value = "***ENCRYPTED***"  # type: ignore[assignment]
 
             # Convert to appropriate type

--- a/backend/tests/test_auth_config_service.py
+++ b/backend/tests/test_auth_config_service.py
@@ -79,8 +79,18 @@ class TestAuthConfigServiceGetConfig:
         result = AuthConfigService.get_config(mock_db, "sensitive_key", decrypt=False)
         assert result == "encrypted_value"
 
-    def test_get_config_decryption_failure_returns_encrypted(self, mock_db):
-        """Test that decryption failure returns encrypted value."""
+    def test_get_config_decryption_failure_returns_none(self, mock_db):
+        """A value that cannot be decrypted is UNSET, never the raw ciphertext.
+
+        This test previously asserted the opposite — that the ciphertext is handed
+        back — which pinned a fail-open as intended behaviour (issue #324). Callers
+        use these values as real credentials (LDAP bind password, OIDC client
+        secret), so ciphertext is at best a baffling auth failure and at worst an
+        encrypted blob shipped to an external IdP or rendered in the admin UI.
+
+        Returning None makes `_get_effective` fall through to the env value and then
+        the coded default — a known source instead of garbage.
+        """
         mock_config = MagicMock(spec=AuthConfig)
         mock_config.config_value = "encrypted_value"
         mock_config.is_sensitive = True
@@ -89,8 +99,24 @@ class TestAuthConfigServiceGetConfig:
         with patch("app.services.auth_config_service.decrypt_api_key") as mock_decrypt:
             mock_decrypt.side_effect = Exception("Decryption failed")
             result = AuthConfigService.get_config(mock_db, "sensitive_key")
-            # Should return the encrypted value on failure
-            assert result == "encrypted_value"
+            assert result is None, "must not hand back the ciphertext"
+
+    def test_get_config_empty_decryption_returns_none(self, mock_db):
+        """A decrypt that returns falsy without raising is also UNSET.
+
+        The quieter half of the same bug: the old code only logged in the `except`
+        branch, so a `decrypt_api_key` that returned None or "" left `value` as the
+        ciphertext and said nothing at all.
+        """
+        mock_config = MagicMock(spec=AuthConfig)
+        mock_config.config_value = "encrypted_value"
+        mock_config.is_sensitive = True
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+
+        with patch("app.services.auth_config_service.decrypt_api_key") as mock_decrypt:
+            mock_decrypt.return_value = None
+            result = AuthConfigService.get_config(mock_db, "sensitive_key")
+            assert result is None, "must not silently fall back to the ciphertext"
 
 
 class TestAuthConfigServiceSetConfig:


### PR DESCRIPTION
Fixes item 6 of #324. Refs #284.

## The bug

`AuthConfigService.get_config` returned the stored **ciphertext** when decryption failed. The comment said so outright:

```python
except Exception as e:
    logger.warning(f"Failed to decrypt config value for {key}: {e}")
    # Return encrypted value if decryption fails
```

There was a **quieter second path** the issue did not mention: when `decrypt_api_key` returned falsy *without raising*, `if decrypted:` was False, `value` stayed as the ciphertext, and **nothing was logged at all**.

## Why it matters

These values are used as real credentials — an LDAP bind password, an OIDC client secret. Handing back ciphertext is at best a baffling authentication failure, and at worst an encrypted blob shipped to an **external IdP** or rendered in the **admin UI**.

## The fix

Both paths return `None` and log.

The sole caller, `_get_effective`, tests `if db_value is not None`, so `None` makes it fall through to the env value and then the coded default — **a known source instead of garbage**. That is the fail-closed direction here: "unset" is recoverable, a wrong credential is not.

The log names `ENCRYPTION_KEY` explicitly, because a rotated or lost key is the usual cause and it means the stored secrets are unrecoverable and must be re-entered — that is the operator action, and it should not require reading the source to work out.

`get_config_by_category` already masked to `***ENCRYPTED***` rather than leaking ciphertext — correct, since that surface feeds the admin UI — but it did so **in silence on both branches**. It now logs while keeping the mask.

## A test asserted the bug

`test_get_config_decryption_failure_returns_encrypted` pinned the fail-open as intended behaviour:

```python
# Should return the encrypted value on failure
assert result == "encrypted_value"
```

It is rewritten to assert `None`, with the reasoning in the docstring so it does not get "fixed" back. A second test covers the silent falsy-decrypt path, which had no coverage at all.

Worth noting for the wider #284 pattern: this is not just code that silently did nothing — it had a **test defending** the behaviour, which is how it survived.

## Verification

`pytest -k auth_config` with `RUN_AUTH_CONFIG_TESTS=true` → **93 passed** (was 91 + the rewritten one + 1 new). Pre-commit green: ruff, ruff-format, mypy, bandit, gitleaks, import-linter.