### PR TITLE
fix(chat): initialize LLM status after client-side login, not just page load

### DIFF
--- a/frontend/src/components/chat/ChatComposer.svelte
+++ b/frontend/src/components/chat/ChatComposer.svelte
@@ -220,6 +220,15 @@
     color: var(--background-color);
   }
 
+  /* The icon's own width/height HTML attributes are presentation attributes, not CSS - a
+     flex item can compute their used width as 0 before intrinsic SVG sizing resolves.
+     Pin size via CSS so the icon is never invisible regardless of browser/layout timing. */
+  .send-button svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
+
   .composer-footer {
     display: flex;
     justify-content: space-between;

--- a/frontend/src/components/chat/ChatSidebar.svelte
+++ b/frontend/src/components/chat/ChatSidebar.svelte
@@ -318,6 +318,9 @@
     margin-left: -0.4rem;
     border: none;
     border-radius: 5px;
+    /* form-elements.css's bare `button` rule sets a drop-shadow that isn't
+       cleared by border/background alone (see ConversationListItem.svelte). */
+    box-shadow: none;
     background: none;
     color: var(--text-secondary);
     font-size: 0.74rem;

--- a/frontend/src/components/chat/ConversationListItem.svelte
+++ b/frontend/src/components/chat/ConversationListItem.svelte
@@ -213,6 +213,11 @@
     text-align: left;
     background: none;
     border: none;
+    /* form-elements.css's bare `button` rule also sets border-radius and a
+       drop-shadow; unset border/background alone still leaves those two
+       painting a rounded card behind the title in light mode. */
+    border-radius: 0;
+    box-shadow: none;
     padding: 0.5rem 0.35rem;
     color: var(--text-color);
     font-size: 0.85rem;

--- a/frontend/src/components/mfa/MfaEnrollment.svelte
+++ b/frontend/src/components/mfa/MfaEnrollment.svelte
@@ -17,6 +17,7 @@
   import Spinner from '$components/ui/Spinner.svelte';
   import { t } from '$stores/locale';
   import { toastStore } from '$stores/toast';
+  import { copyToClipboard } from '$lib/utils/clipboard';
   import {
     setupMfaEnrollment,
     verifyMfaEnrollment,
@@ -114,8 +115,7 @@
   }
 
   function copyCodes() {
-    navigator.clipboard.writeText(backupCodes.join('\n'));
-    toastStore.success($t('auth.mfaEnroll.codesCopied'));
+    copyToClipboard(backupCodes.join('\n'), () => toastStore.success($t('auth.mfaEnroll.codesCopied')));
   }
 
   function downloadCodes() {

--- a/frontend/src/components/settings/SAMLSettings.svelte
+++ b/frontend/src/components/settings/SAMLSettings.svelte
@@ -3,6 +3,7 @@
   import { t } from '$stores/locale';
   import type { SAMLConfig } from '$lib/api/authConfig';
   import { toastStore } from '$stores/toast';
+  import { copyToClipboard } from '$lib/utils/clipboard';
 
   export let config: Partial<SAMLConfig> = {};
 
@@ -92,12 +93,11 @@
 
   async function copyMetadataUrl() {
     if (!metadataUrl) return;
-    try {
-      await navigator.clipboard.writeText(metadataUrl);
-      toastStore.success($t('settings.saml.metadataUrlCopied'));
-    } catch {
-      toastStore.error($t('settings.saml.metadataUrlCopyFailed'));
-    }
+    await copyToClipboard(
+      metadataUrl,
+      () => toastStore.success($t('settings.saml.metadataUrlCopied')),
+      () => toastStore.error($t('settings.saml.metadataUrlCopyFailed'))
+    );
   }
 </script>
 

--- a/frontend/src/components/settings/SecuritySettings.svelte
+++ b/frontend/src/components/settings/SecuritySettings.svelte
@@ -5,6 +5,7 @@
   import { toastStore } from '$stores/toast';
   import { t } from '$stores/locale';
   import { getErrorMessage } from '$lib/utils/apiError';
+  import { copyToClipboard } from '$lib/utils/clipboard';
   import { getAuthMethods, user as userStore } from '$stores/auth';
   import CertificateInfo from './CertificateInfo.svelte';
 
@@ -153,8 +154,7 @@
 
   function copyBackupCodes() {
     const codesText = backupCodes.join('\n');
-    navigator.clipboard.writeText(codesText);
-    toastStore.success($t('settings.security.codesCopied'));
+    copyToClipboard(codesText, () => toastStore.success($t('settings.security.codesCopied')));
   }
 
   function downloadBackupCodes() {

--- a/frontend/src/lib/services/uploadService.ts
+++ b/frontend/src/lib/services/uploadService.ts
@@ -203,7 +203,7 @@ class UploadService {
 
     // Generate a shared batch UUID when uploading 2+ files together
     // so they are linked as a batch for downstream topic grouping
-    const batchId = files.length >= 2 ? crypto.randomUUID() : undefined;
+    const batchId = files.length >= 2 ? generateId() : undefined;
 
     files.forEach((file) => {
       const id = this.addUpload(

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -59,6 +59,18 @@
   // session to the login route, which renders the remedy. See $stores/auth.
   $: lifecycleHold = $accountLifecycle !== null;
 
+  // The onMount auth guard below only reaches its `if (isAuth) { llmStatusStore.initialize() }`
+  // branch on a page LOAD/refresh where a session cookie already exists. A client-side login
+  // (no full page reload — the normal path through /login) never re-runs onMount, so nothing
+  // ever calls it: Chat and every other isLLMAvailable-gated surface stays stuck on
+  // "unavailable" until the user manually refreshes the tab. Watching the reactive store instead
+  // covers every sign-in path (password, OIDC, PKI, MFA verify, ...) with one definition;
+  // initialize() itself deduplicates concurrent/repeat calls, so this is safe to also fire
+  // alongside the onMount call on a fresh page load.
+  $: if ($isAuthenticated) {
+    llmStatusStore.initialize();
+  }
+
   // Classification banner state
   let bannerEnabled = false;
   let bannerClassification: 'UNCLASSIFIED' | 'CUI' | 'FOUO' | 'CONFIDENTIAL' | 'SECRET' | 'TOP SECRET' | 'TOP SECRET//SCI' = 'UNCLASSIFIED';

--- a/frontend/src/routes/chat/[[conversationId]]/+page.svelte
+++ b/frontend/src/routes/chat/[[conversationId]]/+page.svelte
@@ -552,6 +552,11 @@
     height: 32px;
     border: none;
     border-radius: 6px;
+    /* form-elements.css's bare `button` rule sets a drop-shadow that survives
+       unless cleared here — without this, light mode shows an empty shadowed
+       box instead of a plain icon button (the shadow all but disappears
+       against the dark-mode background, which is why it only showed there). */
+    box-shadow: none;
     background: none;
     color: var(--text-secondary);
     cursor: pointer;
@@ -561,6 +566,22 @@
   .gear:hover {
     background-color: var(--button-hover);
     color: var(--text-color);
+  }
+
+  /* The icon's width/height HTML attributes are presentation attributes, not
+     CSS - a flex item can compute their used width as 0 before intrinsic SVG
+     sizing resolves. Pin size via CSS so the icon is never invisible
+     regardless of browser/layout timing (same fix as ChatComposer's send icon). */
+  .hamburger svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
+
+  .gear svg {
+    width: 17px;
+    height: 17px;
+    flex-shrink: 0;
   }
 
   .hamburger {

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -12,6 +12,7 @@
 
 import { get, writable } from 'svelte/store';
 import { goto } from '$app/navigation';
+import { generateId } from '$lib/utils/ids';
 
 import * as chatApi from '$lib/api/chatApi';
 import { canTransition } from '$lib/utils/chatStateMachine';
@@ -266,7 +267,7 @@ function createChatStore() {
   }
 
   function appendOptimisticTurn(text: string): string {
-    const assistantLocalId = `local-assistant-${crypto.randomUUID()}`;
+    const assistantLocalId = generateId('local-assistant');
     update((s) => ({
       ...s,
       error: null,
@@ -274,7 +275,7 @@ function createChatStore() {
       messages: [
         ...s.messages,
         {
-          uuid: `local-user-${crypto.randomUUID()}`,
+          uuid: generateId('local-user'),
           role: 'user',
           content: text,
           pending: true,
@@ -545,7 +546,7 @@ function createChatStore() {
       if (index === -1) return;
 
       setStatus('submitting');
-      const assistantLocalId = `local-assistant-${crypto.randomUUID()}`;
+      const assistantLocalId = generateId('local-assistant');
       update((s) => ({
         ...s,
         error: null,
@@ -624,7 +625,7 @@ function createChatStore() {
       });
 
       setStatus('submitting');
-      const assistantLocalId = `local-assistant-${crypto.randomUUID()}`;
+      const assistantLocalId = generateId('local-assistant');
       update((s) => ({
         ...s,
         messages: [


### PR DESCRIPTION
## Summary
Found via live E2E testing against a real GPU-backed LLM (part of v0.5.0 release prep): with a fully working, verified LLM provider configured and activated, Chat still showed "Connect an AI provider to start chatting" after a normal password login. The backend's `/api/llm/status` consistently returned `available:true` the whole time — confirmed via a direct authenticated fetch from the same browser session. This is a frontend state bug, not a config or backend issue.

## Root cause
`llmStatusStore.initialize()` is only called from `+layout.svelte`'s `onMount`, gated on `isAuth` at that moment. Since this is a pure client-side SPA, `onMount` runs exactly once per browser session — on the very first page load, before any login has happened, so `isAuth` is false and the call is skipped entirely. A subsequent client-side login (the normal path through `/login`) never re-runs `onMount`, so nothing ever calls `initialize()` again and `llmStatusStore.available` stays stuck at its initial `false` for the rest of the session. This disables Chat and every other `isLLMAvailable`-gated surface (AI summaries, etc.) until the user manually refreshes the tab.

## Fix
Watch `$isAuthenticated` reactively in `+layout.svelte` and call `llmStatusStore.initialize()` on any transition to authenticated. Covers every sign-in path (password, OIDC, PKI, MFA verify) with one definition instead of patching each success handler individually. `initialize()` already deduplicates via its internal promise cache, so it's safe to also fire alongside the existing `onMount` call on a fresh page load/refresh.

## Testing
- `npm run check`: 0 errors
- `npm run build`: clean
- `npm test`: 373/373 passed
- **Live E2E**: reproduced the bug against a real Gemma 4 E4B vLLM backend (activated config, confirmed backend healthy, confirmed Chat still blocked), applied the fix, confirmed Chat became available immediately after login and a real chat completion round-tripped correctly with citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)