### PR TITLE
feat(dev): add --with-llm-test overlay for real GPU-backed chat testing

### DIFF
--- a/docker-compose.llm-test.yml
+++ b/docker-compose.llm-test.yml
@@ -1,0 +1,94 @@
+# Real (non-mock) LLM provider for local chat/AI feature testing.
+#
+# docker-compose.mock-llm.yml cans token generation but exercises every other real
+# code path (retrieval, redaction masking, citations, SSE, usage recording). This
+# overlay is for the step beyond that: proving chat renders and reads correctly
+# against an actual model's real output, on a GPU.
+#
+# Two independent services — start whichever fits what you're testing:
+#
+#   vLLM (OpenAI-compatible, default with --with-llm-test):
+#     ./opentr.sh start dev --with-llm-test
+#     Settings -> AI: Provider "Custom (OpenAI-compatible)"
+#       Base URL (from containers): http://llm-test-vllm:8000/v1
+#       Base URL (from host):       http://localhost:${LLM_TEST_PORT:-5195}/v1
+#       Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
+#     Needs a HuggingFace token with access to the gated Gemma weights:
+#       HUGGING_FACE_HUB_TOKEN=<token> in .env (never commit it).
+#
+#   Ollama (opt-in via compose profile, not started by --with-llm-test alone):
+#     docker compose -f docker-compose.yml ... -f docker-compose.llm-test.yml --profile ollama up -d llm-test-ollama
+#     docker exec opentranscribe-llm-test-ollama ollama pull ${LLM_TEST_OLLAMA_MODEL:-gemma3:4b}   # first run only
+#     Settings -> AI: Provider "Ollama"
+#       Base URL (from containers): http://llm-test-ollama:11434
+#       Base URL (from host):       http://localhost:${LLM_TEST_OLLAMA_PORT:-5196}
+#       Model: ${LLM_TEST_OLLAMA_MODEL:-gemma3:4b}
+#
+# GPU: pinned to LLM_TEST_GPU_DEVICE_ID (default 2, an idle secondary GPU) so it never
+# contends with the transcription/diarization GPU (GPU_DEVICE_ID, default 0/1 per
+# deployment). Point it at the transcription GPU only if you know that GPU has spare
+# VRAM for the model you're loading.
+#
+# Not wired into --fresh isolation (scripts/CLAUDE.md, issue #347 pattern): a real
+# model load is GPU-heavy and meant for one deliberate manual test session at a time,
+# not routine parallel fresh/e2e stacks that could contend for the same GPU.
+services:
+  llm-test-vllm:
+    image: vllm/vllm-openai:${LLM_TEST_VLLM_TAG:-latest}
+    container_name: ${LLM_TEST_VLLM_CONTAINER_NAME:-opentranscribe-llm-test-vllm}
+    ipc: host
+    command: >
+      --model ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
+      --served-model-name ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
+      --gpu-memory-utilization ${LLM_TEST_VLLM_GPU_UTIL:-0.85}
+      --max-model-len ${LLM_TEST_VLLM_MAX_LEN:-32000}
+    environment:
+      HUGGING_FACE_HUB_TOKEN: "${HUGGING_FACE_HUB_TOKEN:-}"
+      CUDA_VISIBLE_DEVICES: "${LLM_TEST_GPU_DEVICE_ID:-2}"
+    volumes:
+      - llm_test_hf_cache:/root/.cache/huggingface
+    ports:
+      - "127.0.0.1:${LLM_TEST_PORT:-5195}:8000"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              device_ids: ["${LLM_TEST_GPU_DEVICE_ID:-2}"]
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request;urllib.request.urlopen('http://localhost:8000/health',timeout=3)"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 180s  # model download + load can take several minutes on first run
+    restart: unless-stopped
+
+  llm-test-ollama:
+    image: ollama/ollama:${LLM_TEST_OLLAMA_TAG:-latest}
+    container_name: ${LLM_TEST_OLLAMA_CONTAINER_NAME:-opentranscribe-llm-test-ollama}
+    profiles: ["ollama"]  # opt-in only; not started by --with-llm-test alone (see header)
+    environment:
+      CUDA_VISIBLE_DEVICES: "${LLM_TEST_GPU_DEVICE_ID:-2}"
+    volumes:
+      - llm_test_ollama_data:/root/.ollama
+    ports:
+      - "127.0.0.1:${LLM_TEST_OLLAMA_PORT:-5196}:11434"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              device_ids: ["${LLM_TEST_GPU_DEVICE_ID:-2}"]
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  llm_test_hf_cache:
+  llm_test_ollama_data:

--- a/docker-compose.llm-test.yml
+++ b/docker-compose.llm-test.yml
@@ -12,10 +12,15 @@
 #     Settings -> AI: Provider "Custom (OpenAI-compatible)"
 #       Base URL (from containers): http://llm-test-vllm:8000/v1
 #       Base URL (from host):       http://localhost:${LLM_TEST_PORT:-5195}/v1
-#       Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
-#     Needs a HuggingFace token with access to the gated Gemma weights: set the
-#     project's existing HUGGINGFACE_TOKEN in .env (same var setup-opentranscribe.sh
-#     and docker-compose.benchmark.yml already use — never commit it).
+#       Model: ${LLM_TEST_SERVED_NAME:-gemma-4-e4b}
+#     Default model/image mirror the proven Gemma 4 E4B setup already running in
+#     ~/repos/run_openwebui/docker-compose.yaml's vllm-gemma4-e4b service on this
+#     same host (GPU 2, AWQ 4-bit, 128K-capable) — same image tag, same flags, so
+#     anything validated there carries over here.
+#     A gated base model may need a HuggingFace token: set the project's existing
+#     HUGGINGFACE_TOKEN in .env (same var setup-opentranscribe.sh and
+#     docker-compose.benchmark.yml already use — never commit it). The default AWQ
+#     requantization is a public community repo and doesn't require one.
 #
 #   Ollama (opt-in via compose profile, not started by --with-llm-test alone):
 #     docker compose -f docker-compose.yml ... -f docker-compose.llm-test.yml --profile ollama up -d llm-test-ollama
@@ -35,23 +40,43 @@
 # not routine parallel fresh/e2e stacks that could contend for the same GPU.
 services:
   llm-test-vllm:
-    # latest-cu130: generic (not Gemma-specific) vLLM build matching this host's CUDA
-    # 13.x runtime — override LLM_TEST_VLLM_TAG for a different model family's needs.
-    image: vllm/vllm-openai:${LLM_TEST_VLLM_TAG:-latest-cu130}
+    # gemma4-cu130: the exact image already proven on this host's GPU 2 for Gemma 4
+    # (run_openwebui's vllm-gemma4-e4b service). Override LLM_TEST_VLLM_TAG if you
+    # point LLM_TEST_MODEL at a different model family.
+    image: vllm/vllm-openai:${LLM_TEST_VLLM_TAG:-gemma4-cu130}
     container_name: ${LLM_TEST_VLLM_CONTAINER_NAME:-opentranscribe-llm-test-vllm}
     ipc: host
     command: >
-      --model ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
-      --served-model-name ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
+      --model ${LLM_TEST_MODEL:-Chunity/gemma-4-E4B-it-AWQ-4bit}
+      --served-model-name ${LLM_TEST_SERVED_NAME:-gemma-4-e4b}
+      --dtype float16
+      --quantization awq
       --gpu-memory-utilization ${LLM_TEST_VLLM_GPU_UTIL:-0.85}
-      --max-model-len ${LLM_TEST_VLLM_MAX_LEN:-32000}
+      --max-model-len ${LLM_TEST_VLLM_MAX_LEN:-60000}
+      --chat-template /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      --reasoning-parser gemma4
+      --enable-auto-tool-choice
+      --tool-call-parser gemma4
+      --limit-mm-per-prompt '{"image":4,"audio":0}'
+      --max-num-seqs 4
+      --max-num-batched-tokens 20000
+      --enable-prefix-caching
     environment:
       # Standard var name huggingface_hub reads inside the container, sourced from
       # the project's existing HUGGINGFACE_TOKEN .env convention (see header).
       HUGGING_FACE_HUB_TOKEN: "${HUGGINGFACE_TOKEN:-}"
-      CUDA_VISIBLE_DEVICES: "${LLM_TEST_GPU_DEVICE_ID:-2}"
+      # No CUDA_VISIBLE_DEVICES here: the `deploy.reservations.devices` block below
+      # already restricts the container to one physical GPU, which then appears as
+      # device 0 *inside* the container (matching docker-compose.gpu.yml's pattern).
+      # Also setting CUDA_VISIBLE_DEVICES to the physical index causes NVML to look
+      # for a device index that doesn't exist in the already-restricted container
+      # (NVMLError_InvalidArgument -> vLLM crash-loops with zero log output).
     volumes:
-      - llm_test_hf_cache:/root/.cache/huggingface
+      # Defaults to this host's existing run_openwebui model cache (already has the
+      # Gemma 4 E4B AWQ weights - no redundant multi-GB re-download). Override
+      # LLM_TEST_HF_CACHE_PATH in .env on a host without that path; Docker will
+      # create it fresh there and download into it on first run instead.
+      - ${LLM_TEST_HF_CACHE_PATH:-/mnt/nas/models/hf_vllm_models}:/root/.cache/huggingface
     ports:
       - "127.0.0.1:${LLM_TEST_PORT:-5195}:8000"
     deploy:
@@ -73,8 +98,6 @@ services:
     image: ollama/ollama:${LLM_TEST_OLLAMA_TAG:-latest}
     container_name: ${LLM_TEST_OLLAMA_CONTAINER_NAME:-opentranscribe-llm-test-ollama}
     profiles: ["ollama"]  # opt-in only; not started by --with-llm-test alone (see header)
-    environment:
-      CUDA_VISIBLE_DEVICES: "${LLM_TEST_GPU_DEVICE_ID:-2}"
     volumes:
       - llm_test_ollama_data:/root/.ollama
     ports:
@@ -95,5 +118,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  llm_test_hf_cache:
   llm_test_ollama_data:

--- a/docker-compose.llm-test.yml
+++ b/docker-compose.llm-test.yml
@@ -13,8 +13,9 @@
 #       Base URL (from containers): http://llm-test-vllm:8000/v1
 #       Base URL (from host):       http://localhost:${LLM_TEST_PORT:-5195}/v1
 #       Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}
-#     Needs a HuggingFace token with access to the gated Gemma weights:
-#       HUGGING_FACE_HUB_TOKEN=<token> in .env (never commit it).
+#     Needs a HuggingFace token with access to the gated Gemma weights: set the
+#     project's existing HUGGINGFACE_TOKEN in .env (same var setup-opentranscribe.sh
+#     and docker-compose.benchmark.yml already use — never commit it).
 #
 #   Ollama (opt-in via compose profile, not started by --with-llm-test alone):
 #     docker compose -f docker-compose.yml ... -f docker-compose.llm-test.yml --profile ollama up -d llm-test-ollama
@@ -34,7 +35,9 @@
 # not routine parallel fresh/e2e stacks that could contend for the same GPU.
 services:
   llm-test-vllm:
-    image: vllm/vllm-openai:${LLM_TEST_VLLM_TAG:-latest}
+    # latest-cu130: generic (not Gemma-specific) vLLM build matching this host's CUDA
+    # 13.x runtime — override LLM_TEST_VLLM_TAG for a different model family's needs.
+    image: vllm/vllm-openai:${LLM_TEST_VLLM_TAG:-latest-cu130}
     container_name: ${LLM_TEST_VLLM_CONTAINER_NAME:-opentranscribe-llm-test-vllm}
     ipc: host
     command: >
@@ -43,7 +46,9 @@ services:
       --gpu-memory-utilization ${LLM_TEST_VLLM_GPU_UTIL:-0.85}
       --max-model-len ${LLM_TEST_VLLM_MAX_LEN:-32000}
     environment:
-      HUGGING_FACE_HUB_TOKEN: "${HUGGING_FACE_HUB_TOKEN:-}"
+      # Standard var name huggingface_hub reads inside the container, sourced from
+      # the project's existing HUGGINGFACE_TOKEN .env convention (see header).
+      HUGGING_FACE_HUB_TOKEN: "${HUGGINGFACE_TOKEN:-}"
       CUDA_VISIBLE_DEVICES: "${LLM_TEST_GPU_DEVICE_ID:-2}"
     volumes:
       - llm_test_hf_cache:/root/.cache/huggingface

--- a/opentr.sh
+++ b/opentr.sh
@@ -84,7 +84,7 @@ show_help() {
   echo "                         mock-empty, mock-error, mock-slow"
   echo "  --with-llm-test      - Start a real GPU-backed LLM (vLLM, localhost:5195) for chat"
   echo "                         testing against actual model output, not canned tokens."
-  echo "                         Default model: google/gemma-3-4b-it, GPU 2. See"
+  echo "                         Default model: Gemma 4 E4B (AWQ), GPU 2. See"
   echo "                         docker-compose.llm-test.yml for the Ollama alternative."
   echo "  --with-keycloak-test - Start Keycloak test container (dev or prod; localhost:8180)"
   echo "  --with-authentik-test - Start Authentik test container (dev or prod; localhost:9022)"
@@ -1277,7 +1277,7 @@ start_app() {
       COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.llm-test.yml"
       echo "🧠 Adding real LLM test provider (docker-compose.llm-test.yml)"
       echo "   vLLM — from containers: http://llm-test-vllm:8000/v1   from host: http://localhost:${LLM_TEST_PORT:-5195}/v1"
-      echo "   Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
+      echo "   Model: ${LLM_TEST_SERVED_NAME:-gemma-4-e4b}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
       echo "   Ollama alternative (not auto-started): docker compose ... --profile ollama up -d llm-test-ollama"
     else
       echo "⚠️  --with-llm-test specified but docker-compose.llm-test.yml not found"
@@ -1825,7 +1825,7 @@ reset_and_init() {
       COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.llm-test.yml"
       echo "🧠 Adding real LLM test provider (docker-compose.llm-test.yml)"
       echo "   vLLM — from containers: http://llm-test-vllm:8000/v1   from host: http://localhost:${LLM_TEST_PORT:-5195}/v1"
-      echo "   Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
+      echo "   Model: ${LLM_TEST_SERVED_NAME:-gemma-4-e4b}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
       echo "   Ollama alternative (not auto-started): docker compose ... --profile ollama up -d llm-test-ollama"
     else
       echo "⚠️  --with-llm-test specified but docker-compose.llm-test.yml not found"

--- a/opentr.sh
+++ b/opentr.sh
@@ -82,6 +82,10 @@ show_help() {
   echo "  --with-mock-llm      - Start mock LLM provider (localhost:5199) so chat/AI features"
   echo "                         work without a GPU or API key. Models: mock-gpt, mock-echo,"
   echo "                         mock-empty, mock-error, mock-slow"
+  echo "  --with-llm-test      - Start a real GPU-backed LLM (vLLM, localhost:5195) for chat"
+  echo "                         testing against actual model output, not canned tokens."
+  echo "                         Default model: google/gemma-3-4b-it, GPU 2. See"
+  echo "                         docker-compose.llm-test.yml for the Ollama alternative."
   echo "  --with-keycloak-test - Start Keycloak test container (dev or prod; localhost:8180)"
   echo "  --with-authentik-test - Start Authentik test container (dev or prod; localhost:9022)"
   echo "  --with-watch         - Mount the host watch folder (WATCH_HOST_PATH, default ./watch) for auto-import"
@@ -140,6 +144,7 @@ show_help() {
   echo "  ./opentr.sh start dev --cpu                  # Local CPU-only (skip GPU overlay)"
   echo "  ./opentr.sh start dev --with-ldap-test       # Dev with LDAP test container"
   echo "  ./opentr.sh start dev --with-mock-llm        # Dev with a fake LLM for chat/AI testing"
+  echo "  ./opentr.sh start dev --with-llm-test        # Dev with a real GPU-backed LLM (vLLM) for chat testing"
   echo "  ./opentr.sh start dev --with-keycloak-test   # Dev with Keycloak test container"
   echo "  ./opentr.sh start dev --with-authentik-test  # Dev with Authentik test container"
   echo "  ./opentr.sh start prod                       # Production (pulls from Docker Hub)"
@@ -763,6 +768,7 @@ start_app() {
   WITH_PKI_FLAG=""
   WITH_LDAP_TEST_FLAG=""
   WITH_MOCK_LLM_FLAG=""
+  WITH_LLM_TEST_FLAG=""
   WITH_KEYCLOAK_TEST_FLAG=""
   WITH_AUTHENTIK_TEST_FLAG=""
   WITH_WATCH_FLAG=""
@@ -849,6 +855,10 @@ start_app() {
         ;;
       --with-mock-llm)
         WITH_MOCK_LLM_FLAG="--with-mock-llm"
+        shift
+        ;;
+      --with-llm-test)
+        WITH_LLM_TEST_FLAG="--with-llm-test"
         shift
         ;;
       --with-keycloak-test)
@@ -1258,6 +1268,19 @@ start_app() {
       echo "   Models: mock-gpt (normal) mock-echo mock-empty mock-error mock-slow"
     else
       echo "⚠️  --with-mock-llm specified but docker-compose.mock-llm.yml not found"
+    fi
+  fi
+
+  # Add real GPU-backed LLM test provider if requested
+  if [ -n "$WITH_LLM_TEST_FLAG" ]; then
+    if [ -f "docker-compose.llm-test.yml" ]; then
+      COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.llm-test.yml"
+      echo "🧠 Adding real LLM test provider (docker-compose.llm-test.yml)"
+      echo "   vLLM — from containers: http://llm-test-vllm:8000/v1   from host: http://localhost:${LLM_TEST_PORT:-5195}/v1"
+      echo "   Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
+      echo "   Ollama alternative (not auto-started): docker compose ... --profile ollama up -d llm-test-ollama"
+    else
+      echo "⚠️  --with-llm-test specified but docker-compose.llm-test.yml not found"
     fi
   fi
 
@@ -1793,6 +1816,19 @@ reset_and_init() {
       echo "   Models: mock-gpt (normal) mock-echo mock-empty mock-error mock-slow"
     else
       echo "⚠️  --with-mock-llm specified but docker-compose.mock-llm.yml not found"
+    fi
+  fi
+
+  # Add real GPU-backed LLM test provider if requested
+  if [ -n "$WITH_LLM_TEST_FLAG" ]; then
+    if [ -f "docker-compose.llm-test.yml" ]; then
+      COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.llm-test.yml"
+      echo "🧠 Adding real LLM test provider (docker-compose.llm-test.yml)"
+      echo "   vLLM — from containers: http://llm-test-vllm:8000/v1   from host: http://localhost:${LLM_TEST_PORT:-5195}/v1"
+      echo "   Model: ${LLM_TEST_MODEL:-google/gemma-3-4b-it}   GPU: ${LLM_TEST_GPU_DEVICE_ID:-2}"
+      echo "   Ollama alternative (not auto-started): docker compose ... --profile ollama up -d llm-test-ollama"
+    else
+      echo "⚠️  --with-llm-test specified but docker-compose.llm-test.yml not found"
     fi
   fi
 


### PR DESCRIPTION
## Summary
Adds a real (non-mock) LLM test overlay so chat/AI features can be validated against actual model output on GPU, not just canned tokens (`docker-compose.mock-llm.yml` already covers that path — this is the step beyond it).

## Changes
- `docker-compose.llm-test.yml`: `llm-test-vllm` service (OpenAI-compatible, started by `--with-llm-test`) defaulting to Gemma 4 E4B (AWQ) on the exact image/flags already proven in `~/repos/run_openwebui`'s `vllm-gemma4-e4b` service on this host's GPU 2. Reuses the existing on-disk HF cache (`/mnt/nas/models/hf_vllm_models`, override via `LLM_TEST_HF_CACHE_PATH`) instead of a fresh multi-GB download. `llm-test-ollama` is included as an opt-in compose profile alternative.
- `opentr.sh`: wires `--with-llm-test` following the `--with-mock-llm` pattern exactly (flag parsing, help text, compose-file inclusion at both call sites).
- HF token reuses the project's existing `HUGGINGFACE_TOKEN` .env convention (not a new var name).
- GPU-pinned to `LLM_TEST_GPU_DEVICE_ID` (default 2, an idle secondary GPU) — never contends with the transcription/diarization GPU. Deliberately not wired into `--fresh` isolation (issue #347 pattern): a real model load is GPU-heavy and meant for one deliberate manual session, not routine parallel fresh/e2e stacks.

## Testing (live, not just config review)
- `./opentr.sh start dev --with-llm-test` — container reaches `healthy`, model loads onto GPU 2.
- Direct `/v1/chat/completions` call returns real, coherent generation.
- Full app integration: configured via Settings -> AI, activated, sent a real chat message through the UI — retrieval + citations + real LLM generation confirmed working end to end (see PR #373 for a related bug this surfaced and fixed).
- Fixed one real bug during testing: `deploy.reservations.devices` + an explicit `CUDA_VISIBLE_DEVICES` env var double-restricted the container (NVML looked for a physical index that doesn't exist inside the already-restricted container) — removed the redundant env var, matching `docker-compose.gpu.yml`'s existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)