### PR TITLE
feat(api)!: serve tag objects on the file-detail payload; drop the write-only reactiveFile store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ This release also incorporates the substantial pipeline work that landed since v
 
 ### Changed
 
+- **Removed the write-only `reactiveFile` store from the file-detail page (issue #338)**: `frontend/src/routes/files/[id]/+page.svelte` declared `const reactiveFile = writable(null)` — a page-local `const`, never exported — and wrote to it 13 times. Nothing subscribed: no `$reactiveFile`, no `.subscribe()`, no importer. A store with no subscribers does nothing on `.set()`, so all 13 calls were inert, and they actively misled review (a reader sees `reactiveFile.set(file)` after a mutation and concludes the UI will refresh). The real update path is the page's own `file` assignment/invalidation propagating to its children — which is what `frontend/src/components/fileDetail/CLAUDE.md` already documented as the pattern. The store, its 13 writes, the `setReactiveFile` member of `FileNotificationContext`, its 3 call sites in `$lib/fileDetail/notificationHandler.ts`, and the doc comment that described it as the websocket integration point are all gone. `setFile` is untouched — it performs the real `file = ...` assignment and is load-bearing.
 - **Backend code-quality overhaul (maintainability, no behavior change)**: a sweep of the FastAPI backend with characterization tests as the regression net. **SQLAlchemy 2.0 typed models** — all 26 model files converted from legacy `Column()` to `Mapped[]`/`mapped_column()`, which let mypy see real column types and drop ~165 errors, and made 257 defensive `int(current_user.id)`-style casts provably redundant (removed); a `pg_dump` before/after diff proved zero schema change. **Blocking I/O off the event loop** — 17 `async` handlers that made synchronous MinIO/OpenSearch calls were either converted to `def` (FastAPI threadpools them) or wrapped in `run_in_threadpool`. **Endpoint dedup** — a message-parameterized `require_resource_owner` helper consolidated 17 copy-pasted ownership checks, a shared `paginate()` helper and an `ErrorHandler.internal_error()` replaced repeated boilerplate, all behavior-preserving and snapshot-gated. **Comprehensive endpoint test coverage** — characterization suites for all 39 previously-untested endpoint modules (~720 new tests across auth, files, speakers, settings, collaboration, and system/admin), with a byte-exact ownership-contract spec; coverage floor ratcheted 35 → 37 %. Celery task DB sessions standardized on `session_scope()`. **UUIDv7 generation** — all primary `uuid` columns now mint time-ordered RFC 9562 v7 identifiers (better index locality than random uuid4) via a small dependency-free generator; backward-compatible (existing rows coexist), with a defensive idempotent migration (`v368`) that converts any legacy `varchar(36)` uuid column to native `uuid` so older deployments upgrade without breaking.
 - **In-place storage recovery / re-ingestion**: a new `python -m app.scripts.reingest_minio` registers media objects that exist in MinIO but have no database row — pointing each `MediaFile` at the existing object key (zero copy/duplication) and dispatching the standard pipeline — plus rate-limited yt-dlp metadata-only recovery for orphaned YouTube thumbnails. Built for disaster recovery where media survives but the database is lost.
 - **Fresh / isolated deployments**: `./opentr.sh start dev --fresh <name>` runs a fully isolated stack (own compose project + volumes, NAS overlay never loaded) for safe experimentation; explicit `--nas`/`--no-nas` directives replace the silent auto-load; `.opentranscribe-live-data` marker files and a `data-paths` subcommand guard live bind-mounts against accidental cleanup.
@@ -272,12 +273,72 @@ This release also incorporates the substantial pipeline work that landed since v
 - **Screenshots & Visual Guide published** (`getting-started/screenshots`): a 15-section visual walkthrough covering login through upload, processing, transcripts, speaker management, AI features, collections, bulk operations, and administration. The page existed but was disabled behind an underscore prefix and was unreachable — its image component was defined as `export const Img = ({src}) => <Img src={useBaseUrl(src)} />`, which rendered itself and recursed until the stack blew, and its 51 captions were indented inside their JSX wrapper so MDX parsed them as markdown paragraphs, emitting `<p>` inside `<p>` (invalid HTML, React hydration failure on every viewport). Both are fixed, images are lazy-loaded with async decoding (51 full-size screenshots on one page), and its four dead category-index links (`/docs/user-guide`, `/docs/installation`, `/docs/configuration`, and `/docs/api`, which never existed) now point at real pages. This surfaces 50 screenshots that were on disk but referenced by no published page.
 - **Removed the superseded `_intro.mdx` orphan**: same self-referential image component, imported by nothing, excluded from the build, and factually stale (claimed OpenSearch 3.3.1 against the shipped 3.4, and a 7-language UI against the current 8 locales). Its content is covered by the published `getting-started/introduction`.
 
+### Breaking Changes
+
+#### API — `GET /api/files/{uuid}` returns tag objects instead of tag names (issue #326)
+
+`MediaFileDetail.tags` was `list[str]` — the serializer selected `Tag.name` and nothing else — while
+`GET /api/tags`, `POST /api/tags`, and `POST /api/tags/files/{uuid}/tags` all returned `Tag`
+objects. Three surfaces, two shapes. The file-detail payload now carries the **same object** the tag
+endpoints serve, so there is one definition of a tag on the API.
+
+**Before** (`GET /api/files/{uuid}`):
+
+```json
+{
+  "uuid": "019ec90a-1b2c-7def-8000-000000000001",
+  "filename": "quarterly-review.mp4",
+  "tags": ["Important", "Meeting"]
+}
+```
+
+**After** (`GET /api/files/{uuid}`):
+
+```json
+{
+  "uuid": "019ec90a-1b2c-7def-8000-000000000001",
+  "filename": "quarterly-review.mp4",
+  "tags": [
+    { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a1", "name": "Important", "source": "manual" },
+    { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a2", "name": "Meeting", "source": "auto_ai" }
+  ]
+}
+```
+
+`uuid` (string, UUID) and `name` (string) are always present; `source` is nullable and is `"manual"`
+for a user-applied tag, `"auto_ai"` for one applied by the auto-labeling LLM.
+
+**Why**: `source` is the only thing that distinguishes an AI-applied tag from a manual one, so
+dropping it meant the file-detail page could not badge AI tags after a reload without a second
+request; and `uuid` matters now that `v374_add_tag_user_id` makes tag names unique only **per
+owner**, so a name is no longer a stable identifier for a tag row.
+
+**Scope — exactly one endpoint changed.** `GET /api/files` (the gallery/list endpoint) has **no
+`tags` field at all**, before or after; its response schema `MediaFile` never carried one, and none
+was added here (the list serializer would need a per-row tag query). `GET /api/tags`, `POST
+/api/tags`, `GET /api/tags/unused`, `POST /api/tags/files/{uuid}/tags`, and `DELETE
+/api/tags/files/{uuid}/tags/{tag_name}` are all unchanged — they already returned objects, and the
+delete route is still keyed by tag **name**.
+
+**Not changed**: routes (no route added, removed, or re-pathed), permissions, and tag visibility.
+The serializer returns exactly the tags attached to the file, as it did before; `endpoints/tags.py`
+already made every tag on an accessible file fully visible to that caller via the
+"attached to a file in the accessible-files subquery" arm of `_visible_to`, so the extra fields
+disclose nothing `GET /api/tags` did not already return to the same user. The OpenSearch search
+index still stores tags as a `keyword` array of names, so `tags` on a **search hit** is still
+`string[]`.
+
+**Frontend**: this deletes the shim that made the mismatch survivable — `TagsEditor` no longer
+coerces incoming strings into objects with fabricated `temp-<name>` uuids, and `TagsSection` is
+typed `MediaFileDetail` instead of `any`.
+
 ### Upgrade Notes
 
 - **ACTION REQUIRED — production deployments must set real secrets before upgrading**: hardening now fails closed (see Security), so a deployment still running a default or placeholder `JWT_SECRET_KEY` / `ENCRYPTION_KEY`, or with no `REDIS_PASSWORD`, will **refuse to start** instead of booting insecurely as it silently did before. Set real values (the installer generates them; `.env.example` documents each) before upgrading. To relax intentionally — a LAN-only or evaluation stack — set `ENVIRONMENT=development` explicitly. `./opentr.sh start dev` needs no change.
 - **ACTION REQUIRED — production admin login changes**: the `admin@example.com` / `password` super-admin is no longer seeded outside development. Existing accounts are untouched and you keep signing in as before. On a **new** production deployment, either set `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD`, or grep the backend startup log for `GENERATED password` to retrieve the one-time generated credential and change it after first login.
 - **Breaking — removed media endpoints**: external consumers of `GET /api/files/{uuid}/video`, `/simple-video`, `/content`, `/download`, and `/download-with-token` must migrate to `GET /api/files/{uuid}/stream-url` (playback) and `POST /api/files/{uuid}/prepare-download` (downloads).
 - **Breaking — bulk export endpoint**: `POST /api/files/bulk-export` (sync streamed ZIP) is replaced by `POST /api/files/bulk-export/prepare` + the SSE `GET /api/files/bulk-export-stream`.
+- **Breaking — file-detail `tags` payload (issue #326)**: **if your script reads `tags` from `GET /api/files/{uuid}` as strings, read `tag.name` instead** — e.g. `file.tags.map(t => t.name)` in JS, `[t["name"] for t in file["tags"]]` in Python. `"Important" in file["tags"]` and `", ".join(file["tags"])` are the two patterns that break. There is no migration and no server-side action: this is a response-shape change only, routes/permissions/tag-visibility are unchanged, and `GET /api/files` (list) still sends no `tags` field. Full before/after JSON in Breaking Changes above.
 - **Breaking — file fingerprints regenerated**: the server-side `imohash` fingerprint now uses the real `imohash` package (murmur3 over sampled windows + size) instead of the previous hand-rolled blake2b stand-in, so **every existing `media_file.imohash` value changes**. A one-time recompute runs automatically on first startup after upgrade (`asyncio` task gated by the `imohash_package_recompute_complete` system-settings flag, same pattern as the thumbnail/embedding migrations) and overwrites all rows via fast ranged reads — no manual action required. Cross-pipeline dedup (watch sources, re-upload detection) is unreliable for not-yet-recomputed rows until it finishes; an admin "Recompute File Fingerprints" button is available to re-trigger it.
 - **New required service**: deployments must run the new `celery-redaction` worker — redaction detection runs once per transcript regardless of user settings. It is included in the standard compose overlays; no action is needed when using `./opentr.sh`.
 - **Breaking (unreleased-master only) — v367 schema rewritten**: the cloud-seams migration was rewritten in place to be vendor-neutral (`external_id`/`external_org_id`; billing columns removed from core). No tagged release shipped the old shape; deployments tracking unreleased master (or commercial pins) are repaired automatically by the new `v371` migration, which renames the legacy columns idempotently on startup — no manual action required.

--- a/backend/app/api/endpoints/files/crud.py
+++ b/backend/app/api/endpoints/files/crud.py
@@ -24,6 +24,7 @@ from app.models.media import TranscriptSegment
 from app.models.user import User
 from app.schemas.media import MediaFileDetail
 from app.schemas.media import MediaFileUpdate
+from app.schemas.media import Tag as TagSchema
 from app.schemas.media import TranscriptSegment as TranscriptSegmentSchema
 from app.schemas.media import TranscriptSegmentUpdate
 from app.services.formatting_service import FormattingService
@@ -103,11 +104,34 @@ def get_media_file_by_id(
     return db_file  # type: ignore[no-any-return]
 
 
-def get_file_tags(db: Session, file_id: int) -> list[str]:
-    """Get tags for a media file."""
+def get_file_tags(db: Session, file_id: int) -> list[TagSchema]:
+    """Get the tags attached to a media file as full tag objects.
+
+    Returns the same ``{uuid, name, source}`` shape ``/api/tags`` serves, so the
+    file-detail payload and the tag endpoints agree on one definition of a tag.
+
+    Visibility is unchanged from the previous name-only serializer: this returns
+    every tag attached to ``file_id``, and the caller has already been gated on
+    the file itself. ``endpoints/tags.py:_visible_to`` makes a tag visible when it
+    is attached to a file in the caller's accessible-files subquery, so any tag
+    reachable here is one ``GET /api/tags`` would already return in full to the
+    same caller. Widening the fields therefore discloses nothing new.
+
+    Args:
+        db: Database session.
+        file_id: Internal media file ID.
+
+    Returns:
+        Tag schemas for the file, or an empty list if the query fails.
+    """
     try:
-        tags = db.query(Tag.name).join(FileTag).filter(FileTag.media_file_id == file_id).all()
-        return [tag[0] for tag in tags]
+        tags = (
+            db.query(Tag)
+            .join(FileTag, FileTag.tag_id == Tag.id)
+            .filter(FileTag.media_file_id == file_id)
+            .all()
+        )
+        return [TagSchema.model_validate(tag) for tag in tags]
     except Exception as tag_error:
         logger.exception(f"Error getting tags: {tag_error}")
         db.rollback()
@@ -524,7 +548,7 @@ def _redaction_pending(db: Session, cfg: Any, db_file: MediaFile) -> bool:
 
 def _build_media_file_response(
     db_file: MediaFile,
-    tags: list[str],
+    tags: list[TagSchema],
     collections: list[dict[Any, Any]],
     speakers: list[Speaker],
     analytics: Analytics | None,
@@ -541,7 +565,7 @@ def _build_media_file_response(
 
     Args:
         db_file: MediaFile object
-        tags: List of tag names
+        tags: Tag objects attached to the file ({uuid, name, source})
         collections: List of collection dictionaries
         speakers: List of speakers
         analytics: Analytics object or None

--- a/backend/app/schemas/CLAUDE.md
+++ b/backend/app/schemas/CLAUDE.md
@@ -62,6 +62,13 @@ Request/response shaping and validation only; logic lives in `app/services`. 25 
 - **Some schemas are dead documentation** — the endpoint hand-builds a dict instead: all of `search.py`
   bar `SetEmbeddingModelSchema` (`api/endpoints/search.py` declares no `response_model` at all),
   `CustomVocabularyResponse`, `UserASRSettingsResponse`, `ASRSettingsList`, `SpeakerClusterResponse`.
+- **There is exactly one tag shape (#326).** `media.py:Tag` (`uuid`/`name`/`source`) is what
+  `/api/tags` (as `TagWithCount`), `POST /api/tags`, `POST /api/tags/files/{uuid}/tags` **and**
+  `MediaFileDetail.tags` all serve. `MediaFileDetail.tags` was `list[str]` until #326 — don't
+  reintroduce a name-only projection; `source` is the AI-vs-manual signal and names are unique
+  only per owner since `v374_add_tag_user_id`. `MediaFile` (the **list** schema) has no `tags`
+  field at all, and adding one costs a per-row query. Note the OpenSearch index is a separate
+  contract: search hits still carry `tags` as a `keyword` array of names.
 - **`ConnectionTestResponse` is defined twice** (`llm_settings.py:152`, `watch_source.py:293`) and
   `__init__.py` exports only the LLM one — the package-level import silently yields the wrong shape.
 - `sharing.py:24 Share.shared_by` is typed `UserBrief` but `UUIDBaseSchema` maps `shared_by` to a bare

--- a/backend/app/schemas/media.py
+++ b/backend/app/schemas/media.py
@@ -502,7 +502,27 @@ class MediaFileDetail(MediaFile):
     # Pre-grouped view of transcript_segments (overlap groups kept together).
     # Mirrors the frontend grouping so it can render groups without recomputing.
     grouped_segments: list[GroupedTranscriptSegment] = []
-    tags: list[str] = []
+    # Full tag objects (uuid + name + source), the same shape `/api/tags` returns.
+    # Names alone lost `source`, so the detail page could not badge AI-applied tags
+    # without a second lookup. BREAKING wire change (issue #326) — see CHANGELOG.
+    tags: list["Tag"] = Field(
+        default=[],
+        description=(
+            "Tags attached to this file, as full tag objects — the same shape "
+            "`GET /api/tags` returns. BREAKING (issue #326): this was an array of tag "
+            "*name strings*; clients reading `tags` as strings must now read `tag.name`. "
+            "Note `GET /api/files` (list) carries no `tags` field at all."
+        ),
+        json_schema_extra={
+            "example": [
+                {
+                    "uuid": "019ec90a-3f41-7aaa-8000-0000000000a1",
+                    "name": "Important",
+                    "source": "manual",
+                }
+            ]
+        },
+    )
     collections: list["Collection"] = []
     analytics: Optional["Analytics"] = None
     speakers: list[Speaker] = []
@@ -546,9 +566,21 @@ class TagBase(BaseModel):
 
 
 class Tag(TagBase, UUIDBaseSchema):
-    """Tag with UUID as public identifier"""
+    """Tag with UUID as public identifier.
 
-    source: str | None = None
+    The single tag shape on the API: served by ``GET /api/tags`` (as
+    ``TagWithCount``), ``POST /api/tags``, ``POST /api/tags/files/{uuid}/tags``,
+    and — since issue #326 — ``MediaFileDetail.tags``. Tag names are unique only
+    per owner (``v374_add_tag_user_id``), so ``uuid`` is the stable identifier.
+    """
+
+    source: str | None = Field(
+        default=None,
+        description=(
+            "How the tag was applied: 'manual' for a user action, 'auto_ai' for the "
+            "auto-labeling LLM. Null on tags created before this field existed."
+        ),
+    )
 
 
 class TagWithCount(Tag):

--- a/backend/tests/api/test_files_crud.py
+++ b/backend/tests/api/test_files_crud.py
@@ -4,7 +4,7 @@ Covers ``files/crud.py`` plus the list/get/update/delete routes wired in
 ``files/__init__.py``:
 
 - ``GET  /api/files``                     (list, pagination, filters)
-- ``GET  /api/files/{uuid}``              (detail)
+- ``GET  /api/files/{uuid}``              (detail, incl. the #326 tag wire contract)
 - ``GET  /api/files/{uuid}/info``         (lightweight metadata)
 - ``PUT  /api/files/{uuid}``              (metadata update)
 - ``DELETE /api/files/{uuid}``            (delete via cancel_upload fall-through)
@@ -24,7 +24,9 @@ import uuid
 import pytest
 from fastapi import status
 
+from app.models.media import FileTag
 from app.models.media import MediaFile
+from app.models.media import Tag
 
 
 def _make_file(db_session, owner, *, file_status: str = "completed", **overrides) -> MediaFile:
@@ -226,6 +228,77 @@ def test_get_file_segment_limit_negative_422(client, user_token_headers, normal_
         params={"segment_limit": -1},
     )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+# ---------------------------------------------------------------------------
+# GET /api/files/{uuid}  —  tag wire contract (issue #326)
+#
+# The detail payload used to serialize tags as bare name strings while every
+# /api/tags surface returned objects. These pin the single agreed shape so the
+# contract can't silently regress to `list[str]`.
+# ---------------------------------------------------------------------------
+
+
+def test_file_detail_tags_are_objects_not_names(
+    client, user_token_headers, normal_user, db_session
+):
+    """`tags` carries `{uuid, name, source}` objects, never bare name strings."""
+    media_file = _make_file(db_session, normal_user)
+    tag = Tag(name=f"contract-{uuid.uuid4().hex[:8]}", user_id=normal_user.id, source="auto_ai")
+    db_session.add(tag)
+    db_session.flush()
+    db_session.add(FileTag(media_file_id=media_file.id, tag_id=tag.id, source="auto_ai"))
+    db_session.commit()
+
+    response = client.get(f"/api/files/{media_file.uuid}", headers=user_token_headers)
+    assert response.status_code == status.HTTP_200_OK
+
+    tags = response.json()["tags"]
+    assert len(tags) == 1
+    payload = tags[0]
+    assert isinstance(payload, dict), "tags must be objects, not strings (#326)"
+    assert payload["uuid"] == str(tag.uuid)
+    assert payload["name"] == tag.name
+    assert payload["source"] == "auto_ai"
+    # The hybrid-ID rule: the internal integer id never reaches the wire.
+    assert "id" not in payload
+
+
+def test_file_detail_tags_match_the_tags_endpoint_shape(
+    client, user_token_headers, normal_user, db_session
+):
+    """The detail payload and ``GET /api/tags`` agree field-for-field."""
+    media_file = _make_file(db_session, normal_user)
+    tag = Tag(name=f"contract-{uuid.uuid4().hex[:8]}", user_id=normal_user.id, source="manual")
+    db_session.add(tag)
+    db_session.flush()
+    db_session.add(FileTag(media_file_id=media_file.id, tag_id=tag.id, source="manual"))
+    db_session.commit()
+
+    from_detail = client.get(f"/api/files/{media_file.uuid}", headers=user_token_headers).json()[
+        "tags"
+    ][0]
+    listing = client.get("/api/tags", headers=user_token_headers).json()
+    from_tags = next(t for t in listing if t["uuid"] == str(tag.uuid))
+
+    # /api/tags adds usage_count (TagWithCount); everything else is identical.
+    for field in ("uuid", "name", "source"):
+        assert from_detail[field] == from_tags[field]
+    assert set(from_detail) == {"uuid", "name", "source"}
+
+
+def test_file_list_still_has_no_tags_field(client, user_token_headers, normal_user, db_session):
+    """The gallery list endpoint carries no ``tags`` field — deliberately (#326).
+
+    Adding one would need a per-row tag query. Pinned so the two endpoints
+    aren't confused for each other when reading the changelog.
+    """
+    _make_file(db_session, normal_user)
+    response = client.get("/api/files", headers=user_token_headers)
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()["items"]
+    assert items, "expected at least the file just created"
+    assert all("tags" not in item for item in items)
 
 
 # ---------------------------------------------------------------------------

--- a/docs-site/docs/operations/upgrading.md
+++ b/docs-site/docs/operations/upgrading.md
@@ -181,6 +181,46 @@ The migration runs through the Admin UI:
 Embedding migration can take significant time depending on the number of speakers and media files. Plan accordingly and run during a maintenance window.
 :::
 
+### Breaking API Changes
+
+These only affect you if you call the OpenTranscribe REST API directly — from a script,
+an integration, or another service. The web UI ships with each release and is always in sync.
+
+The authoritative, always-current schema is the deployment's own OpenAPI document at
+`/api/openapi.json` (browsable at `/api/docs`). Check it against your client after any upgrade.
+
+#### `GET /api/files/{uuid}` — `tags` is now an array of objects
+
+`tags` on the **file-detail** response used to be an array of tag name strings. It is now an array
+of tag objects, matching what `GET /api/tags` has always returned:
+
+```json
+// Before
+"tags": ["Important", "Meeting"]
+
+// After
+"tags": [
+  { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a1", "name": "Important", "source": "manual" },
+  { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a2", "name": "Meeting",   "source": "auto_ai" }
+]
+```
+
+**If you were reading `tags` as strings, read `tag.name` instead** — `file.tags.map(t => t.name)`
+in JavaScript, `[t["name"] for t in file["tags"]]` in Python. The two patterns that break are
+`", ".join(file["tags"])` and `"Important" in file["tags"]`.
+
+`uuid` and `name` are always present. `source` is nullable: `"manual"` for a tag a user applied,
+`"auto_ai"` for one applied by auto-labeling, `null` for tags predating the field.
+
+What did **not** change:
+
+- `GET /api/files` (the list endpoint) has **no** `tags` field, before or after.
+- `GET /api/tags`, `POST /api/tags`, `GET /api/tags/unused`,
+  `POST /api/tags/files/{uuid}/tags` and `DELETE /api/tags/files/{uuid}/tags/{tag_name}` are
+  unchanged — they already returned objects, and the delete route is still keyed by tag **name**.
+- Search results still carry `tags` as plain strings (the search index stores tag names).
+- No routes, permissions, or tag-visibility rules changed. No database migration is involved.
+
 ### Other Major Upgrade Considerations
 
 - **OpenSearch version changes**: May require reindexing all data

--- a/frontend/src/components/TagsEditor.svelte
+++ b/frontend/src/components/TagsEditor.svelte
@@ -25,27 +25,6 @@
     .filter(tag => tag.source === 'auto_ai')
     .map(tag => tag.name);
 
-  // Ensure tags are always in the correct format
-  $: {
-    if (Array.isArray(tags)) {
-      // Handle case where backend returns tag names as strings instead of objects
-      tags = tags.map((tag: Tag | string): Tag => {
-        if (typeof tag === 'string') {
-          // Convert string tag to object format with a temporary UUID
-          return { uuid: `temp-${tag}`, name: tag };
-        } else if (tag && typeof tag === 'object') {
-          // Ensure tag object has required properties - preserve uuid and source
-          return {
-            uuid: tag.uuid !== undefined ? tag.uuid : `temp-${tag.name}`,
-            name: tag.name || '',
-            source: tag.source || undefined
-          };
-        }
-        return tag;
-      });
-    }
-  }
-
   let allTags: Tag[] = [];
   let newTagInput = '';
   let loading = false;

--- a/frontend/src/components/TagsSection.svelte
+++ b/frontend/src/components/TagsSection.svelte
@@ -3,9 +3,10 @@
   import { slide } from 'svelte/transition';
   import { t } from '$stores/locale';
   import type { Tag } from '$lib/types/tag';
+  import type { MediaFileDetail } from '$lib/types/media';
   import TagsEditor from './TagsEditor.svelte';
 
-  export let file: any = null;
+  export let file: MediaFileDetail | null = null;
   export let isTagsExpanded: boolean = false;
   export let aiTagSuggestions: Array<{name: string, confidence: number, rationale?: string}> = [];
 
@@ -16,7 +17,7 @@
   }
 
   // The file-detail page owns `file`; forward the editor's update instead of
-  // mutating the prop, so the page can update its state and `reactiveFile`.
+  // mutating the prop, so the page's own `file` assignment drives the re-render.
   function forwardTagsUpdated(event: CustomEvent<{ tags: Tag[] }>) {
     dispatch('tagsUpdated', event.detail);
   }
@@ -31,8 +32,8 @@
     <h4 class="section-heading">{$t('tags.title')}</h4>
     <div class="tags-preview">
       {#if file?.tags && file.tags.length > 0}
-        {#each file.tags.slice(0, 3) as tag, i}
-          <span class="tag-chip">{tag && tag.name ? tag.name : tag}</span>
+        {#each file.tags.slice(0, 3) as tag (tag.uuid)}
+          <span class="tag-chip">{tag.name}</span>
         {/each}
         {#if file.tags.length > 3}
           <span class="tag-chip more">{$t('tags.moreCount', { count: file.tags.length - 3 })}</span>

--- a/frontend/src/components/TagsSection.test.ts
+++ b/frontend/src/components/TagsSection.test.ts
@@ -3,13 +3,17 @@
  *
  * `TagsSection` used to carry a handler commented "Re-emit the event to parent
  * component" that never called `dispatch` — it mutated the `file` prop and
- * stopped. The file-detail page listens for `tagsUpdated` to update its own
- * state and `reactiveFile`, so tag edits never propagated. These tests pin the
- * forwarding: the editor's `tagsUpdated` must reach the page unchanged, and the
- * section must not mutate the page-owned `file` object.
+ * stopped. The file-detail page listens for `tagsUpdated` to assign `file.tags`,
+ * which is what re-renders the section, so tag edits never propagated. These
+ * tests pin the forwarding: the editor's `tagsUpdated` must reach the page
+ * unchanged, and the section must not mutate the page-owned `file` object.
+ *
+ * The tag payload is `Tag[]` on the wire now (#326) — `MediaFileDetail.tags`
+ * carries objects, not bare names — so the fixture uses tag objects.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import type { MediaFileDetail } from '$lib/types/media';
 import TagsSection from './TagsSection.svelte';
 
 const axiosMock = vi.hoisted(() => ({
@@ -20,9 +24,12 @@ const axiosMock = vi.hoisted(() => ({
 
 vi.mock('$lib/axios', () => ({ default: axiosMock }));
 
-function fileWithTags() {
+function fileWithTags(): MediaFileDetail {
   return {
     uuid: 'file-uuid-1',
+    filename: 'alpha.mp4',
+    status: 'completed',
+    upload_time: '2026-01-01T00:00:00Z',
     tags: [{ uuid: 'tag-uuid-1', name: 'alpha' }],
   };
 }

--- a/frontend/src/components/fileDetail/CLAUDE.md
+++ b/frontend/src/components/fileDetail/CLAUDE.md
@@ -39,6 +39,13 @@ Presentational children extracted from the file-detail route `src/routes/files/[
 
 ## Gotchas
 
+- **Prop-drilling is the settled pattern — don't add a store for page state (#338).** The page
+  used to also write a `reactiveFile` writable on every mutation; nothing ever subscribed to it,
+  so all 13 `.set()` calls were inert while reading as if they refreshed the UI. It has been
+  deleted. The update path is the page's own `file` assignment (`file = {...file}`, or a member
+  assignment like `file.tags = …`) invalidating the variable, which re-renders the children
+  through their props. `notificationHandler.setFile` exists for exactly that reason and must keep
+  doing the real assignment.
 - The file-detail E2E (`backend/tests/e2e/test_file_detail_transcript.py`) guards the page's
   transcript/export/speaker-editor surfaces — keep those working when adding children here.
 - This is a coordinator route: it legitimately keeps a large `<script>` (data loading, WebSocket

--- a/frontend/src/lib/fileDetail/notificationHandler.ts
+++ b/frontend/src/lib/fileDetail/notificationHandler.ts
@@ -15,8 +15,8 @@ export type TranslateFn = (key: string, options?: Record<string, unknown>) => st
  * switch lived inline in `onMount`.
  *
  * CRITICAL: `setFile` must perform the real `file = ...` assignment in the page
- * (not a no-op clone) so reactivity fires; `setReactiveFile` must call
- * `reactiveFile.set(...)` exactly as the inline code did.
+ * (not a no-op clone) so reactivity fires — that assignment is the only thing
+ * that propagates an update to the child components.
  */
 export interface FileNotificationContext {
   // --- current-file identity & state reads ---
@@ -28,7 +28,6 @@ export interface FileNotificationContext {
 
   // --- file object mutation (must do the real `file = ...` assignment) ---
   setFile: (f: any) => void;
-  setReactiveFile: (f: any) => void;
 
   // --- flag setters ---
   setCurrentProcessingStep: (s: string) => void;
@@ -88,7 +87,6 @@ export function handleFileNotification(
             t('fileDetail.processingDefault')
         );
         ctx.setFile({ ...file }); // Trigger reactivity
-        ctx.setReactiveFile(ctx.getFile());
       }
     } else if (
       notificationStatus === 'completed' ||
@@ -116,7 +114,6 @@ export function handleFileNotification(
         }
 
         ctx.setFile({ ...file }); // Trigger reactivity
-        ctx.setReactiveFile(ctx.getFile());
       }
 
       // Clear processing step and refresh transcript data after completion
@@ -200,7 +197,6 @@ export function handleFileNotification(
 
           // Force reactivity update by creating new object reference
           ctx.setFile({ ...file });
-          ctx.setReactiveFile(ctx.getFile());
         }
       } else if (status === 'failed' || status === 'error') {
         // Summary failed - stop spinners and show error

--- a/frontend/src/lib/types/media.ts
+++ b/frontend/src/lib/types/media.ts
@@ -1,6 +1,7 @@
 /**
  * Shared media file types used across gallery components.
  */
+import type { Tag } from '$lib/types/tag';
 
 /**
  * Every value of the backend `FileStatus` enum (`backend/app/core/enums.py`).
@@ -29,7 +30,6 @@ export interface MediaFile {
   duration?: number;
   file_size?: number;
   content_type?: string;
-  tags?: string[];
   summary?: string;
   file_hash?: string;
   thumbnail_url?: string;
@@ -94,6 +94,11 @@ export interface MediaFile {
  * can't silently start depending on a field the list endpoint never sends.
  */
 export interface MediaFileDetail extends MediaFile {
+  /**
+   * Full tag objects, the same shape `/api/tags` returns (#326). `GET /files`
+   * sends no tags, so this deliberately lives here and not on `MediaFile`.
+   */
+  tags?: Tag[];
   transcript_segments?: unknown[];
   grouped_segments?: GroupedTranscriptSegment[];
   total_segments?: number;

--- a/frontend/src/lib/types/tag.ts
+++ b/frontend/src/lib/types/tag.ts
@@ -1,9 +1,10 @@
 /**
  * Canonical tag shape, mirroring `backend/app/schemas/media.py:Tag`.
  *
- * Import via `$lib/types/tag`. Note `MediaFile.tags` is a `string[]` (the
- * backend flattens tags to names on the file payload) — this object shape is
- * what the `/tags` endpoints and the tag editor/filter surfaces return.
+ * Import via `$lib/types/tag`. This is the **only** tag shape on the API:
+ * `/tags`, `POST /tags/files/{uuid}/tags` and `MediaFileDetail.tags` all serve
+ * it (#326). The gallery list endpoint `GET /files` sends no tags at all, which
+ * is why `MediaFile` has no `tags` field — only `MediaFileDetail` does.
  */
 export interface Tag {
   uuid: string;

--- a/frontend/src/routes/files/[id]/+page.svelte
+++ b/frontend/src/routes/files/[id]/+page.svelte
@@ -3,8 +3,9 @@
   import type { Segment, Speaker } from '$lib/types/speaker';
   import type { Collection } from '$lib/types/collection';
   import type { Comment } from '$lib/types/comment';
+  import type { Tag } from '$lib/types/tag';
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
-  import { writable, get } from 'svelte/store';
+  import { get } from 'svelte/store';
   import axiosInstance from '$lib/axios';
   import { formatDuration } from '$lib/utils/formatting';
   import { loadTxtPrefs, saveTxtPrefs } from '$lib/export/txtExportPrefs';
@@ -188,9 +189,6 @@
   let bulkSaveInProgress = false;
   let bulkSaveDecisions = new Map();
 
-  // Reactive store for file updates
-  const reactiveFile = writable(null);
-
 
   /**
    * Fetches file details from the API
@@ -239,7 +237,6 @@
 
         // Update file object
         file = { ...file };
-        reactiveFile.set(file);
 
         // Process the new transcript data
         processTranscriptData();
@@ -283,7 +280,6 @@
             redactionActive = true;
           }
         }
-        reactiveFile.set(file);
 
         // Track pagination metadata
         totalSegments = response.data.total_segments || 0;
@@ -357,7 +353,6 @@
             redactionActive = true;
           }
         }
-        reactiveFile.set(file);
         processTranscriptData();
       }
     } catch (error) {
@@ -417,7 +412,6 @@
           ...response.data.transcript_segments
         ];
         file = { ...file }; // Trigger reactivity
-        reactiveFile.set(file);
 
         // Update pagination state
         totalSegments = response.data.total_segments || totalSegments;
@@ -469,7 +463,6 @@
           ...response.data.transcript_segments
         ];
         file = { ...file };
-        reactiveFile.set(file);
         totalSegments = response.data.total_segments || totalSegments;
 
         if (file?.uuid && file.transcript_segments && speakerList) {
@@ -816,7 +809,6 @@
         // Update file data (includes analytics and transcript segments)
         file = response.data;
         collections = response.data.collections || [];
-        reactiveFile.set(file);
 
         // Process transcript data from the refreshed response
         processTranscriptData();
@@ -858,7 +850,6 @@
       if (response.data && typeof response.data === 'object') {
         // Update analytics from refreshed response
         file.analytics = response.data.analytics;
-        reactiveFile.set(file);
       }
     } catch (error) {
       console.error('Error refreshing analytics after speaker change:', error);
@@ -1008,7 +999,6 @@
       // Update file data
       file.transcript_segments = transcriptData.map(segment => ({ ...segment }));
       file = { ...file }; // Trigger reactivity
-      reactiveFile.set(file);
     }
 
     // Update subtitles in the video player with new speaker names
@@ -1119,7 +1109,6 @@
               ...file,
               transcript_segments: updatedSegments
             };
-            reactiveFile.set(file);
 
 
             // Clear cached processed videos so downloads will use updated transcript
@@ -1532,7 +1521,6 @@
 
       file.transcript_segments = [...transcriptData];
       file = { ...file };
-      reactiveFile.set(file);
     }
 
     // Update subtitles and clear cache (async, don't block)
@@ -1574,10 +1562,11 @@
     }
   }
 
-  function handleTagsUpdated(event: any) {
+  // `file.tags` is the update path: assigning a member of the reactive `file`
+  // invalidates it, which re-renders TagsSection with the new tag objects.
+  function handleTagsUpdated(event: CustomEvent<{ tags: Tag[] }>) {
     if (file) {
       file.tags = event.detail.tags;
-      reactiveFile.set(file);
     }
   }
 
@@ -1591,7 +1580,6 @@
     if (file) {
       file.collections = updatedCollections;
       file = { ...file }; // Trigger reactivity
-      reactiveFile.set(file);
     }
   }
 
@@ -1884,7 +1872,6 @@
               getRedactionStatus: () => redactionStatus,
               getVideoPlayerComponent: () => videoPlayerComponent,
               setFile: (f) => (file = f),
-              setReactiveFile: (f) => reactiveFile.set(f),
               setCurrentProcessingStep: (s) => (currentProcessingStep = s),
               setSummaryGenerating: (v) => (summaryGenerating = v),
               setGeneratingSummary: (v) => (generatingSummary = v),


### PR DESCRIPTION
Closes the tag-contract half of #326 and all of #338. Refs #284.

> [!WARNING]
> **BREAKING API CHANGE.** `GET /api/files/{uuid}` returns `tags` as an array of
> objects instead of an array of strings. If your script reads `tags` as strings,
> read `tag.name` instead. Nothing else on the API changed.

---

## Task 1 — #326: one definition of a tag on the API

### The disagreement

| Endpoint | `tags` returned (before) |
|---|---|
| `GET /api/files` (list) | **no `tags` field at all** |
| `GET /api/files/{uuid}` (detail) | **`string[]`** — bare names |
| `GET /api/tags`, `POST /api/tags`, `POST /api/tags/files/{uuid}/tags` | **`Tag` objects** `{uuid, name, source[, usage_count]}` |

`MediaFileDetail.tags` was `list[str]` because the serializer selected `Tag.name` and
nothing else. The frontend bridged the gap by fabricating `temp-<name>` uuids in
`TagsEditor`, which is why `TagsSection` still carried `file: any` — there was no single
right shape to cast to.

### The change

`MediaFileDetail.tags` is now `list[Tag]` — the same object the tag endpoints already
serve.

```jsonc
// before
"tags": ["Important", "Meeting"]

// after
"tags": [
  { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a1", "name": "Important", "source": "manual" },
  { "uuid": "019ec90a-3f41-7aaa-8000-0000000000a2", "name": "Meeting",   "source": "auto_ai" }
]
```

`uuid` and `name` are always present; `source` is nullable (`"manual"` / `"auto_ai"` /
`null` for tags predating the field).

**Why it matters, not just tidiness.** `source` is the only signal distinguishing an
AI-applied tag from a manual one — dropping it meant the file-detail page could not badge
AI tags after a reload without a second request. And `uuid` matters because
`v374_add_tag_user_id` made tag names unique only *per owner*, so a name is no longer a
stable identifier for a tag row.

### Scope — exactly one endpoint changed

- `GET /api/files` (list) has **no** `tags` field, before or after. None was added: the
  list serializer would need a per-row tag query, i.e. an N+1. Reported, not guessed —
  and pinned by a test so the two endpoints don't get confused later.
- The `/api/tags` routes are untouched. `DELETE /tags/files/{uuid}/tags/{tag_name}` is
  still keyed by **name** (changing it would move the route digest).
- The OpenSearch index still stores tag names, so `tags` on a **search hit** is still
  `string[]`. `SearchResultCard` is correct as-is.

### Tag visibility is unchanged (`v374_add_tag_user_id`)

`get_file_tags` returns exactly the tags attached to the file, as before — the query
changed from `db.query(Tag.name)` to `db.query(Tag)`, same rows. The caller is already
gated on the file itself, and `endpoints/tags.py:_visible_to` already makes a tag visible
when it is *attached to a file in the accessible-files subquery*, so every tag reachable
here is one `GET /api/tags` would already return **in full** to the same caller. The extra
fields disclose nothing new. (An admin viewing another user's file is the one case where
the file may sit outside their own accessible-files subquery — but admins already received
these tag names and have full read access to the file by design; that gate is untouched.)

### Frontend — the shim is deleted, not adapted

| Consumer of `file.tags` | Change |
|---|---|
| `components/TagsEditor.svelte` (coercion block) | **deleted** — no more `temp-<name>` uuid fabrication |
| `components/TagsSection.svelte` (preview chips + editor prop) | `{tag && tag.name ? tag.name : tag}` → `{tag.name}`, keyed each; `file: any` → `file: MediaFileDetail \| null` |
| `routes/files/[id]/+page.svelte:handleTagsUpdated` | typed `CustomEvent<{ tags: Tag[] }>` |
| `lib/types/media.ts` | `tags?: string[]` **moved off `MediaFile`** (the list shape never carried it) onto `MediaFileDetail` as `Tag[]` |
| `lib/types/tag.ts` | doc corrected — this is now the only tag shape on the API |
| `components/TagsSection.test.ts` | fixture typed `MediaFileDetail` |
| `components/search/SearchResultCard.svelte` (`hit.tags`) | **unchanged** — OpenSearch hit, still `string[]` |
| `lib/export/*` (TXT/SRT/VTT/CSV/JSON) | **unchanged** — zero occurrences of "tag" in the export module; exports never read tags |
| gallery (`routes/+page.svelte`, `components/gallery/*`) | **unchanged** — the list payload has no tags; the only `tags` there is the filter event's `string[]` of tag *names* sent as `?tag=` query params |

No `tags.join(', ')` or `in file.tags` anywhere in `frontend/src` — swept before changing
the shape.

---

## Task 2 — #338: delete the write-only `reactiveFile` store

`routes/files/[id]/+page.svelte` declared `const reactiveFile = writable(null)` —
page-local, never exported — and wrote it **13 times**. Nothing subscribed: no
`$reactiveFile`, no `.subscribe()`, no importer. A store with no subscribers does nothing
on `.set()`, so all 13 calls were inert while reading as if they refreshed the UI. That
cost real review time on #335.

The `notificationHandler.ts:19` comment naming `reactiveFile.set(...)` as the integration
point was a refactor-fidelity note (the switch was lifted out of `onMount` verbatim), not
evidence of a consumer.

**Deleted:** the declaration, the 13 `.set()` calls, the now-unused `writable` import, the
`setReactiveFile` member of `FileNotificationContext`, its 3 call sites, and the stale doc
comment.

**`setFile` is untouched.** It performs the real `file = ...` assignment, which is what
actually propagates an update to the children — browser-verified below.

`components/fileDetail/CLAUDE.md` now states the prop-drilling pattern explicitly, so the
convention and the code no longer disagree about which pattern the page uses.

---

## Documentation

- **`CHANGELOG.md`** — a new `### Breaking Changes` section under `[Unreleased]` with the
  exact before/after JSON, the field semantics, an explicit statement of what did *not*
  change, plus a one-sentence consumer migration line under `### Upgrade Notes`.
- **`docs-site/docs/operations/upgrading.md`** — a new "Breaking API Changes" section under
  Major Version Upgrades with the same before/after and the `tag.name` fix.
  **Note:** docs-site has **no API-reference pages** — `sidebars.ts` still carries the
  `apiSidebar` (`api/files`, `api/tags`, …) commented out with "until pages are created".
  Rather than invent an API-reference tree in this PR, the migration note went on the
  existing upgrade page, which is where an operator looks for breakage. Flagging that
  choice explicitly.
- **The OpenAPI document itself** — `MediaFileDetail.tags` now carries a description that
  names the breaking change and the `tag.name` fix, plus a worked `example`; `Tag.source`
  documents `manual` / `auto_ai` / null. An integrator reading `/api/docs` sees it first.
- `backend/app/schemas/CLAUDE.md` and `frontend/src/components/fileDetail/CLAUDE.md`
  updated so the next person doesn't reintroduce either defect.

---

## Verification

**Backend** — `pytest backend/tests/unit backend/tests/api -q` green (exit 0) against a
throwaway Postgres matching CI's shape (removed afterwards); `import app.main` OK.
Three new contract tests in `tests/api/test_files_crud.py`:

- tags are objects with `{uuid, name, source}` and no internal `id`
- the detail payload matches `GET /api/tags` field-for-field
- the list endpoint still has **no** `tags` field

**Route digest unchanged — this is a payload change, not a routing change.** 409 routes
(`app.routes` minus the WebSocket route), byte-identical before and after:
`sha256("\n".join(sorted("<METHODS> <path>")))[:16]` = `c6f90411568e4bd1`, unchanged;
410 total routes = `45ac77dbef4179a8`, unchanged. (The repo ships no route-digest tool, so
this is a locally-defined but reproducible formula computed on the same tree before and
after the change; the **409** count matches the expected figure exactly.)

**Frontend** — `npm run lint` 0 errors, `npx svelte-check --threshold error` **0 errors /
0 warnings**, `npm run build` green, `npm run test` **153 passed (29 files)**,
`npm run check:i18n` green (4016 keys × 8 locales).
`pre-commit run --all-files` green (all 22 hooks).

**Browser, light AND dark**, against an isolated stack (fresh Vite + uvicorn from this
branch → throwaway Postgres/Redis; **no dev data touched**):

| Check | Light | Dark |
|---|---|---|
| Header preview chips render names | ✅ `["Quarterly Review","Budget"]` | ✅ same |
| Editor chips render names | ✅ | ✅ |
| `source: auto_ai` badge (★ + `.ai-tag`) shows **on page load** | ✅ | ✅ |
| No `[object Object]` anywhere in `document.body.innerText` | ✅ | ✅ |
| Add a tag → editor **and** header preview update | — | ✅ (this is the #338 proof: propagation survives the store removal) |
| Remove that tag → both revert | — | ✅ |

The AI badge surviving a page load is the thing the old `string[]` payload made impossible.

Non-2xx on the file-detail page were `/suggestions` 404 (the known pre-existing one),
`/video` 404, and `/waveform` 500. The first two reproduce identically on the untouched
dev stack; the waveform 500 is my isolated harness having no MinIO object for the seeded
row. **Zero tag-related errors.**

**Dev data**: none created or deleted. The tag add/remove was performed against the
throwaway database, not the dev stack; the dev stack still reports its original 4 seeded
system tags at `usage_count: 0` and 17 files. Both throwaway containers were removed.
