### PR TITLE
chore(backend): bump pinned deps behind Dependabot's proposed floors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Skill: `.claude/skills/docker-build-push/SKILL.md` (multi-arch requires `USE_REM
 
 Alembic runs automatically on dev backend startup — `alembic upgrade head` is production-only.
 
-Host venv for pre-commit / mypy / ruff / bandit / pytest outside Docker lives at `backend/venv/` and already exists. If it doesn't: `cd backend && python3.11 -m venv venv && source venv/bin/activate && pip install -r requirements.txt pre-commit mypy ruff bandit`.
+Host venv for pre-commit / mypy / ruff / bandit / pytest outside Docker lives at `backend/venv/` and already exists. If it doesn't: `cd backend && python3.11 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && pip install --no-deps -r requirements-nodeps.txt && pip install pre-commit mypy ruff bandit`. The `requirements-nodeps.txt` step is mandatory, not optional — it installs whisperx/faster-whisper/gliner, and skipping it leaves the venv without a working ASR/redaction stack. This is the exact two-step install `Dockerfile.prod` runs; see `requirements-nodeps.txt`'s header for why those three packages need `--no-deps`.
 
 ### Pre-commit / lint hooks
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -14,7 +14,11 @@ engine) · `app/utils` (shared helpers) · `app/middleware`.
 ## Commands
 
 Prefer running inside the container (`./opentr.sh shell backend`). The host venv at
-`backend/venv/` exists for pre-commit, mypy, ruff, bandit, and pytest outside Docker.
+`backend/venv/` exists for pre-commit, mypy, ruff, bandit, and pytest outside Docker. It needs a
+two-step install: `pip install -r requirements.txt` then `pip install --no-deps -r
+requirements-nodeps.txt` — see that file's header. This is the same two-step sequence
+`Dockerfile.prod` runs; there is no Dockerfile-only install step for this project. If a package
+is only ever installed inside the image, it belongs in one of these two files instead.
 
 `alembic upgrade head` is **production-only** — dev applies migrations automatically on
 backend startup via `app/db/migrations.py`.

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy only requirements first for better layer caching
-COPY requirements.txt .
+COPY requirements.txt requirements-nodeps.txt ./
 
 # Upgrade pip to latest version first (security fix for CVE-2025-8869)
 RUN pip install --user --no-cache-dir --upgrade pip
@@ -38,19 +38,11 @@ RUN pip install --user --no-cache-dir --upgrade pip
 # Use --user to install to /root/.local which we'll copy to final stage
 RUN pip install --user --no-cache-dir --no-warn-script-location -r requirements.txt
 
-# Install WhisperX with --no-deps to keep our version pins in requirements.txt
-# WhisperX 3.8.1 has native pyannote-audio>=4.0.0 support — no monkey patches needed
-# We still use --no-deps to prevent surprise dependency upgrades
-RUN pip install --user --no-cache-dir --no-warn-script-location --no-deps whisperx==3.8.1
-
-# Force onnxruntime-gpu as the final resolver for the ``onnxruntime`` namespace.
-# Both ``onnxruntime-gpu`` and ``onnxruntime`` install Python files into
-# ``onnxruntime/``; whichever installs last wins. A plain ``pip uninstall
-# onnxruntime`` removes files shared with the GPU variant. Re-installing with
-# ``--force-reinstall`` after everything else puts the GPU module files back
-# and ensures CUDAExecutionProvider is available at runtime.
-RUN pip install --user --no-cache-dir --force-reinstall --no-deps \
-    "onnxruntime-gpu==1.26.0"
+# WhisperX, faster-whisper, and gliner all need --no-deps — see requirements-nodeps.txt
+# for why. This exact command is also what a local venv setup runs (see
+# backend/CLAUDE.md); it must never diverge into a Dockerfile-only inline install.
+# WhisperX 3.8.1 has native pyannote-audio>=4.0.0 support — no monkey patches needed.
+RUN pip install --user --no-cache-dir --no-warn-script-location --no-deps -r requirements-nodeps.txt
 
 # Content redaction: Presidio needs a spaCy pipeline for tokenization. Use the small
 # English model (~12 MB) — PII NER is handled by GLiNER + Presidio's regex recognizers,

--- a/backend/app/api/websockets.py
+++ b/backend/app/api/websockets.py
@@ -5,7 +5,6 @@ import logging
 
 import redis.asyncio as redis
 from fastapi import APIRouter
-from fastapi import Depends
 from fastapi import WebSocket
 from fastapi import WebSocketDisconnect
 from redis.exceptions import RedisError
@@ -13,10 +12,10 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from sqlalchemy.orm import Session
 
 from app.auth.token_service import token_service
+from app.db.session_utils import session_scope
 
 from ..core.config import settings
 from ..core.security import verify_token
-from ..db.base import get_db
 from ..models.user import User
 
 # Set up logging
@@ -267,7 +266,7 @@ def _try_authenticate_token(
 
 
 @router.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)):
+async def websocket_endpoint(websocket: WebSocket):
     """WebSocket endpoint with first-message authentication.
 
     Authentication flow:
@@ -276,6 +275,17 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
     3. If no cookie, wait up to 10 s for a first-message ``authenticate`` frame.
     4. On success, register the connection and proceed with the normal
        message loop; on failure, close with an appropriate error code.
+
+    Deliberately does NOT take ``db: Session = Depends(get_db)``: a WebSocket route's
+    injected dependencies stay open for the *whole connection*, not just one
+    request/response like HTTP — and this connection can live for hours. DB access is
+    only needed for the few-millisecond auth check below, so each attempt opens its own
+    short-lived ``session_scope()`` instead. Holding a session open for the connection's
+    full lifetime left an idle, uncommitted transaction checked out of the pool for as
+    long as the socket stayed connected: wasted a pool slot, silently discarded any
+    write from the external-auth user-sync path (``get_db``'s cleanup only closes, which
+    rolls back — it never commits), and could block a schema migration waiting on the
+    same table for as long as any client stayed connected.
     """
     # Initialize Redis subscriber if not already running
     setup_redis()
@@ -288,7 +298,16 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
     # 1. Try cookie-based auth
     token = websocket.cookies.get("access_token")
     if token:
-        user = _try_authenticate_token(token, db, websocket)
+        with session_scope() as db:
+            user = _try_authenticate_token(token, db, websocket)
+            # session_scope() commits on exit, which expires every attribute on `user`
+            # (SQLAlchemy's default expire_on_commit) — the only attribute touched after
+            # this block is user.id, which must survive the session closing. Expunge
+            # BEFORE the block exits/commits so the already-loaded columns stay readable
+            # on the now-detached instance; expunging after commit would be too late,
+            # since expiry already happened.
+            if user is not None:
+                db.expunge(user)
 
     # 2. If no cookie auth, wait for first-message authentication
     if not user:
@@ -298,7 +317,10 @@ async def websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)
             if data.get("type") != "authenticate" or not data.get("token"):
                 await websocket.close(code=4001, reason="Authentication required")
                 return
-            user = _try_authenticate_token(data["token"], db, websocket)
+            with session_scope() as db:
+                user = _try_authenticate_token(data["token"], db, websocket)
+                if user is not None:
+                    db.expunge(user)
             if not user:
                 await websocket.close(code=4003, reason="Invalid token")
                 return

--- a/backend/app/transcription/audio.py
+++ b/backend/app/transcription/audio.py
@@ -2,6 +2,23 @@
 
 Uses faster_whisper.decode_audio() which is the same function WhisperX
 calls internally via whisperx.load_audio().
+
+This is the ONLY audio-loading path in the app for a reason: torchcodec (a
+transitive dependency pulled in by pyannote.audio's audio I/O layer) cannot
+load its native library in this environment — its GPU decoder needs CUDA
+13's libnvrtc.so.13, but torch here is built against cu128 (CUDA 12.8).
+torchaudio.load() defaults to the torchcodec backend as of the torchaudio
+version pinned here, so it raises RuntimeError on any call. decode_audio()
+never touches torchcodec (it shells out via PyAV/ffmpeg), and everywhere
+this app calls pyannote's Pipeline it passes an already-loaded
+`{"waveform": tensor, "sample_rate": ...}` dict (see diarizer.py) rather
+than a file path — pyannote's own file-path-based `Audio().get_duration()`
+telemetry path is the other place that reaches for torchcodec, and dict
+inputs skip it entirely. Verified empirically: faster-whisper transcription,
+pyannote diarization (via a dict input, matching diarizer.py exactly), and
+GLiNER redaction NER all run correctly end-to-end on GPU in this
+environment. Do not add a torchaudio.load() call or pass a raw file path
+into a pyannote Pipeline — either will hit the broken torchcodec backend.
 """
 
 import logging

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -88,7 +88,9 @@ sentence-transformers>=5.6.0
 nltk>=3.9.4
 
 # Cloud ASR provider SDKs (lazily imported)
-deepgram-sdk>=7.4.0
+# deepgram-sdk<7.6.0 breaks under websockets>=15 — see requirements.txt for the full
+# explanation. Caught by tests/unit/test_provider_sdk_compat.py.
+deepgram-sdk>=7.6.0
 assemblyai>=0.64.25
 google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -20,7 +20,7 @@
 # scope["route"].path — breaks route-templated metrics labels (see requirements.txt)
 fastapi>=0.136.3,<0.137
 uvicorn[standard]>=0.49.0
-websockets>=11.0.3
+websockets>=17.0.1
 sqlalchemy>=2.0.51
 alembic>=1.18.5
 pydantic>=2.13.4
@@ -36,7 +36,8 @@ joserfc>=1.7.4
 python3-saml>=1.16.0
 python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
-bcrypt==3.2.2
+# See requirements.txt for why this can't go to bcrypt 5.0.0 (passlib incompatibility).
+bcrypt>=4.3.0,<5
 email-validator
 
 # Observability (Prometheus metrics + structured JSON logs) — CI imports app.main
@@ -56,20 +57,22 @@ httpx>=0.28.1
 python-dotenv>=1.2.2
 ldap3>=2.9.1
 slowapi>=0.1.10
-cryptography>=49.0.0
+cryptography>=50.0.0
 pyotp>=2.10.0
 qrcode[pil]>=8.2
 
 # AI/ML stack (CPU wheels via the extra index above)
 numpy>=2.1.0
-torch==2.8.0
-torchaudio==2.8.0
+# See requirements.txt for why 2.11.0 (not a newer torch) is the pinned pair.
+torch==2.11.0
+torchaudio==2.11.0
 ctranslate2>=4.8.1,<5
 faster-whisper>=1.2.1
-transformers>=4.48.0
+# See requirements.txt for why transformers is capped <5.0.0.
+transformers>=4.48.0,<5.0.0
 huggingface-hub<1.0.0
 onnx>=1.22.0
-onnxruntime==1.27.0
+onnxruntime==1.28.0
 omegaconf>=2.3.1
 
 # Supporting libraries

--- a/backend/requirements-lite.txt
+++ b/backend/requirements-lite.txt
@@ -2,7 +2,7 @@
 # scope["route"].path — breaks route-templated metrics labels (see requirements.txt)
 fastapi>=0.136.3,<0.137
 uvicorn[standard]>=0.49.0
-websockets>=11.0.3
+websockets>=17.0.1
 sqlalchemy>=2.0.51
 alembic>=1.18.5
 pydantic>=2.13.4
@@ -13,7 +13,8 @@ joserfc>=1.7.4
 python3-saml>=1.16.0
 python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
-bcrypt==3.2.2
+# See requirements.txt for why this can't go to bcrypt 5.0.0 (passlib incompatibility).
+bcrypt>=4.3.0,<5
 email-validator
 # Asynchronous Tasks
 celery>=5.6.3
@@ -32,7 +33,7 @@ ldap3>=2.9.1
 slowapi>=0.1.10
 
 # PKI/X.509 Certificate Authentication
-cryptography>=49.0.0
+cryptography>=50.0.0
 
 # MFA/TOTP Authentication (FedRAMP IA-2)
 pyotp>=2.10.0
@@ -46,7 +47,11 @@ numpy>=1.25.2
 # Use --extra-index-url so PyPI remains available for all other packages.
 # --index-url would replace PyPI entirely, breaking pyannote.audio and other deps.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.8.0+cpu
+torch==2.11.0+cpu
+# Explicit CPU pin - without it, pyannote.audio>=4.0.7's own torchaudio>=2.8.0
+# floor lets pip resolve whatever it wants, including a CUDA-linked PyPI build
+# into what's supposed to be a CPU-only image.
+torchaudio==2.11.0+cpu
 
 # PyAnnote (CPU-only, for speaker embedding extraction and cross-file speaker matching)
 pyannote.audio>=4.0.7

--- a/backend/requirements-lite.txt
+++ b/backend/requirements-lite.txt
@@ -70,7 +70,9 @@ sentence-transformers>=5.6.0  # For semantic search embeddings (all-MiniLM-L6-v2
 # NLTK data files (punkt_tab) must be pre-downloaded for offline usage
 
 # Cloud ASR provider SDKs (lazily imported — only needed for configured provider)
-deepgram-sdk>=7.4.0
+# deepgram-sdk<7.6.0 breaks under websockets>=15 — see backend/requirements.txt for the
+# full explanation. Caught by tests/unit/test_provider_sdk_compat.py.
+deepgram-sdk>=7.6.0
 assemblyai>=0.64.25
 google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0

--- a/backend/requirements-nodeps.txt
+++ b/backend/requirements-nodeps.txt
@@ -1,0 +1,24 @@
+# Packages that MUST be installed with `pip install --no-deps -r requirements-nodeps.txt`,
+# as a second step after `pip install -r requirements.txt` — in Docker AND in a local venv.
+# There is no such thing as "the Docker-only install step": if it's not expressible the same
+# way in both places, it doesn't belong in this project. See backend/CLAUDE.md.
+#
+# Why --no-deps at all: each package below has its own transitive dependency that would
+# otherwise conflict with a pin in requirements.txt if installed normally.
+#
+#   whisperx==3.8.1
+#     Keeps our own version pins (torch, ctranslate2, transformers, ...) in requirements.txt
+#     authoritative instead of letting whisperx's own floors override them.
+#
+#   faster-whisper==1.2.1, gliner==0.2.28
+#     Both declare an unconditional `onnxruntime` dependency upstream (no platform marker).
+#     requirements.txt pins `onnxruntime-gpu` (with a matching `onnxruntime` CPU fallback for
+#     non-Linux/non-x86_64 only) — a normal resolve of these two packages installs plain
+#     `onnxruntime` alongside it. Both packages write into the same `onnxruntime/` import
+#     namespace, and whichever installs last silently wins, dropping CUDAExecutionProvider
+#     with no error. --no-deps means WE own their transitive closure instead: their other
+#     real dependencies (av, tokenizers, tqdm, sentencepiece, transformers, huggingface-hub,
+#     ctranslate2, torch) are all pinned explicitly in requirements.txt already.
+whisperx==3.8.1
+faster-whisper==1.2.1
+gliner==0.2.28

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -73,7 +73,8 @@ torch==2.11.0
 torchaudio==2.11.0
 
 # =============================================================================
-# WhisperX 3.8.1 Dependencies (explicit since we install with --no-deps)
+# WhisperX / faster-whisper / GLiNER dependencies (explicit — all three are
+# installed with --no-deps from requirements-nodeps.txt, see that file for why)
 # Source: https://github.com/m-bain/whisperx/blob/main/pyproject.toml
 # =============================================================================
 # CTranslate2 - inference engine for Whisper
@@ -81,16 +82,22 @@ torchaudio==2.11.0
 # We use >=4.6.0 for cuDNN 9 support (required for CUDA 12.8)
 ctranslate2>=4.8.1,<5
 
-# faster-whisper - CTranslate2-based Whisper implementation
-# whisperx requires >=1.1.1
-faster-whisper>=1.2.1
+# faster-whisper's own dependencies (it's installed --no-deps; see
+# requirements-nodeps.txt): av>=11, tokenizers<1,>=0.13, tqdm (no version
+# constraint upstream). ctranslate2 and huggingface-hub above/below already
+# satisfy its other needs.
+av>=11
+tokenizers>=0.13,<1
+tqdm>=4.66
 
 # ML/Data processing
 # transformers>=5.0.0 needs huggingface-hub>=1.0.0, but whisperx (3.8.1 and current
 # 3.8.6) caps huggingface-hub<1.0.0, and gliner==0.2.28 caps transformers<5.14.0 -
 # capped here so Dependabot stops proposing an incompatible jump. Revisit once
 # whisperx ships a huggingface-hub>=1.0 compatible release.
-transformers>=4.48.0,<5.0.0
+# Floor raised to 4.51.3 (gliner's actual "requires_dist" floor) now that gliner
+# is also --no-deps below and no longer has pip enforcing that constraint for us.
+transformers>=4.51.3,<5.0.0
 huggingface-hub<1.0.0
 # pandas removed: only used by diarizer/speaker_assigner/reprocess, replaced with
 # DiarizeResult numpy dataclass. Saves ~72 MB. See app/transcription/diarize_result.py.
@@ -104,8 +111,15 @@ huggingface-hub<1.0.0
 onnx>=1.22.0
 # Pinned to the validated version (1.27.0) so --no-cache container builds and venv
 # setups are reproducible — an unpinned >= floor could resolve a newer release with
-# a different bundled CUDA at build time. onnxruntime-gpu and onnxruntime ship in
-# lockstep, so both pin to the same version.
+# a different bundled CUDA at build time. Both lines pin the same version so the
+# non-Linux/non-x86_64 CPU fallback below stays in lockstep with the GPU build.
+#
+# Nothing else in this file may depend on plain `onnxruntime` without a platform
+# marker: pip installs both packages side by side when something does (they write
+# into the same `onnxruntime/` import namespace, and whichever installs last wins
+# — silently dropping CUDAExecutionProvider). faster-whisper and gliner both have
+# an unconditional `onnxruntime` dependency upstream, which is exactly why both
+# are installed with --no-deps from requirements-nodeps.txt instead of from this file.
 onnxruntime-gpu==1.28.0; sys_platform == 'linux' and platform_machine == 'x86_64'
 onnxruntime==1.28.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 # NOTE: `tensorrt` was added during Phase 6.3 spike but removed 2026-04-23.
@@ -126,8 +140,8 @@ pyannote.audio @ git+https://github.com/davidamacey/pyannote-audio.git@gpu-optim
 # Required by pyannote/embedding model checkpoint (pickle dependency)
 omegaconf>=2.3.1
 
-# NOTE: whisperx==3.8.1 is installed separately in Dockerfile with --no-deps
-# to keep our version pins in requirements.txt authoritative
+# NOTE: whisperx==3.8.1 is installed separately from requirements-nodeps.txt
+# with --no-deps to keep our version pins in requirements.txt authoritative
 # =============================================================================
 
 # Supporting libraries
@@ -146,7 +160,14 @@ nltk>=3.9.4  # Required by whisperx>=3.7.6, also for SnowballStemmer
 # NLTK data files (punkt_tab) must be pre-downloaded for offline usage
 
 # Cloud ASR provider SDKs (lazily imported — only needed for configured provider)
-deepgram-sdk>=7.4.0
+# deepgram-sdk<7.6.0 breaks under websockets>=15: DeepgramClient.listen.v1 eagerly imports
+# its streaming socket_client module even for our REST-only transcribe_file() call path, and
+# that module imports `websockets.legacy.client`, which imports `BINARY` from
+# `websockets.frames` — a symbol websockets removed in 15.0. Caught by
+# tests/unit/test_provider_sdk_compat.py::TestDeepgramSdkContract. 7.6.0 fixes it upstream
+# (same websockets>=12.0 floor, so it's the SDK's own import chain that changed, not a
+# websockets pin) — verified via a real import + client.listen.v1.media.transcribe_file check.
+deepgram-sdk>=7.6.0
 assemblyai>=0.64.25
 google-cloud-speech>=2.40.0
 azure-cognitiveservices-speech>=1.50.0
@@ -171,7 +192,9 @@ meeteval>=0.4.3
 presidio-analyzer>=2.2.363
 presidio-anonymizer>=2.2.355
 # GLiNER = small CPU zero-shot NER for names/addresses (plugs into Presidio).
-gliner>=0.2.27
+# Installed with --no-deps from requirements-nodeps.txt (gliner==0.2.28) — see the
+# onnxruntime comment above; its other real dependencies (torch, transformers,
+# huggingface_hub, sentencepiece, tqdm) are all already pinned elsewhere in this file.
 # detoxify = toxicity classification (segment-level). transformers (above) backs
 # the Tiny-Toxic-Detector / multilingual-toxic-xlm-roberta models.
 detoxify>=0.5.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@
 # Cap until the observability middleware adapts to the new routing.
 fastapi>=0.136.3,<0.137
 uvicorn[standard]>=0.49.0
-websockets>=11.0.3
+websockets>=17.0.1
 sqlalchemy>=2.0.51
 alembic>=1.18.5
 pydantic>=2.13.4
@@ -22,7 +22,11 @@ joserfc>=1.7.4
 python3-saml>=1.16.0
 python-multipart>=0.0.32
 passlib[bcrypt]>=1.7.4
-bcrypt==3.2.2
+# bcrypt>=5.0.0 removed the __about__ shim passlib 1.7.4 (unmaintained since 2020)
+# reads to detect the backend version, hard-breaking bcrypt_sha256/bcrypt verification
+# with "password cannot be longer than 72 bytes" for every password (pyca/bcrypt #1079,
+# #1082). 4.3.0 is the last 4.x release and keeps the compat shim.
+bcrypt>=4.3.0,<5
 email-validator
 
 # Observability (Prometheus metrics + structured JSON logs)
@@ -49,7 +53,7 @@ ldap3>=2.9.1
 slowapi>=0.1.10
 
 # PKI/X.509 Certificate Authentication
-cryptography>=49.0.0
+cryptography>=50.0.0
 
 # MFA/TOTP Authentication (FedRAMP IA-2)
 pyotp>=2.10.0
@@ -60,9 +64,13 @@ qrcode[pil]>=8.2
 numpy>=2.1.0
 
 # PyTorch with CUDA 12.8 support (CVE-2025-32434 fixed in 2.6.0+)
+# 2.11.0 is the newest matched torch/torchaudio pair on the cu128 index (torch has
+# continued past it to 2.12/2.13 on cu129/cu130, but torchaudio stopped releasing
+# at 2.11.0 everywhere - it's in maintenance mode and no longer version-locked to
+# torch, so this is genuinely the latest usable pair without a CUDA index migration).
 --extra-index-url https://download.pytorch.org/whl/cu128
-torch==2.8.0
-torchaudio==2.8.0
+torch==2.11.0
+torchaudio==2.11.0
 
 # =============================================================================
 # WhisperX 3.8.1 Dependencies (explicit since we install with --no-deps)
@@ -78,7 +86,11 @@ ctranslate2>=4.8.1,<5
 faster-whisper>=1.2.1
 
 # ML/Data processing
-transformers>=4.48.0
+# transformers>=5.0.0 needs huggingface-hub>=1.0.0, but whisperx (3.8.1 and current
+# 3.8.6) caps huggingface-hub<1.0.0, and gliner==0.2.28 caps transformers<5.14.0 -
+# capped here so Dependabot stops proposing an incompatible jump. Revisit once
+# whisperx ships a huggingface-hub>=1.0 compatible release.
+transformers>=4.48.0,<5.0.0
 huggingface-hub<1.0.0
 # pandas removed: only used by diarizer/speaker_assigner/reprocess, replaced with
 # DiarizeResult numpy dataclass. Saves ~72 MB. See app/transcription/diarize_result.py.
@@ -94,8 +106,8 @@ onnx>=1.22.0
 # setups are reproducible — an unpinned >= floor could resolve a newer release with
 # a different bundled CUDA at build time. onnxruntime-gpu and onnxruntime ship in
 # lockstep, so both pin to the same version.
-onnxruntime-gpu==1.27.0; sys_platform == 'linux' and platform_machine == 'x86_64'
-onnxruntime==1.27.0; sys_platform != 'linux' or platform_machine != 'x86_64'
+onnxruntime-gpu==1.28.0; sys_platform == 'linux' and platform_machine == 'x86_64'
+onnxruntime==1.28.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 # NOTE: `tensorrt` was added during Phase 6.3 spike but removed 2026-04-23.
 # ORT's TensorrtExecutionProvider hit rebuild storms on pyannote's variable
 # input shapes — 2 min CPU saturation, 0% GPU usage, no inference. Microbench

--- a/backend/tests/test_fedramp_controls.py
+++ b/backend/tests/test_fedramp_controls.py
@@ -172,6 +172,18 @@ class TestLoginBannerAcknowledgmentAC8:
     proceeding.
     """
 
+    # get_login_banner() resolves login_banner_* via auth_settings.get_bool(), which is
+    # DB > .env > coded default (app/api/endpoints/auth/methods.py). Patching
+    # settings.LOGIN_BANNER_ENABLED only moves the .env layer and is silently ignored
+    # whenever a real login_banner_enabled row already exists in auth_config — which it
+    # does on any environment where the banner was ever configured through the admin UI.
+    # These tests write the DB row directly (the same path AuthConfigService.set_config
+    # takes for a real admin change) so they exercise the precedence the endpoint actually
+    # implements and pass independent of ambient DB state. Serialized to one xdist worker
+    # like test_auth_config_integration.py, since both write the same shared
+    # login_banner_* rows and racing UPDATEs against them can deadlock under -n auto.
+    pytestmark = pytest.mark.xdist_group("auth_config")
+
     def test_login_banner_config_exists(self):
         """Verify login banner configuration settings exist."""
         from app.core.config import settings
@@ -180,29 +192,65 @@ class TestLoginBannerAcknowledgmentAC8:
         assert hasattr(settings, "LOGIN_BANNER_TEXT")
         assert hasattr(settings, "LOGIN_BANNER_CLASSIFICATION")
 
-    def test_get_login_banner_when_disabled(self, client):
+    def test_get_login_banner_when_disabled(self, client, db_session, admin_user):
         """Test banner endpoint returns disabled state when banner is off."""
-        with patch("app.core.config.settings.LOGIN_BANNER_ENABLED", False):
-            response = client.get("/api/auth/banner")
-            assert response.status_code == 200
-            data = response.json()
-            assert data["enabled"] is False
+        from app.services.auth_config_service import AuthConfigService
 
-    def test_get_login_banner_when_enabled(self, client):
+        AuthConfigService.set_config(
+            db=db_session,
+            key="login_banner_enabled",
+            value=False,
+            is_sensitive=False,
+            category="banner",
+            user_id=admin_user.id,
+            data_type="bool",
+        )
+
+        response = client.get("/api/auth/banner")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+
+    def test_get_login_banner_when_enabled(self, client, db_session, admin_user):
         """Test banner endpoint returns banner content when enabled."""
+        from app.services.auth_config_service import AuthConfigService
+
         test_banner_text = "This is a US Government system. Unauthorized access prohibited."
         test_classification = "UNCLASSIFIED"
 
-        with (
-            patch("app.core.config.settings.LOGIN_BANNER_ENABLED", True),
-            patch("app.core.config.settings.LOGIN_BANNER_TEXT", test_banner_text),
-            patch("app.core.config.settings.LOGIN_BANNER_CLASSIFICATION", test_classification),
-        ):
-            response = client.get("/api/auth/banner")
-            assert response.status_code == 200
-            data = response.json()
-            assert data["enabled"] is True
-            assert data["requires_acknowledgment"] is True
+        AuthConfigService.set_config(
+            db=db_session,
+            key="login_banner_enabled",
+            value=True,
+            is_sensitive=False,
+            category="banner",
+            user_id=admin_user.id,
+            data_type="bool",
+        )
+        AuthConfigService.set_config(
+            db=db_session,
+            key="login_banner_text",
+            value=test_banner_text,
+            is_sensitive=False,
+            category="banner",
+            user_id=admin_user.id,
+        )
+        AuthConfigService.set_config(
+            db=db_session,
+            key="login_banner_classification",
+            value=test_classification,
+            is_sensitive=False,
+            category="banner",
+            user_id=admin_user.id,
+        )
+
+        response = client.get("/api/auth/banner")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["requires_acknowledgment"] is True
+        assert data["text"] == test_banner_text
+        assert data["classification"] == test_classification
 
     def test_banner_acknowledgment_requires_authentication(self, client):
         """Test that banner acknowledgment requires authentication."""

--- a/backend/tests/unit/test_handler_and_ws_hardening.py
+++ b/backend/tests/unit/test_handler_and_ws_hardening.py
@@ -164,6 +164,79 @@ def test_websocket_auth_accepts_active_user_with_valid_token(monkeypatch):
     assert ws_module._try_authenticate_token("tok", db) is cast("User", active)
 
 
+@pytest.mark.asyncio
+async def test_websocket_endpoint_survives_session_close(db_session, normal_user, monkeypatch):
+    """Regression test: websocket_endpoint() itself must survive its own auth check.
+
+    websocket_endpoint() used to take ``db: Session = Depends(get_db)`` at the function
+    level. For an HTTP route that dependency is released right after the response, but
+    for a WebSocket route FastAPI only releases it when the handler *returns* — i.e. not
+    until the client disconnects, which can be hours later. That held a pooled DB
+    connection (and, worse, an uncommitted transaction — the auth query was never
+    committed) open for the connection's entire lifetime, which is exactly what let a
+    long-lived socket's leftover transaction block a schema migration waiting on the
+    same table (found via live traffic during the v0.5.0 dependency-upgrade session).
+
+    The fix scopes DB access to just the auth check via ``session_scope()``, which
+    commits and closes immediately. But that commit expires every attribute on the
+    returned ORM object by SQLAlchemy's default ``expire_on_commit``, and the only
+    attribute touched afterward (``user.id``, for ``manager.connect`` and
+    ``manager.disconnect``) then raised ``DetachedInstanceError`` on the now-closed
+    session — caught live, not by any existing test. The fix for *that* is
+    ``db.expunge(user)`` before each auth block exits/commits.
+
+    Calls the real ``websocket_endpoint()`` directly with a minimal fake ``WebSocket``
+    (driving it through Starlette's actual ASGI ``TestClient.websocket_connect`` hit an
+    unrelated, unexplained clean disconnect — nothing in this codebase tests the real
+    ``/ws`` route end-to-end yet, and chasing that was out of scope for this fix). This
+    still exercises the unmodified function body end to end, so removing either
+    ``db.expunge(user)`` call reintroduces the exact crash and fails this test.
+    """
+    import contextlib
+    from unittest.mock import AsyncMock
+
+    from fastapi import WebSocketDisconnect
+    from sqlalchemy.orm import Session
+
+    from app.api import websockets as ws_module
+    from app.core.security import create_access_token
+
+    # session_scope() normally opens its own SessionLocal() connection, which can't see
+    # normal_user (created on the test's savepoint-isolated db_session, never really
+    # committed). A session bound to db_session's own connection shares that same
+    # transaction/savepoint — so it CAN see normal_user — while still being a distinct
+    # Session object that can be genuinely committed and closed, the same way the real
+    # session_scope() is. That distinction matters here: DetachedInstanceError only
+    # fires once a session is truly gone, not merely committed, and db_session itself
+    # can't be closed without breaking the rest of the fixture/test machinery.
+    @contextlib.contextmanager
+    def _fake_session_scope():
+        scoped = Session(bind=db_session.connection())
+        try:
+            yield scoped
+            scoped.commit()
+        finally:
+            scoped.close()
+
+    monkeypatch.setattr(ws_module, "session_scope", _fake_session_scope)
+    # Not exercising Redis pub/sub here — irrelevant to the DB session bug, and a real
+    # subscribe attempt against an unreachable Redis would just add unrelated noise.
+    monkeypatch.setattr(ws_module, "setup_redis", lambda: None)
+
+    token = create_access_token(normal_user.uuid)
+
+    fake_ws = AsyncMock()
+    fake_ws.cookies = {"access_token": token}
+    # Ends the message loop immediately via the same path a real client disconnect
+    # takes, exercising manager.disconnect(websocket, user.id) too — the second of the
+    # two user.id accesses that follow the auth check.
+    fake_ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+    # No exception — especially no DetachedInstanceError — means both auth-block
+    # expunges are doing their job.
+    await ws_module.websocket_endpoint(fake_ws)
+
+
 # ── A0.8: startup assertions ─────────────────────────────────────────────────────
 
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,17 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      # Exclude the host's backend/venv/ (docs: `backend/CLAUDE.md`) from the container's
+      # view: every backend-image service already has its own venv baked in at
+      # /home/appuser/.local (Dockerfile.prod), so the host one is never used here. Without
+      # this, `pip install` (or even routine .pyc bytecode writes from running pytest
+      # against that venv) into backend/venv looks like a source change to `backend`'s
+      # `uvicorn --reload` watcher, forcing a full app reload — which can abandon any
+      # in-flight WebSocket connection's DB session mid-transaction, leaking an
+      # idle-in-transaction Postgres connection that then blocks schema migrations and
+      # anything else touching the same table. Same fix as `frontend`'s /app/node_modules
+      # exclusion below.
+      - /app/venv
       - ${MODEL_CACHE_DIR:-./models}/sentence-transformers:/home/appuser/.cache/sentence-transformers
     command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload  # Enable hot reload
     environment:
@@ -46,6 +57,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
       - ${MODEL_CACHE_DIR:-./models}/nltk_data:/home/appuser/.cache/nltk_data
@@ -60,6 +72,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
 
@@ -72,6 +85,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
 
   celery-redaction:
     image: opentranscribe-backend:latest
@@ -82,6 +96,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
 
@@ -94,6 +109,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
 
   celery-nlp-worker:
     image: opentranscribe-backend:latest
@@ -104,6 +120,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
 
   celery-embedding-worker:
     image: opentranscribe-backend:latest
@@ -114,6 +131,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/sentence-transformers:/home/appuser/.cache/sentence-transformers
 
   celery-beat:
@@ -125,6 +143,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
 
   frontend:
     image: opentranscribe-frontend:latest
@@ -184,6 +203,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
       - ${MODEL_CACHE_DIR:-./models}/nltk_data:/home/appuser/.cache/nltk_data
@@ -202,6 +222,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
       - ${MODEL_CACHE_DIR:-./models}/nltk_data:/home/appuser/.cache/nltk_data
@@ -218,6 +239,7 @@ services:
       dockerfile: Dockerfile.prod
     volumes:
       - ./backend:/app  # Mount source code for development
+      - /app/venv  # Exclude host backend/venv/ — see the `backend` service above for why
       - ${MODEL_CACHE_DIR:-./models}/huggingface:/home/appuser/.cache/huggingface
       - ${MODEL_CACHE_DIR:-./models}/torch:/home/appuser/.cache/torch
       - ${MODEL_CACHE_DIR:-./models}/nltk_data:/home/appuser/.cache/nltk_data

--- a/docs/research/openwhispr-comparison.md
+++ b/docs/research/openwhispr-comparison.md
@@ -125,14 +125,14 @@ OpenWhispr **does have real speaker diarization**, not a stub — but it's struc
 
 Comparing your 7 LLM providers against their 9 turns up three genuine gaps worth prioritizing, and several that aren't:
 
-| Provider | Verdict | Why |
-|---|---|---|
-| **Tinfoil** | **Add — highest priority** | Runs inference inside confidential-computing enclaves (TEEs) so not even the provider can see plaintext data — a cryptographic guarantee, not a policy promise. This is a better fit for *your* FIPS-140-3-aligned, FedRAMP-aligned enterprise/government positioning than it is for OpenWhispr's actual individual-user market. It would let compliance-sensitive customers get cloud-LLM speed/quality with a hard technical guarantee against provider-side exposure — strengthens a differentiator you already lead on rather than just closing a parity gap. |
-| **Gemini (Google)** | **Add** | You already integrate Google Cloud Speech for ASR but have no direct Google LLM path. Rounds out direct access to all three major labs (OpenAI/Anthropic/Google) instead of two, and Gemini's long-context models are a natural fit for your multi-section summarization stitching on long transcripts. |
-| **Groq** | **Add** | Not a model — an inference host (custom LPU silicon) running open models (Llama/Mixtral-class) at very low latency. Matters anywhere latency is user-visible: chat streaming, live-ish summarization. Your `openrouter` provider may already route to Groq-hosted models indirectly, but that's subject to OpenRouter's markup and routing choices, not a guaranteed low-latency path. |
-| Corti | Skip | Healthcare-vertical-specific (clinical note structuring, medical coding awareness) — only relevant if pursuing a healthcare vertical, which doesn't fit your current FedRAMP/government-leaning positioning. |
-| `enterprise` / `lan` | Skip | Conceptually already covered by your existing `custom` / `vllm` / `ollama` self-hosted-endpoint options. |
-| `openwhispr` | N/A | Their own hosted product, not a general-purpose provider pattern to borrow. |
+| Provider | Verdict | Issue | Why |
+|---|---|---|---|
+| **Tinfoil** | **Add — highest priority** | [#378](https://github.com/attevon-llc/OpenTranscribe/issues/378) | Runs inference inside confidential-computing enclaves (TEEs) so not even the provider can see plaintext data — a cryptographic guarantee, not a policy promise. This is a better fit for *your* FIPS-140-3-aligned, FedRAMP-aligned enterprise/government positioning than it is for OpenWhispr's actual individual-user market. It would let compliance-sensitive customers get cloud-LLM speed/quality with a hard technical guarantee against provider-side exposure — strengthens a differentiator you already lead on rather than just closing a parity gap. |
+| **Gemini (Google)** | **Add** | [#379](https://github.com/attevon-llc/OpenTranscribe/issues/379) (plain API) + [#382](https://github.com/attevon-llc/OpenTranscribe/issues/382) (Vertex AI, split out — see §11) | You already integrate Google Cloud Speech for ASR but have no direct Google LLM path. Rounds out direct access to all three major labs (OpenAI/Anthropic/Google) instead of two, and Gemini's long-context models are a natural fit for your multi-section summarization stitching on long transcripts. |
+| **Groq** | **Add** | [#380](https://github.com/attevon-llc/OpenTranscribe/issues/380) | Not a model — an inference host (custom LPU silicon) running open models (Llama/Mixtral-class) at very low latency. Matters anywhere latency is user-visible: chat streaming, live-ish summarization. Your `openrouter` provider may already route to Groq-hosted models indirectly, but that's subject to OpenRouter's markup and routing choices, not a guaranteed low-latency path. |
+| Corti | Skip | — | Healthcare-vertical-specific (clinical note structuring, medical coding awareness) — only relevant if pursuing a healthcare vertical, which doesn't fit your current FedRAMP/government-leaning positioning. |
+| `enterprise` / `lan` | Skip | — | Conceptually already covered by your existing `custom` / `vllm` / `ollama` self-hosted-endpoint options. |
+| `openwhispr` | N/A | — | Their own hosted product, not a general-purpose provider pattern to borrow. |
 
 ### Other capability gaps found while researching this (not provider-related)
 
@@ -230,6 +230,42 @@ Checked `openwhispr.com/pricing` directly (2026-08-09):
 
 ---
 
+## 11. Local and cloud model catalog — what they actually ship, model by model
+
+Pulled directly from `src/models/modelRegistryData.json` (structured registry: `localProviders`, `cloudProviders`, `enterpriseProviders`, `openwhisprCloudModels`), not from marketing copy.
+
+### Local models (6 families, all `.gguf` via llama.cpp, fetched on-demand from Hugging Face — see §5 for the download-on-first-use mechanism)
+
+| Family | Count | Size range | Notable |
+|---|---|---|---|
+| **Liquid AI** | 5 | 230M – 8B (MoE) | `LFM2.5-1.2B-Instruct` is their **recommended** default — "excellent instruction following." Also `LFM2.5-230M`/`350M` ("instant cleanup on modest hardware") and `LFM2.5-8B-A1B`, a MoE with only ~1.5B active params. Purpose-picked for *dictation cleanup* latency, not general chat. |
+| Qwen | 12 | 1.5B – 32B | Qwen3.5-9B-Q4_K_M is top recommended ("powerful hybrid model," 262K context) |
+| Gemma (Google) | 11 | 1B – 31B | Includes Google's official QAT (quantization-aware training) builds — smaller size, quality preserved; `gemma-4-e4b-it-qat` recommended |
+| Mistral | 3 | 7B – 12B | Mistral Nemo 12B recommended |
+| Meta Llama | 3 | 1B – 8B | Llama 3.2 3B recommended |
+| OpenAI OSS | 1 | 20B | `gpt-oss-20b-mxfp4`, recommended |
+
+**This is not a functional gap on our side.** Our local LLM path (`vllm`/`ollama`) already accepts any GGUF/HF model a user points it at, Liquid AI included — OpenWhispr's actual edge here is a curated download-picker UI (pick a model, it fetches the right quant automatically), not model access itself. What *is* missing: we have zero mentions of Liquid AI or LFM2 anywhere in `docs/` (verified by grep). Their design intent — small, fast, strong at instruction-following for lightweight tasks — maps well onto things like our redaction/tagging LLM calls or lighter chat scoping. Adding a "recommended local models" section to the Ollama/vLLM setup docs is cheap, closes a real awareness gap, and requires no code.
+
+### Cloud models, current line-up per provider
+
+- **OpenAI**: GPT-5.6 (Sol/Terra/Luna variants), 5.5, 5.2, 5-mini/nano, 4.1 family
+- **Anthropic**: Claude Opus 5, Sonnet 5, Fable 5, Haiku 4.5, plus older Opus/Sonnet 4.x
+- **Gemini**: 3.5 Flash, 3.1 Pro, 3 Flash, 2.5 Flash Lite, plus Gemma 4 hosted variants
+- **Groq**: Qwen3 32B, GPT-OSS 120B/20B, Llama 3.3 70B, Llama 3.1 8B, plus their own agentic "Compound"/"Compound Mini" models
+- **Tinfoil**: Kimi K2.6, GLM-5.2, GPT-OSS 120B, Gemma 4 31B
+- **Corti**: their own S1/S1-mini models (healthcare-specific — still a skip per §4)
+
+**Tinfoil model-provenance note, relevant to issue #378**: Kimi K2 is Moonshot AI's model and GLM-5 is Zhipu AI's — both Chinese labs' open-weight releases, running inside Tinfoil's confidential-computing enclaves alongside GPT-OSS and Gemma. Tinfoil's core value prop (data confidentiality via TEE attestation) is unaffected by this, but for a FIPS/FedRAMP-aligned product, model *provenance* — not just data confidentiality — may matter to some government/enterprise customers. Before shipping Tinfoil as a default option, confirm whether their API lets us pin/restrict to a specific model (e.g., GPT-OSS/Gemma only) rather than exposing their full catalog. Doesn't block the issue, just needs a decision during implementation.
+
+**Enterprise routing gap — resolved into two issues**: OpenWhispr's `enterpriseProviders` list includes `bedrock` (AWS), `azure` (Azure OpenAI), **and `vertex` (GCP Vertex AI)**. We already have Bedrock; we don't have Vertex AI, and it's architecturally distinct enough from a plain Gemini API key (IAM/ADC-based credentials, no stored secret, same shape as `BEDROCK`'s boto3 Converse pattern in `backend/app/services/llm_bedrock.py`) that it needed its own issue rather than folding into #379. Split as: **#379** now scoped to the plain Google AI Studio Gemini API (generic API-key provider, same pattern as `OPENAI`/`ANTHROPIC`), **#382** for Vertex AI as a new SDK-based provider mirroring `BEDROCK` exactly (own `SDK_PROVIDERS` entry, own `llm_vertex.py` module, ADC credential chain, no per-user API key).
+
+### One more structural note: OpenWhispr Cloud is itself a curated proxy, not a proprietary model
+
+`openwhisprCloudModels` (their own hosted tier definitions) routes "Fast" through Groq (Llama 3.3 70B / 3.1 8B) and "Balanced"/"Quality" through OpenRouter (Claude Sonnet 4.6/Opus 4.8, Gemini 2.5 Flash, GPT-4.1). Their paid cloud product has no model of its own — it's a curated, marked-up proxy over providers we're evaluating adding directly (Groq) or already have indirect access to (OpenRouter). Worth knowing if the pricing comparison in §10 ever comes up in a sales conversation — their Pro/Business tiers are largely priced access to the same underlying models available via API elsewhere.
+
+---
+
 ## Appendix: file/function citations for this report
 
 - Transcription: `src/helpers/whisperServer.js` (spawn, args, HTTP POST, `--no-timestamps` rationale), `src/helpers/audioManager.js` (`MediaRecorder` batch path, `AudioWorkletProcessor` streaming path), `src/helpers/ffmpegUtils.js` (WAV conversion), `scripts/download-whisper-cpp.js`.
@@ -244,3 +280,6 @@ Checked `openwhispr.com/pricing` directly (2026-08-09):
 - Video support gap: `src/components/notes/UploadAudioView.tsx:1433` (accept list), `src/helpers/urlAudioDownloader.js:929-930` (`-x --audio-format`), `src/helpers/audioStorage.js` (`.webm`-only storage); OpenTranscribe contrast: `backend/app/services/storage_recovery_service.py`, `backend/app/services/media_download_service.py`, `frontend/src/components/VideoPlayer.svelte`, `PlyrMiniPlayer.svelte`.
 - LLM provider inventory: `src/services/ai/inferenceProviders/*.ts` (OpenWhispr), `backend/app/services/llm_service.py:42` (`LLMProvider` enum, OpenTranscribe).
 - Other gaps: MCP/API absence verified by repo-wide grep of `backend/app` and `docs/`; live-ASR absence verified via `backend/app/api/websockets.py`; custom vocabulary confirmed via `backend/app/api/endpoints/custom_vocabulary.py`; existing tracked issues checked via `gh issue list --repo attevon-llc/OpenTranscribe` (#365 Recall.ai meeting capture, #366 NVIDIA Parakeet/Canary).
+- Model catalog (local + cloud, all providers, including Liquid AI/LFM2.5, Tinfoil's model list, and the `vertex`/`bedrock`/`azure` `enterpriseProviders` list): `src/models/modelRegistryData.json`. Confirmed no `docs/` mentions of "liquid" or "lfm2" on our side via repo-wide grep.
+- Bedrock-as-SDK-provider precedent used to scope the Vertex AI issue: `backend/app/services/llm_bedrock.py` (module docstring), `backend/app/services/llm_service.py:48,56` (`SDK_PROVIDERS`), `backend/app/core/config.py:923-930` (`BEDROCK_REGION`/`BEDROCK_MODEL_NAME` settings pattern).
+- Issues opened from this analysis: #378 (Tinfoil), #379 (Gemini — plain API), #380 (Groq), #382 (GCP Vertex AI — SDK-based, split from #379).

--- a/docs/research/openwhispr-comparison.md
+++ b/docs/research/openwhispr-comparison.md
@@ -1,0 +1,246 @@
+# OpenTranscribe vs. OpenWhispr — Competitive & Technical Comparison
+
+**Research date:** 2026-08-09
+**Sources:** `github.com/OpenWhispr/openwhispr` (cloned locally at `/mnt/nvm/repos/openwhispr`, MIT license), cross-referenced against `/mnt/nvm/repos/transcribe-app` (backend code, `docs/ARCHITECTURE.md`, `docs/combined-engine-design.md`, `docs/diarization-boundary-results/`, `CHANGELOG.md [0.4.0]`, `README.md`).
+**Scope:** Code-level research only. No code in either repo was modified as part of this document.
+
+---
+
+## 1. What each project actually is
+
+| | **OpenTranscribe** | **OpenWhispr** |
+|---|---|---|
+| Form factor | Self-hosted web platform, Docker Compose, multi-container | Native desktop app (Electron), single install, single user |
+| Target user | Teams/orgs — multi-user, self-hosted or enterprise deployment | Individual — dictation + meeting notes on your own machine |
+| Core use case | Upload/record files, transcribe, diarize, search a library, chat with a knowledge base of recordings | Push-to-talk dictation into any app, live meeting notes with speaker ID, local AI notes/chat |
+| License | (Attevon LLC, not MIT per your CLAUDE.md constraints) | **MIT** — confirmed, `LICENSE`: `Copyright (c) 2024 OpenWhispr Team` |
+| Codebase size | Backend alone spans dozens of services/tasks across a distributed system | 587 files / **~128,000 LOC** in `src/` (JS/TS), 61 runtime deps + 23 dev deps in `package.json` |
+
+These are not really the same product wearing different clothes — OpenWhispr is architecturally a **local-first dictation/meeting-notes desktop app**; OpenTranscribe is a **multi-tenant transcription platform**. The overlap is real (both do Whisper-based ASR + speaker diarization + AI chat over transcripts), but the design centers are different, which explains most of the size/complexity gap below. That said, OpenWhispr's *implementation techniques* are genuinely worth studying — several are things a heavier platform can also use.
+
+---
+
+## 2. Transcription: how each actually does it
+
+### OpenWhispr (code-level, verified)
+
+- **Local engine**: `whisper.cpp`, run as a **separately compiled C++ binary** (`whisper-server`), spawned via `child_process.spawn` from Electron's main process (`src/helpers/whisperServer.js:532`). Not a Node addon, not Python — a per-platform binary (`whisper-server-<platform>-<arch>[-cuda|-vulkan]`) pulled from OpenWhispr's own `whisper.cpp` fork (pinned tag `0.0.8`) at **build time**, not bundled generically for all platforms.
+- **Audio path (dictation)**: browser `MediaRecorder` → single `Blob` → written to temp file → **ffmpeg** (via `ffmpeg-static`) converts to **16kHz mono 16-bit PCM WAV** (hard requirement of whisper.cpp) → one multipart/form-data POST (hand-built, no `form-data` package) to `whisper-server`'s local HTTP `/inference` endpoint → single JSON response parsed. **Strictly batch — no partial/streaming results for local transcription.**
+- **`--no-timestamps` is used deliberately** — a comment in the code documents a whisper.cpp v1.9.x regression that corrupts word timestamps under their line-wrap mode, so they disable timestamp mode entirely and just take the plain text. **This means OpenWhispr dictation transcripts have no word-level timestamps at all** — a real capability gap vs. OpenTranscribe, where word/segment-level timestamps are foundational (needed for the whole diarization-merge and boundary-correction pipeline).
+- **Streaming does exist, but only for 3 cloud providers** (Deepgram, AssemblyAI, OpenAI Realtime) — those use a completely different capture path: an inline `AudioWorkletProcessor` converting Float32 → Int16 PCM in an 800-sample ring buffer, streamed over WebSocket. Local whisper.cpp never streams.
+- **No deterministic post-processing** (no punctuation restoration module, no formatting rules found). Optional "cleanup" is an **LLM rewrite pass** (`wrapCleanupTranscript`), not a dedicated ASR post-processor.
+- **Meeting capture** is architecturally distinct from dictation: continuous raw 24kHz PCM to disk, replayed through diarization at meeting end.
+
+### OpenTranscribe (for contrast)
+
+- Local: faster-whisper/WhisperX on GPU (with word-level timestamp alignment as a first-class output, since diarization merge depends on it). Also 10 pluggable cloud ASR providers (Deepgram, AssemblyAI, OpenAI, Google, Azure, AWS, Speechmatics, Gladia, pyannote.ai) via a factory abstraction (`backend/app/services/asr/factory.py`).
+- 3-stage Celery pipeline (`preprocess → gpu → postprocess`) rather than a single-process HTTP round trip — built for concurrent multi-user throughput, not single-user latency.
+
+**Takeaway**: OpenWhispr's local transcription is legitimate and simple (subprocess + HTTP + ffmpeg), but it deliberately sacrifices word-level timestamps for local dictation, which is a real capability OpenTranscribe has that OpenWhispr does not. It's a fair trade for a dictation tool (you're pasting the text, not indexing it), but it would be a regression if it were used as-is for a searchable multi-file archive.
+
+### No video support, anywhere — confirmed in code
+
+The README claims "transcribe existing audio **and video**," but this doesn't hold up once traced through the code:
+
+- **File upload is audio-only.** `src/components/notes/UploadAudioView.tsx:1433` — `accept=".mp3,.wav,.m4a,.webm,.ogg,.oga,.flac,.aac,.opus"`. No `.mp4`, `.mov`, `.mkv`, or `.avi` anywhere in the accept list.
+- **Even the video-URL import path strips video immediately.** The YouTube/URL downloader calls yt-dlp with `-x --audio-format` (`src/helpers/urlAudioDownloader.js:929-930`) — yt-dlp's audio-extraction flag. So pasting a YouTube URL never gives the app a video file to work with; it downloads and discards the video stream before the app ever sees it.
+- **No video playback UI exists at all** — zero `<video>` tags anywhere in `src/components`. Every stored recording is `.webm` audio (`audioStorage.js`), consistent with the app's identity as a dictation/notes tool, not a media library.
+- **OpenTranscribe, for contrast**: `.mp4/.mkv/.mov/.avi` are first-class accepted upload types with dedicated content-type handling (`backend/app/services/storage_recovery_service.py`, `backend/app/services/media_download_service.py`), and there's a real in-app video player (`frontend/src/components/VideoPlayer.svelte`, `PlyrMiniPlayer.svelte`) — you can upload a video file and watch it alongside its transcript, not just extract audio from it.
+
+This is a genuine, verifiable capability gap, not a nuance — "transcribe existing audio and video" in their README overstates what the product does; it transcribes audio, including audio *pulled from* video sources, but never handles or plays video itself.
+
+---
+
+## 3. Diarization: how each actually does it — this is the section that matters most to you
+
+### OpenWhispr's diarization, traced end to end
+
+OpenWhispr **does have real speaker diarization**, not a stub — but it's structurally simpler and less tuned than what you've built. Two separate mechanisms:
+
+**(a) Offline/batch diarization (the one that produces the final transcript labels)**
+
+1. Trigger: at meeting end (`src/helpers/ipcHandlers.js:9685`), raw 24kHz PCM → resampled to 16kHz mono WAV.
+2. Spawns a **separately compiled binary**, `sherpa-onnx-diarize` (from `k2-fsa/sherpa-onnx` releases — not written by OpenWhispr), via `child_process.spawn`, with CLI flags:
+   ```
+   --segmentation.pyannote-model=<path>
+   --embedding.model=<path>
+   --clustering.num-clusters=<n>
+   --clustering.cluster-threshold=<t>
+   --min-duration-on=0.2  --min-duration-off=0.5
+   ```
+3. **Segmentation model**: `sherpa-onnx-pyannote-segmentation-3-0` — this is **pyannote's own segmentation-3.0 model**, exported to ONNX by the sherpa-onnx project. Same model family you use, just ONNX-exported and run through a compiled binary instead of PyTorch.
+4. **Embedding model**: `3dspeaker_speech_campplus_sv_en_voxceleb_16k.onnx` — a CAM++ speaker-verification model (VoxCeleb-trained). **Not** the WeSpeaker 256-dim embeddings your fork uses — a different embedding model entirely.
+5. **Clustering**: agglomerative clustering happens *inside the compiled sherpa-onnx binary* — not visible/vendored source in the OpenWhispr repo itself, just consumed via CLI flags (`num-clusters=-1` for auto-detect, `cluster-threshold=0.55` default).
+6. **Output**: plain-text stdout lines (`start -- end speaker_N`), regex-parsed.
+7. **Post-processing found**: exactly one — `capSpeakerClusters()`, a pure-JS pass that sums per-speaker duration and collapses any speaker beyond a target count into the dominant speaker. **No boundary-smoothing, no acoustic re-check, no WSER-style tuning of any kind was found anywhere in the repo.**
+8. **Transcript merge**: segment-level (not word-level) overlap between diarization segments and transcript segments — `overlap = min(segEnd, dSeg.end) - max(segStart, dSeg.start)`, picks the diarization label with max overlap, falls back to nearest-midpoint distance. Mic-sourced audio is unconditionally labeled "you" (no diarization needed for the local speaker at all in the meeting-notes use case).
+9. **Where the transcript-side timestamps actually come from, given `--no-timestamps` is set** (this looked like a contradiction until traced): `--no-timestamps` is a single flag passed once to the shared `whisper-server` process (`whisperServer.js:151`) — it applies to *every* call to that server, dictation and meetings alike, so Whisper itself never emits timing info for either path. The `seg.timestamp` the merge code reads (`diarization.js:471-472`, confirmed via `audioManager.js:1077`) is instead `(Date.now() - recordingStartTime) / 1000` — a JS-side wall-clock stamp of when the app *sent* that chunk, not anything Whisper computed. Segment end is then approximated as either the next chunk's capture timestamp or `segStart + 2.5s`. The diarization side, by contrast, has real model-derived timing from the sherpa-onnx segmentation pass. So the merge is fundamentally *rough capture-order chunk boundaries* (transcript) matched against *precise model timing* (diarization) — which is the underlying reason the merge has to be segment-level rather than word-level: there's no fine-grained transcript-side timing to align against in the first place, not just a design choice.
+
+**(b) Live/online diarization (provisional labels during the meeting)**
+
+- Runs in parallel via `onnxruntime-node` (a real Node native addon, not a subprocess) doing Silero VAD scoring + CAM++ embedding extraction on speech windows.
+- Simple nearest-centroid clustering in plain JS (`_findNearestTransient`, cosine similarity against running centroids) — no formal clustering algorithm, just running centroids with a similarity threshold.
+- Purely for responsive UI labels while the meeting is live; **the offline sherpa-onnx pass is what determines the final transcript labels** — live labels get overwritten.
+
+**(c) Cross-meeting speaker memory** — a feature you may want to look at:
+
+- SQLite tables (`speaker_profiles`, `speaker_mappings`, `note_speaker_embeddings`) persist a 512-dim CAM++ embedding **only when a user manually renames a speaker** (e.g. "Speaker 1" → "Alice") — this is explicit, one-time, per-person, not automatic bulk clustering across your whole library.
+- Future-meeting matching: cosine similarity against every stored profile, requiring **both** an absolute similarity floor (`MATCH_THRESHOLD = 0.65`) **and** a margin over the second-best candidate (`MATCH_MARGIN = 0.03`) — specifically to avoid confidently mislabeling similar-sounding voices.
+- Profile embeddings update via exponential moving average (`0.3 * new + 0.7 * stored`) rather than being overwritten, so a profile stabilizes over repeated meetings with the same person.
+- This is conceptually similar in spirit to your cross-file speaker matching via OpenSearch kNN, but implemented as a simple local SQLite + cosine-similarity scheme rather than a search-cluster-backed system. It works because it's single-user/local-scale, not library/org-scale.
+
+### Direct comparison to your pipeline
+
+| | **OpenTranscribe** | **OpenWhispr** |
+|---|---|---|
+| Segmentation model | pyannote v4, your GPU-optimized fork (`davidamacey/pyannote-audio@gpu-optimizations`) | Stock pyannote segmentation-3.0, ONNX-exported by a third party (sherpa-onnx) |
+| Embedding model | WeSpeaker 256-dim | CAM++ (3D-Speaker/VoxCeleb) — different model family |
+| Batch-size / VRAM tuning | Explicit, fixed at 16, DER-invariance validated 1–128 | Not applicable — CPU-side ONNX Runtime, no batch-size tuning surfaced |
+| Boundary correction | Custom 2-stage: boundary smoothing (**-32% WSER**, default on) + acoustic backchannel re-check (**+15% more**, opt-in) | **None found.** Only post-hoc speaker-count capping. |
+| Word- vs. segment-level speaker assignment | Word-level (needed for boundary smoothing to work at all) | Segment-level overlap only |
+| Benchmarked accuracy | 0.27% WSER on your hand-labeled clip, tied for best of 7 engines incl. AWS/AssemblyAI/pyannote.ai/Speechmatics; DER@0.25 ≈ 0.22 on AMI, matching published pyannote figures | No published accuracy benchmarks found in the repo (no equivalent of your `docs/diarization-boundary-results/`) |
+| Cross-recording speaker ID | OpenSearch kNN voiceprint matching across the entire multi-user library, gender-informed cluster validation | SQLite cosine-similarity match against manually-named local profiles only |
+| Hardware flexibility | CUDA GPU (incl. Blackwell), hybrid CPU+MPS mode, multi-GPU split | CPU-only ONNX Runtime for embeddings/VAD; diarization binary presumably CPU (no CUDA flag seen in the sherpa-onnx-diarize invocation) |
+
+**Bottom line on diarization**: your concern about someone else's "similar and lighter" tool not actually doing the job well is well-founded here, and the evidence supports it directly — OpenWhispr uses an out-of-the-box pyannote segmentation model with no boundary-correction tuning and no published accuracy validation, while you have empirical, benchmarked evidence that your tuned pipeline **ties premium commercial cloud diarization APIs** on speaker-boundary accuracy. This is a legitimately strong, defensible differentiator, not marketing language — it's something you can cite (your own `docs/diarization-boundary-results/cloud-comparison.md`) that a lightweight competitor plainly has not done. The one thing worth borrowing conceptually is not a diarization algorithm improvement but the **speaker-count capping heuristic** (collapsing over-clustered minor speakers into the dominant one by cumulative duration) — simple, cheap, and complementary to what you already do; worth checking whether your pipeline already handles the "too many spurious speakers" failure mode as gracefully.
+
+---
+
+## 4. Model / API connections
+
+### OpenWhispr
+
+- **ASR**: local whisper.cpp (any GGML model size the user downloads) + cloud streaming (Deepgram, AssemblyAI, OpenAI Realtime, and **Corti** — healthcare-specific ambient/clinical streaming STT, `cortiStreaming.js`) + local NVIDIA **Parakeet** (fast multilingual ASR model, run via sherpa-onnx/ONNX as a local Whisper alternative, not a cloud provider).
+- **LLM**: local `llama-server` (llama.cpp, GGUF models) + 9 cloud/network providers, one file each in `src/services/ai/inferenceProviders/`: `openai`, `anthropic`, `gemini`, `groq`, `enterprise`, `lan` (generic OpenAI-compatible LAN endpoint), `tinfoil`, `corti`, `openwhispr` (their own hosted cloud).
+- **Provider abstraction**: one thin file per provider (`anthropic.ts`, `groq.ts`, etc.), registered in `inferenceProviders/index.ts`'s `PROVIDER_REGISTRY` — simpler than a factory-catalog pattern since there's no per-user credential encryption/multi-tenant concern to design around.
+- **No LDAP/OIDC/SAML/PKI, no per-user encrypted API key storage** — makes sense, it's a single-user local app; there's exactly one user, so provider credentials are just local config, not a security-sensitive multi-tenant concern.
+
+### OpenTranscribe (for contrast, already documented in your codebase)
+
+- 10 ASR providers, 7 LLM providers (`openai`, `vllm`, `ollama`, `anthropic`, `openrouter`, `custom`, `bedrock` — `backend/app/services/llm_service.py:42`, a single `LLMProvider(StrEnum)` with per-provider branches, not a per-file pattern), per-user AES-256-GCM encrypted API keys, PBKDF2-SHA256 600k iterations — this is solving a different problem (multi-tenant credential isolation) that OpenWhispr's design doesn't need to address at all.
+
+**What you can learn**: OpenWhispr's per-provider file pattern (`inferenceProviders/local.ts`, `.../deepgram.ts`, etc., each self-contained) is clean and easy to extend — worth comparing against your single-enum-with-branches pattern in `llm_service.py` for long-term maintainability as you add more providers, though your version has to handle strictly more (per-user settings resolution, encrypted secrets, shared-config permissions) that a single-user app doesn't.
+
+### LLM provider gap analysis — what's actually worth adding
+
+Comparing your 7 LLM providers against their 9 turns up three genuine gaps worth prioritizing, and several that aren't:
+
+| Provider | Verdict | Why |
+|---|---|---|
+| **Tinfoil** | **Add — highest priority** | Runs inference inside confidential-computing enclaves (TEEs) so not even the provider can see plaintext data — a cryptographic guarantee, not a policy promise. This is a better fit for *your* FIPS-140-3-aligned, FedRAMP-aligned enterprise/government positioning than it is for OpenWhispr's actual individual-user market. It would let compliance-sensitive customers get cloud-LLM speed/quality with a hard technical guarantee against provider-side exposure — strengthens a differentiator you already lead on rather than just closing a parity gap. |
+| **Gemini (Google)** | **Add** | You already integrate Google Cloud Speech for ASR but have no direct Google LLM path. Rounds out direct access to all three major labs (OpenAI/Anthropic/Google) instead of two, and Gemini's long-context models are a natural fit for your multi-section summarization stitching on long transcripts. |
+| **Groq** | **Add** | Not a model — an inference host (custom LPU silicon) running open models (Llama/Mixtral-class) at very low latency. Matters anywhere latency is user-visible: chat streaming, live-ish summarization. Your `openrouter` provider may already route to Groq-hosted models indirectly, but that's subject to OpenRouter's markup and routing choices, not a guaranteed low-latency path. |
+| Corti | Skip | Healthcare-vertical-specific (clinical note structuring, medical coding awareness) — only relevant if pursuing a healthcare vertical, which doesn't fit your current FedRAMP/government-leaning positioning. |
+| `enterprise` / `lan` | Skip | Conceptually already covered by your existing `custom` / `vllm` / `ollama` self-hosted-endpoint options. |
+| `openwhispr` | N/A | Their own hosted product, not a general-purpose provider pattern to borrow. |
+
+### Other capability gaps found while researching this (not provider-related)
+
+- **MCP server — real gap.** OpenWhispr ships a public API and an MCP (Model Context Protocol) server (README: "Public API & MCP... manage notes and transcriptions programmatically or connect your AI assistant"), Pro-tier and up. OpenTranscribe has no MCP server anywhere in `backend/app` or `docs/` (verified by grep — the only hit was this document). Given your product already centers on "AI chat over your transcripts," an MCP server would let Claude/other agents use OpenTranscribe as a tool directly (search transcripts, pull summaries, query speakers) rather than only being usable through your own chat UI. Worth a scoping discussion, not just a provider add — larger than the LLM-provider issues below.
+- **Live/real-time meeting transcription — confirmed non-gap-by-design, but worth naming.** OpenWhispr auto-detects Zoom/Teams/FaceTime calls and transcribes+diarizes live as the meeting happens. OpenTranscribe is verified file-based/batch-only: `backend/app/api/websockets.py` exists but is purely a server→client push-notification channel (job progress, broadcast) — no provider or endpoint takes live audio-in for streaming transcription. This matches the project's own documented constraint (no real-time/streaming ASR claims). Not a quick fix — it's a different architecture, not a missing provider — but it's already tracked at the "ingest live meetings" level by existing issue **#365** ("Recall.ai meeting capture — ingest meetings, transcripts, speakers and metadata into the same library"), which takes the bot-ingestion route rather than building native live capture.
+- **Custom vocabulary — not a gap, you're already there.** OpenTranscribe has `backend/app/api/endpoints/custom_vocabulary.py` and `backend/app/models/custom_vocabulary.py`, wired into at least the AssemblyAI provider. No need to chase this one.
+- **NVIDIA Parakeet (local ASR)** — already tracked as issue **#366** ("NVIDIA NeMo (Parakeet / Canary) as a first-class local transcription engine"), so no new issue needed there either.
+
+---
+
+## 5. How OpenWhispr keeps the install small — the actual mechanism
+
+This is the most transferable lesson, and it's a clear, replicable pattern:
+
+1. **No PyTorch, no CTranslate2, anywhere in the codebase.** Confirmed by a repo-wide grep — zero matches for `pytorch`, `torch`, `ctranslate2`. This is the single biggest size lever: a Python+PyTorch+CUDA stack is multiple GB before you've added a single model; OpenWhispr never pays that cost because it never uses that stack.
+2. **All heavy inference runs through compiled, statically-linked native binaries, not embedded runtimes**: `whisper-server` (whisper.cpp/GGML), `llama-server` (llama.cpp/GGUF), `sherpa-onnx-diarize` (ONNX Runtime statically linked inside the binary), `qdrant` (Rust binary for vector search). Each is a small, purpose-built C++/Rust binary instead of a general-purpose ML framework — GGML/ONNX Runtime compiled binaries are on the order of tens of MB, not gigabytes.
+3. **Binaries are fetched per-platform at build time, not bundled for every OS/arch.** `scripts/download-whisper-cpp.js`, `download-llama-server.js`, `download-sherpa-onnx.js`, `download-qdrant.js` each pull exactly one binary for the target platform/arch during `prebuild:*` — a macOS installer never carries Windows/Linux binaries.
+4. **Model *weights* are not bundled in the installer at all.** The prebuild scripts fetch the *inference engine binaries* and small auxiliary models (VAD, diarization segmentation/embedding models — these are small, tens of MB), but the actual Whisper transcription model weights (tiny/base/small/medium/large) and any local LLM GGUF weights are downloaded **on first use, chosen by the user**, via `modelManagerBridge.js` at runtime from Hugging Face. This is the same trick MacWhisper and similar tools use: ship an empty shell, let the user's first-run experience pull only the model size they actually want.
+5. **`electron-builder`'s `files` allowlist explicitly excludes dev tooling** from the packaged app — `typescript`, `eslint`, `vite`, `rollup`, `postcss`, `electron-builder` itself, etc. are all excluded via `!**/node_modules/<pkg>/**` globs, even though they're in `node_modules` during development.
+6. **`onnxruntime-node`** is used narrowly (VAD scoring, standalone embedding extraction) rather than pulled in for everything — ONNX Runtime's native addon is a fraction of PyTorch's footprint for inference-only workloads.
+
+**What's directly applicable to your `Dockerfile.lite`**: you already have the core idea right (`requirements-lite.txt`, CPU-only, ~2-3GB vs ~12-13.8GB full). The OpenWhispr pattern confirms the biggest remaining lever if you ever wanted to shrink further would be replacing any PyTorch-based CPU inference paths with ONNX Runtime or GGML-based equivalents (e.g., `faster-whisper` already uses CTranslate2, which is much lighter than raw PyTorch — worth checking whether `requirements-lite.txt` still pulls in a full `torch` wheel for anything, e.g. sentence-transformers for embeddings, since that's exactly the kind of dependency OpenWhispr avoids entirely by using ONNX Runtime for its embedding models instead).
+
+---
+
+## 6. Search and "AI chat" without OpenSearch
+
+- **Vector store**: **Qdrant**, run as a standalone compiled Rust binary (`src/helpers/qdrantManager.js:97`, `spawn(binaryPath, ["--config-path", configPath], ...)`), downloaded via `scripts/download-qdrant.js` — same sidecar-binary pattern as the ASR/diarization/LLM engines. Not embedded-in-process; a local server the app talks to over localhost.
+- **Embeddings**: a local MiniLM-class model run through `onnxruntime-node` in a worker thread (same worker that handles speaker embeddings) — no OpenAI embeddings API dependency for local-only usage.
+- **No BM25/full-text engine equivalent to OpenSearch was identified** — search appears to be vector-similarity-only via Qdrant, not a hybrid BM25+vector approach like your `HybridSearchService` (RRF fusion). This is a meaningful capability gap on OpenWhispr's side: pure semantic search without keyword/exact-match fallback will underperform on things like exact names, jargon, or short technical terms that dense embeddings handle poorly. Your hybrid RRF approach is more robust for this reason.
+- **Why they can skip OpenSearch and you can't (by design)**: Qdrant-as-a-binary is a single-user, single-tenant, embedded-scale vector index — no cluster, no sharding, no multi-tenant filtering, no ML Commons plugin. Your OpenSearch deployment does double duty (full-text + neural search + multi-tenant org-scoping + redaction-aware snippet masking), which is inherently a heavier, cluster-capable system because it's serving concurrent multi-org queries at library scale, not one person's local notes.
+- **AI chat**: LLM providers (local llama-server or cloud) generate answers grounded in Qdrant-retrieved context — architecturally the same RAG shape as your chat pipeline (retrieve → prompt → generate), just without your scoping/redaction/reranking/governance layers, which again are multi-tenant-specific concerns a single-user app doesn't need.
+
+**What you can learn**: Qdrant is a legitimately interesting lightweight alternative to consider for any future single-tenant/self-hosted-lite deployment profile — it's a much smaller footprint than an OpenSearch cluster if you ever wanted a genuinely minimal "OpenTranscribe Lite" single-user mode that doesn't need multi-tenant search. It would not replace OpenSearch for your primary product, but the pattern of "compiled vector-DB binary spawned as a sidecar" is worth knowing about as an option.
+
+---
+
+## 7. What you can concretely borrow (MIT license permits direct reuse)
+
+Ranked by how directly transferable each is to your codebase:
+
+1. **Speaker-count capping post-process** — cheap, simple, complements your existing pipeline; check if you already handle over-clustering as gracefully (`capSpeakerClusters` logic: sort by cumulative speaking duration, keep top-N, collapse the rest into the dominant speaker).
+2. **On-demand model weight downloads instead of bundling** — if not already true of every deployment mode, confirm your Docker images don't bake in every ASR model size; if they do, consider a first-run download flow for optional/larger model variants to shrink base images further.
+3. **Per-provider file pattern for LLM inference** (`inferenceProviders/<name>.ts`, one file per provider, thin and uniform) — worth a structural comparison against your ASR/LLM factory pattern for long-term maintainability, even though your factory needs to do more.
+4. **Sidecar-binary pattern for CPU-bound auxiliary inference** (VAD, small embedding models) via ONNX Runtime instead of full PyTorch, if you have any CPU-mode paths still pulling in `torch` for lightweight tasks.
+5. **Cross-session speaker memory via simple threshold+margin matching** (`similarity >= floor AND similarity - second_best >= margin`) — a nice, easy-to-explain heuristic for avoiding false-positive speaker identity matches; worth comparing against whatever confidence-scoring your own speaker-ID suggestion feature uses.
+
+What is **not** worth borrowing: their diarization tuning itself (yours is measurably better and validated), their lack of word-level timestamps in local dictation mode, and their lack of hybrid full-text+vector search (their pure-vector approach is a known weakness, not a strength).
+
+---
+
+## 8. Where OpenTranscribe is a clear market differentiator
+
+Independent of anything above, these are capabilities a single-user desktop tool like OpenWhispr structurally cannot offer, because they only make sense at multi-user/organizational scale:
+
+- **Empirically validated diarization accuracy** tying premium commercial cloud APIs (AWS Transcribe, pyannote.ai, AssemblyAI, Speechmatics) — a rare, citable, benchmarked claim most competitors (lightweight or not) don't have.
+- **Multi-user, multi-tenant architecture**: organizations, RBAC, collection sharing, per-org search scoping.
+- **Enterprise identity**: LDAP/AD, OIDC (7 named IdPs), SAML 2.0, PKI/CAC-PIV smart cards, SCIM 2.0 provisioning, reverse-proxy header auth — six methods simultaneously.
+- **Compliance posture**: audit logging (AU-2/AU-3), FedRAMP-aligned controls (IA-5/AC-7/AC-8), FIPS 140-3 aligned crypto — none of this is meaningful for a local single-user app.
+- **Hybrid BM25+vector search at library scale** with multi-tenant filtering, vs. OpenWhispr's pure-vector single-user index.
+- **Governed RAG chat**: scoped by recording/collection/tag/speaker, redaction-masked before hitting any LLM (fails closed), layered system prompts with non-overridable base rules, per-tenant narrowing-only settings cascade — a compliance-aware chat feature, not just "ask your notes."
+- **Cross-file speaker intelligence at library scale** via OpenSearch kNN across an entire multi-user corpus, vs. OpenWhispr's local SQLite table of manually-named profiles.
+- **Automated ingestion** (Watch Sources: S3/SMB/local folder polling with dedup) for team workflows, vs. OpenWhispr's manual per-recording flow.
+- **Horizontal scalability**: 6+ specialized Celery workers, multi-GPU split/scale modes, Flower monitoring — built to serve many concurrent users, not one.
+
+The honest framing for positioning: OpenWhispr is a well-built, genuinely capable **personal dictation and meeting-notes tool** with clever, size-conscious engineering (compiled-binary sidecars, on-demand model downloads, no PyTorch). It is not a competitor to OpenTranscribe as a **team/organizational transcription platform** — it's closer to a category adjacent to MacWhisper/Wispr Flow than to a self-hosted enterprise transcription system. The overlap that matters for messaging is narrow (both transcribe with Whisper-family models and both diarize), and on the one piece you've spent real, measurable effort on — diarization accuracy — you have benchmarked evidence they don't have anything close to.
+
+---
+
+## 9. Should OpenTranscribe move off PyTorch? (checked against your own prior optimization work)
+
+This question came up directly out of this comparison, and it turns out your team already ran the experiment — `docs/upstream-patches/phase-6-2-lessons-learned.md` and `phase-6-3-spike-results.md` have hard numbers. Short answer: **mostly no, and the "yes" parts are narrower than "move off Python/PyTorch" suggests.**
+
+- **Transcription isn't naive Python/PyTorch to begin with.** `faster-whisper`/WhisperX already run on **CTranslate2**, a compiled C++ inference engine — the same *category* of thing as OpenWhispr's whisper.cpp, just a different implementation. There's no "switch to compiled code" win available here because that switch already happened.
+- **Diarization (pyannote) is where PyTorch actually runs**, and replacing it with plain ONNX Runtime on GPU was measured to be **4-8x slower**, not faster (`phase-6-2-lessons-learned.md`). Cause: ONNX Runtime 1.25's CUDA execution provider has no CUDA kernel for several ops pyannote's graph uses (`LSTM`, `If`, `Sin`, `Cos`), so those ops silently fall back to CPU mid-graph, forcing GPU↔CPU memory copies on every forward pass. A 2.2-hour benchmark that takes ~100s under eager PyTorch was still running after 28 minutes under ONNX Runtime CUDA EP before it was killed.
+- **TensorRT is the one place a real win showed up** (`phase-6-3-spike-results.md`) — 2x faster than PyTorch eager, but only on the embedding sub-model, and only in a fixed-shape microbenchmark. At full-pipeline scale it hit a different wall: TensorRT compiles a new engine per input shape (~12s each), and the segmentation model sees 30+ distinct batch shapes per run, so first-run performance is *worse* until shape-profiling is added (documented, not yet implemented — real remaining work, not a dead end). It also costs +4.5GB of image size and engine plans are locked to one GPU architecture (an A6000 build won't run on a 4090 or H100).
+- **The one clearly-open, cheap win**: ONNX Runtime's *CPU* execution provider is expected to be 2-3x faster than eager PyTorch on CPU (normal — ORT fuses kernels, no autograd tape). This would directly help `Dockerfile.lite`/CPU deployments and is flagged in your own docs as untested — "simple benchmark, no code changes."
+
+**Why this differs from OpenWhispr's story**: OpenWhispr's "avoid Python for speed" pitch is solving a different problem — one meeting on one person's laptop, where per-call overhead matters. Once you're batching 16-32 items on a shared GPU, kernel execution already happens in compiled CUDA/cuDNN either way and Python's overhead is negligible against GPU compute time. Your real remaining levers are the three already scoped in your own docs: finish TensorRT shape-profiling (~5-10% E2E, GPU path), validate ORT CPU EP (lite mode), validate CoreML EP (Mac/MPS, also untested).
+
+---
+
+## 10. OpenWhispr Cloud — pricing and positioning
+
+Checked `openwhispr.com/pricing` directly (2026-08-09):
+
+| Tier | Price | Adds over previous tier |
+|---|---|---|
+| Free | $0 | Unlimited *local* dictation, 2,000 words/week cloud transcription, 5 hrs meeting recording/month, 100+ languages, custom dictionary, zero data retention, community support |
+| Pro | $6.67/user/mo ($80/yr) | Unlimited cloud transcription, 20 hrs meetings/mo, cross-device sync, personal API access, MCP integration, mobile app, email support |
+| Business | $16.67/user/mo ($200/yr) — "Most Popular" | Unlimited meeting recordings, **speaker labels**, **chat over your data**, priority support |
+| Enterprise | Custom | Advanced team/admin tools, **SSO & SAML**, **SCIM provisioning**, **audit logs**, org-wide retention controls, custom DPAs, dedicated support |
+
+**Why this matters for positioning**: speaker diarization and AI chat over transcripts are **Business-tier, $16.67/user/month** features in their cloud product. SSO/SAML/SCIM/audit logs — the whole slate of enterprise identity and compliance features — is their **top, custom-priced Enterprise tier**. Those are exactly the capabilities OpenTranscribe already ships for free in a self-hosted deployment (§8 above). The sharper comparison isn't "our feature list vs. their feature list" — it's that what you give away by default is their highest-paying customers' upsell ceiling. Local dictation itself stays free and unlimited across all their tiers (as it should for an MIT desktop app), but everything resembling "team/organizational transcription platform" — the category OpenTranscribe actually competes in — is gated behind their paid tiers, and still doesn't include benchmarked diarization accuracy or hybrid search at any price.
+
+---
+
+## Appendix: file/function citations for this report
+
+- Transcription: `src/helpers/whisperServer.js` (spawn, args, HTTP POST, `--no-timestamps` rationale), `src/helpers/audioManager.js` (`MediaRecorder` batch path, `AudioWorkletProcessor` streaming path), `src/helpers/ffmpegUtils.js` (WAV conversion), `scripts/download-whisper-cpp.js`.
+- Diarization: `src/helpers/diarization.js` (`diarize()`, `mergeWithTranscript()`, `capSpeakerClusters()`, `convertRawPcmToWav()`), `src/helpers/liveSpeakerIdentifier.js` (live clustering, profile matching), `src/helpers/database.js` (`speaker_profiles`/`speaker_mappings` schema, EMA update), `scripts/download-sherpa-onnx.js`.
+- Packaging: `package.json` (`build`/`prebuild:*`/`download:*` scripts, `electron-builder.json` `files` allowlist), `src/helpers/modelManagerBridge.js` (runtime model downloads).
+- Search/chat: `src/helpers/qdrantManager.js`, `scripts/download-qdrant.js`, `src/workers/onnxWorker.js`.
+- License: `LICENSE` (MIT, OpenWhispr Team, 2024).
+- Timestamp mechanism: `src/helpers/whisperServer.js:151` (`--no-timestamps`), `src/helpers/audioManager.js:1077` (`Date.now() - recordingStartTime` capture stamping), `src/helpers/diarization.js:471-472` (merge logic reading `seg.timestamp`).
+- OpenTranscribe baseline: `docs/ARCHITECTURE.md`, `docs/combined-engine-design.md`, `docs/diarization-boundary-results/dataset-sweep.md` and `cloud-comparison.md`, `backend/app/services/asr/factory.py`, `backend/app/services/chat/`, `backend/app/services/search/`, `CHANGELOG.md [0.4.0] - 2026-03-22`.
+- PyTorch/ONNX/TensorRT findings: `docs/upstream-patches/phase-6-2-lessons-learned.md`, `docs/upstream-patches/phase-6-3-spike-results.md`.
+- OpenWhispr Cloud pricing: `openwhispr.com/pricing` (fetched 2026-08-09; pricing/tiers are external and may change — reverify before citing externally).
+- Video support gap: `src/components/notes/UploadAudioView.tsx:1433` (accept list), `src/helpers/urlAudioDownloader.js:929-930` (`-x --audio-format`), `src/helpers/audioStorage.js` (`.webm`-only storage); OpenTranscribe contrast: `backend/app/services/storage_recovery_service.py`, `backend/app/services/media_download_service.py`, `frontend/src/components/VideoPlayer.svelte`, `PlyrMiniPlayer.svelte`.
+- LLM provider inventory: `src/services/ai/inferenceProviders/*.ts` (OpenWhispr), `backend/app/services/llm_service.py:42` (`LLMProvider` enum, OpenTranscribe).
+- Other gaps: MCP/API absence verified by repo-wide grep of `backend/app` and `docs/`; live-ASR absence verified via `backend/app/api/websockets.py`; custom vocabulary confirmed via `backend/app/api/endpoints/custom_vocabulary.py`; existing tracked issues checked via `gh issue list --repo attevon-llc/OpenTranscribe` (#365 Recall.ai meeting capture, #366 NVIDIA Parakeet/Canary).


### PR DESCRIPTION
## What

Bumps backend dependencies behind Dependabot's proposed floors (torch 2.8.0→2.11.0, onnxruntime restructuring, whisperx/faster-whisper/gliner, deepgram-sdk, websockets, and others — see `9b5ce31a` for the full pin list), plus everything found and fixed while actually validating that bump end-to-end.

Supersedes #367 (Dependabot's raw version-bump proposal) — that PR alone doesn't include any of the fixes below and would reintroduce the breakage they fix. Closing #367 as superseded once this merges.

## Real bugs found and fixed during validation

Each is its own commit with full root-cause writeup — summarizing here:

1. **`deepgram-sdk` incompatibility** — this branch's `websockets` bump to `>=17.0.1` (security floor) breaks `deepgram-sdk<7.6.0`: its `.listen.v1` accessor eagerly imports a legacy streaming module that references a symbol `websockets` removed in 15.0, even for our REST-only call path. Bumped to `>=7.6.0`, which fixes it upstream (verified via a real import + call check, not just changelog reading).

2. **`onnxruntime`/`onnxruntime-gpu` namespace collision** — `faster-whisper` and `gliner` both declare an unconditional `onnxruntime` dependency with no platform marker; installed normally, that silently races against our `onnxruntime-gpu` pin for the same import namespace and can drop `CUDAExecutionProvider` with no error. Fixed by moving both to `--no-deps` (matching the existing `whisperx` pattern) with their real transitive deps pinned explicitly. Verified via `onnxruntime.get_available_providers()` and real GPU transcription/diarization/redaction inference against real audio.

3. **Docker-only install step** — the above `--no-deps` packages were only installable via an inline `Dockerfile.prod` `RUN` command, invisible to a plain `pip install -r requirements.txt` in the documented local venv setup. Added `requirements-nodeps.txt` as a real, version-controlled file both Docker and a local venv now install from identically — verified in a completely fresh venv, not just an already-upgraded one, with every transitive dependency of the three `--no-deps` packages cross-checked against their actual `requires()` metadata.

4. **Docker dev container reload storm → leaked DB connections** — `docker-compose.override.yml` bind-mounts all of `backend/` (including `backend/venv/`) into every backend-image container. `backend`'s `uvicorn --reload` has no exclusions, so a `pip install` (or even routine `.pyc` writes from running pytest against that venv) looked like a source change and forced a full app reload — abandoning any in-flight WebSocket's DB session. Root-caused via `pg_locks`/`pg_stat_activity` after a reload-storm-triggered leak stalled a pending schema migration for ~15 minutes. Fixed by excluding `/app/venv` (matching the existing `frontend`/`node_modules` pattern) across all 12 backend-image services.

5. **The actual WebSocket session leak the above exposed** — `websocket_endpoint()` took `db: Session = Depends(get_db)` at the function level. FastAPI only releases a WebSocket route's injected dependency when the handler *returns* — not until disconnect, which can be hours later — so every connection held a pooled DB connection (and an uncommitted transaction, since `get_db`'s cleanup only closes/rolls back, never commits) open for its entire lifetime. Fixed by scoping DB access to a short-lived `session_scope()` used only for the auth check, plus a `db.expunge(user)` fix for the `DetachedInstanceError` that scoping exposed (SQLAlchemy's `expire_on_commit` default). Added a regression test verified to actually fail without either fix and pass with both.

6. **FedRAMP login-banner tests asserting off stale ambient DB state** — pre-existing, unrelated to the dependency bump, just the first time the full local gate ran end-to-end against a dev DB with a real `login_banner_enabled` row. The tests patched an env var the endpoint only consults as a DB-config fallback, so the patches were silently irrelevant. Fixed to write the DB-backed config directly, the same path a real admin action takes.

## Verification

- Fresh-venv install parity: `pip install -r requirements.txt && pip install --no-deps -r requirements-nodeps.txt` in a completely clean venv, zero `onnxruntime` collision, `CUDAExecutionProvider` present, every app module (`app.transcription.audio`, `app.transcription.diarizer`, `app.services.diarization.local_provider`, `app.services.redaction`) imports cleanly.
- Real GPU inference: faster-whisper transcription, pyannote diarization (via the app's actual dict-input call pattern), GLiNER redaction NER — all verified against real audio in the live container.
- Full local `pytest tests/ -n auto` (5000+ tests): after all fixes above, only 2 failures remain, both confirmed pre-existing, non-deterministic Postgres deadlocks unrelated to this branch's diff (none of these commits touch the tables/files involved) — tracked separately as #389, with an agent already dispatched.
- `docker-compose ... config --quiet` validated with the exact overlay set used in dev (`docker-compose.yml` + `docker-compose.override.yml` + `docker-compose.gpu.yml` + `docker-compose.nas.yml`).
- Live container recreate confirmed `/app/venv` is empty inside the container (mount exclusion works) and sustained monitoring (zero idle-in-transaction connections, zero `DetachedInstanceError`) over real traffic.
- All commits pass pre-commit hooks (ruff, mypy, bandit, import-linter) individually.

## Follow-ups tracked separately

- #389 — the 2 pre-existing flaky test failures found during this validation (agent dispatched).
- #376 — frontend dead-code cleanup audit (unrelated, found via a separate pass this session).

Ref task tracking: closes out the backend half of the dependency-upgrade work for v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
