### PR TITLE
security: stop caching a blind redaction pass as clean, and surface unverifiable password history

### DIFF
--- a/backend/app/auth/password_policy.py
+++ b/backend/app/auth/password_policy.py
@@ -268,6 +268,9 @@ class PasswordPolicy:
         # Check against the last N passwords
         history_to_check = password_history[: self.history_count]
 
+        checked = 0
+        unverifiable = 0
+
         for old_hash in history_to_check:
             if not old_hash:
                 continue
@@ -275,10 +278,32 @@ class PasswordPolicy:
                 if verify_func(plain_password, old_hash):
                     logger.warning("Password reuse detected in history check")
                     return False
-            except Exception as e:
-                # Log but don't fail if hash verification has issues
-                logger.debug(f"Error checking password history: {e}")
-                continue
+                checked += 1
+            except Exception:
+                # An entry we cannot verify is NOT evidence that the password is
+                # unused — we simply do not know. Keep going, but say so out loud:
+                # this used to log at debug, i.e. invisibly in production, so a
+                # history that had silently stopped being checked looked identical
+                # to one that passed (issue #324).
+                unverifiable += 1
+                logger.exception("Could not verify a password-history entry")
+
+        if unverifiable:
+            # Deliberately NOT fail-closed. Rejecting the new password would leave
+            # the user on their CURRENT password — a guaranteed reuse — which is
+            # worse than possibly permitting an old one. So allow the change and
+            # make the degradation alertable instead.
+            level = logger.critical if checked == 0 else logger.error
+            level(
+                "Password-history check was %s: %d of %d entries could not be "
+                "verified. The reuse control is %s. This usually means the stored "
+                "hashes were written under a different scheme (see FIPS_MODE / "
+                "FIPS_VERSION) and can no longer be verified.",
+                "completely blind" if checked == 0 else "degraded",
+                unverifiable,
+                unverifiable + checked,
+                "NOT being enforced" if checked == 0 else "partially enforced",
+            )
 
         return True
 

--- a/backend/app/services/redaction/service.py
+++ b/backend/app/services/redaction/service.py
@@ -38,6 +38,7 @@ class RedactionService:
         run_profanity: bool = True,
         run_pii: bool = True,
         run_toxicity: bool = True,
+        failures: list[str] | None = None,
     ) -> tuple[list[dict], dict | None]:
         """Run cached detectors for one segment. Returns (span_dicts, toxicity_scores).
 
@@ -45,6 +46,13 @@ class RedactionService:
         Toxicity is a per-segment score dict (no char span). For bulk detection the
         caller sets ``run_toxicity=False`` and batches toxicity separately (faster).
         ``run_*`` flags are gated by per-language detector support.
+
+        Args:
+            failures: Optional sink. A detector that raises appends its name here so
+                the caller can tell "found nothing" apart from "could not look".
+                Detection is cached once and never re-run, so a swallowed failure
+                would otherwise be indistinguishable from a clean result forever
+                (issue #324).
         """
         spans: list[RedactionSpan] = []
         # Profanity (curated, user-independent → safe to cache).
@@ -58,6 +66,8 @@ class RedactionService:
                 spans.extend(pii_presidio.detect_pii(text, words, det_cfg))
             except Exception as exc:  # noqa: BLE001
                 logger.warning("PII detection skipped for a segment: %s", exc)
+                if failures is not None:
+                    failures.append("pii")
         # Toxicity score (per-segment).
         toxicity: dict | None = None
         if run_toxicity:
@@ -113,6 +123,13 @@ class RedactionService:
             .all()
         )
 
+        # Detectors that RAISED, as opposed to ones deliberately skipped for the
+        # transcript's language. Detection is cached once and never re-run, so a
+        # swallowed failure would be cached as "nothing found" permanently — a
+        # transcript full of PII would look clean forever (issue #324). Anything
+        # in here means the cached result is not trustworthy.
+        detector_failures: list[str] = []
+
         llm_spans_by_idx: dict[int, list] = {}
         if run_llm:
             try:
@@ -125,6 +142,7 @@ class RedactionService:
                 }
             except Exception as exc:  # noqa: BLE001
                 logger.warning("LLM redaction detection failed for file %s: %s", file_id, exc)
+                detector_failures.append("llm")
 
         # Serialize GPU inference (no-op on CPU) so concurrent files never stack model
         # activations on one GPU — peak VRAM stays bounded to a single inference.
@@ -144,7 +162,8 @@ class RedactionService:
                             [str(s.text or "") for s in segments], media.language
                         )
                     except Exception as exc:  # noqa: BLE001
-                        logger.debug("Batch toxicity skipped for file %s: %s", file_id, exc)
+                        logger.warning("Batch toxicity failed for file %s: %s", file_id, exc)
+                        detector_failures.append("toxicity")
 
                 for idx, seg in enumerate(segments):
                     span_dicts, _ = RedactionService.detect_segment_spans(
@@ -154,12 +173,34 @@ class RedactionService:
                         run_profanity=run_profanity,
                         run_pii=run_pii,
                         run_toxicity=False,
+                        failures=detector_failures,
                     )
                     if idx in llm_spans_by_idx:
                         span_dicts = span_dicts + llm_spans_by_idx[idx]
                     pii_count += sum(1 for s in span_dicts if s.get("category") == "pii")
                     seg.redactions = span_dicts or None  # type: ignore[assignment]
                     seg.toxicity = tox_scores[idx]  # type: ignore[assignment]
+            if detector_failures:
+                # Do NOT cache a degraded pass as DONE. Detection runs once and is
+                # never re-run, so marking this complete would permanently record
+                # "no PII found" for a transcript nobody actually finished scanning
+                # (issue #324). FAILED keeps the file eligible for re-detection.
+                #
+                # The spans that DID succeed are committed — they are real findings
+                # and dropping them would be strictly worse — but the status makes
+                # clear the result is partial.
+                failed = sorted(set(detector_failures))
+                media.redaction_status = C.REDACTION_STATUS_FAILED  # type: ignore[assignment]
+                db.commit()
+                logger.error(
+                    "Redaction detection for file %s completed with failed detectors %s; "
+                    "marking FAILED so it is re-run rather than caching an incomplete "
+                    "result as clean. Partial spans found so far were kept.",
+                    file_id,
+                    failed,
+                )
+                return {"status": "failed", "reason": "detector_failure", "detectors": failed}
+
             media.redaction_status = C.REDACTION_STATUS_DONE  # type: ignore[assignment]
             media.redaction_model_version = C.REDACTION_MODEL_VERSION  # type: ignore[assignment]
             db.commit()


### PR DESCRIPTION
Closes the last two items of #324 (items 4 and 5). Refs #284.

Both are the same shape as the rest of that issue: **a control that could not actually run, recorded as though it had.**

## Redaction — a failed scan cached as "clean" forever (item 5)

`detect_and_store` set `redaction_status = DONE` **unconditionally**, while the detectors underneath swallowed their own failures:

| Detector | Failure handling before |
|---|---|
| per-segment PII | caught, `warning`, empty spans |
| batch toxicity | caught, **`debug`**, all scores `None` |
| LLM | caught, `warning`, no spans |

So a transient failure — model not loaded, OOM, LLM provider down — produced empty spans, a `DONE` status, and, because detection is **detect-once/cache-forever**, a transcript permanently recorded as containing no PII. It is never re-scanned, so the failure is invisible from that moment on.

**Fix:** detector exceptions land in a `detector_failures` sink (`detect_segment_spans` gains an optional `failures` list) and the run is marked `FAILED` rather than `DONE`, keeping the file eligible for re-detection.

Two deliberate choices worth calling out:
- **Spans that DID succeed are still committed.** They are real findings; discarding them would be strictly worse. Only the *status* changes, so the result is not misrepresented as complete.
- **Language-gated skips are untouched.** `detector_language_support` skips are intentional, not failures, and must not trigger a retry loop.

Batch toxicity also moves from `debug` to `warning` — at `debug` it was invisible in production.

## Password history — an unverifiable hash counted as "not a match" (item 4)

The reuse check treated a hash it could not verify as a non-match and logged at `debug`. If every stored hash became unverifiable — plausible after a hashing-scheme or FIPS-mode change — the control **silently stopped enforcing anything**, and a fully blind check was indistinguishable from a clean pass.

**I deliberately did NOT make this fail closed**, unlike everything else in #324, and want that decision visible rather than buried:

> Rejecting the new password leaves the user on their **current** password — a guaranteed reuse. Permitting a *possibly* reused old one is strictly better. Failing closed here would make the security outcome worse, not better.

So the fix is visibility, not refusal: count verifiable vs unverifiable entries, log `ERROR` when the check is degraded and `CRITICAL` when it was **completely blind**, and name `FIPS_MODE` / `FIPS_VERSION` as the usual cause so the operator has somewhere to look.

## Verification

`pytest -k "redaction or password_policy or password_history"` → **54 passed, 1 skipped**. Pre-commit green (ruff, ruff-format, mypy, bandit, gitleaks, import-linter).

## After this

#324 is fully addressed: item 1–2 in #336, item 3 in #331, item 6 in #341, items 4–5 here. The only #324 follow-up left is documentation — the AWS deployment guide should require **ElastiCache Redis with Multi-AZ + automatic failover**, so the Redis-degraded window from #336 is seconds of failover rather than an outage.