### PR TITLE
fix(tests): eliminate cross-worker Postgres deadlocks in migration/settings suites

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -104,6 +104,7 @@ markers = [
     "integration: integration tests requiring running dev environment",
     "gpu: tests requiring a physical GPU — deselected from the fast suite, run by the gate",
     "models: tests requiring ML model weights (Presidio/GLiNER/toxicity) — skipped in fast CI",
+    "ddl_exclusive: performs schema DDL (DROP/ALTER TABLE) needing full DB-wide exclusivity, not just self-consistency — see tests/conftest.py's advisory-lock isolation (issue #389)",
 ]
 norecursedirs = ["tests/e2e"]
 

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -73,9 +73,25 @@ Per-suite prose lives in `README.md`, `AUTH_TEST_SETUP.md`, `e2e/README.md`.
   into the live dev cluster.
 - `--dist loadgroup`: tests sharing mutable global state need
   `pytestmark = pytest.mark.xdist_group("<name>")` (`test_auth_config_integration.py`,
-  `unit/test_media_mirror_service.py`, `api/test_scim.py`, `api/test_proxy_auth_endpoint.py`)
-  or they interleave across workers. User fixtures use
-  UUID-suffixed emails for the same reason.
+  `unit/test_media_mirror_service.py`, `api/test_scim.py`, `api/test_proxy_auth_endpoint.py`,
+  and — group per overlapping `SystemSettings` key namespace, issue #389 — `"backup_system_settings"`
+  on `unit/test_backup_metrics.py` + `unit/test_backup_service.py` + `unit/test_backup_alerts.py`,
+  `"engine_system_settings"` on `test_engine_settings.py` + `api/test_engine_settings_endpoints.py`)
+  or they interleave across workers and can deadlock on `system_settings_key_key`
+  (two workers inserting the same overlapping keys in reversed order). User fixtures
+  use UUID-suffixed emails for the same reason.
+- **DDL tests need more than `xdist_group`.** `xdist_group("migration_ddl")` only stops those
+  tests from colliding with *each other*; it does nothing about an unrelated worker's ordinary
+  DML running at the same moment. `DROP TABLE`/`ALTER TABLE ... DROP CONSTRAINT` takes
+  `ACCESS EXCLUSIVE`, and when the dropped object is a foreign key, Postgres needs that lock on
+  the *referenced* table too (removing the FK's enforcement trigger, which lives there) — e.g.
+  dropping `scim_token` also locks `user`, and `v377`/`v381`'s tests `ALTER TABLE "user"`
+  directly. Since nearly every other test touches a `user` row, this could deadlock against any
+  worker in the suite (issue #389). `@pytest.mark.ddl_exclusive` (on all six
+  `unit/test_v37{7,8}_*`/`test_v38{0,1,2,3}_migration_consistency.py` files) makes `db_session`
+  take a Postgres advisory lock (`tests/conftest.py`'s `_DDL_ISOLATION_LOCK_KEY`) — SHARED for
+  every ordinary test, EXCLUSIVE for a `ddl_exclusive` test — giving real cross-worker mutual
+  exclusion that `xdist_group` alone can't.
 - E2E runs from the repo root against `backend/tests/e2e/`, so `e2e/pytest.ini` becomes the
   rootdir config — pyproject `addopts` (`-n auto`, `-m 'not integration'`) do **not** apply.
 

--- a/backend/tests/api/test_engine_settings_endpoints.py
+++ b/backend/tests/api/test_engine_settings_endpoints.py
@@ -15,11 +15,18 @@ leak check). No real GPU worker or Redis is exercised.
 
 from __future__ import annotations
 
+import pytest
 from fastapi import status
 
 from app.services.system_settings_service import get_setting
 
 _BASE = "/api/admin/engine-settings"
+
+# This file and test_engine_settings.py both write engine.boundary_* keys through the
+# same POST /update endpoint with no coordination between them — under `-n auto` two
+# workers inserting overlapping keys in different orders can deadlock on the
+# system_settings_key_key unique index (issue #389).
+pytestmark = pytest.mark.xdist_group("engine_system_settings")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 from dotenv import dotenv_values
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 # Add backend directory to Python path for imports
@@ -170,8 +171,15 @@ def _clear_process_auth_cache():
     clear_process_auth_settings_cache()
 
 
+#: Postgres advisory-lock namespace reserved for test-suite DDL isolation (issue #389).
+#: Uses the 2-key `(classid, objid)` form, which hashes into a lock space entirely
+#: separate from single-key `pg_advisory_lock(N)` calls (e.g. app/db/migrations.py's
+#: startup guard uses `pg_advisory_lock(42)`) — the two can never collide.
+_DDL_ISOLATION_LOCK_KEY = (990389, 1)
+
+
 @pytest.fixture(scope="function")
-def db_session():
+def db_session(request):
     """Fixture that provides a SQLAlchemy session for tests.
 
     Uses nested transactions (savepoints) for test isolation - all changes made during
@@ -179,11 +187,42 @@ def db_session():
 
     This handles the case where the code under test calls commit() by using
     a savepoint that can be rolled back.
+
+    Tests marked ``@pytest.mark.ddl_exclusive`` run schema DDL (``DROP TABLE`` /
+    ``ALTER TABLE ... DROP CONSTRAINT``) that takes Postgres's ``ACCESS EXCLUSIVE``
+    lock. That lock is not confined to the table named in the statement: dropping a
+    table (or constraint) with a foreign key also drops the FK's enforcement trigger
+    on the *referenced* table, which needs an ``ACCESS EXCLUSIVE`` lock there too
+    (issue #389 — dropping `scim_token` this way also locks `user`, since
+    `scim_token.created_by` references it). Nearly every other test creates or
+    touches a `user` row, so under `-n auto` a `ddl_exclusive` test can deadlock
+    against an unrelated worker's ordinary DML — a cross-table lock-wait cycle, not
+    just a collision with another DDL test. The existing `xdist_group("migration_ddl")`
+    marker only keeps DDL tests off each other on one worker; it does nothing about
+    every OTHER worker's unmarked tests running at the same wall-clock moment.
+    A Postgres advisory lock gives real mutual exclusion across every xdist worker
+    (they all talk to the same Postgres instance): every ordinary test takes the
+    lock's SHARED form for the life of its transaction; a `ddl_exclusive` test takes
+    the EXCLUSIVE form, which blocks until every in-flight ordinary test finishes and
+    blocks every new one from starting until the DDL transaction ends (commit or
+    rollback — `pg_advisory_xact_lock*` auto-releases either way, so a failed test
+    can't leave the suite wedged).
     """
     from sqlalchemy import event
 
     connection = engine.connect()
     transaction = connection.begin()
+
+    if request.node.get_closest_marker("ddl_exclusive") is not None:
+        connection.execute(
+            text("SELECT pg_advisory_xact_lock(:k1, :k2)"),
+            {"k1": _DDL_ISOLATION_LOCK_KEY[0], "k2": _DDL_ISOLATION_LOCK_KEY[1]},
+        )
+    else:
+        connection.execute(
+            text("SELECT pg_advisory_xact_lock_shared(:k1, :k2)"),
+            {"k1": _DDL_ISOLATION_LOCK_KEY[0], "k2": _DDL_ISOLATION_LOCK_KEY[1]},
+        )
 
     # Create a session bound to this connection
     session = TestingSessionLocal(bind=connection)

--- a/backend/tests/test_engine_settings.py
+++ b/backend/tests/test_engine_settings.py
@@ -6,10 +6,19 @@ key and be reflected on the subsequent GET with ``source == "db"``. Uses the rea
 ``db_session`` fixture with savepoint rollback — no mocks for the data layer.
 """
 
+import pytest
+
 from app.services.system_settings_service import get_setting
 
 _BASE = "/api/admin/engine-settings"
 _DB_KEY = "engine.boundary_smoothing_enabled"
+
+# This file and test_engine_settings_endpoints.py both write engine.boundary_* keys
+# through the same POST /update endpoint with no coordination between them — under
+# `-n auto` two workers inserting overlapping keys in different orders can deadlock on
+# the system_settings_key_key unique index (issue #389, same mechanism as
+# test_backup_metrics.py's "backup_system_settings" group).
+pytestmark = pytest.mark.xdist_group("engine_system_settings")
 
 
 class TestEngineSettingsBoundarySmoothing:

--- a/backend/tests/unit/test_backup_alerts.py
+++ b/backend/tests/unit/test_backup_alerts.py
@@ -10,9 +10,18 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from app.services import backup_alerts
 from app.services import backup_service as bs
 from app.services import system_settings_service as sss
+
+# This file, test_backup_metrics.py, and test_backup_service.py all upsert the same
+# backup.* SystemSettings keys (bs.KEY_*) with no coordination between them — under
+# `-n auto` two workers inserting overlapping keys in different orders can deadlock on
+# the system_settings_key_key unique index (issue #389). Same pattern/precedent as
+# test_media_mirror_service.py's "media_mirror_system_settings" group.
+pytestmark = pytest.mark.xdist_group("backup_system_settings")
 
 
 def _clear_backup_keys(db_session):

--- a/backend/tests/unit/test_backup_metrics.py
+++ b/backend/tests/unit/test_backup_metrics.py
@@ -12,11 +12,21 @@ import json
 from datetime import UTC
 from datetime import datetime
 
+import pytest
 from prometheus_client import REGISTRY
 
 from app.core.backup_metrics import update_backup_metrics
 from app.services import backup_service as bs
 from app.services import system_settings_service as sss
+
+# This file, test_backup_service.py, and test_backup_alerts.py all upsert the same
+# backup.* SystemSettings keys (bs.KEY_*) with no coordination between them — under
+# `-n auto` two workers inserting overlapping keys in different orders can deadlock on
+# the system_settings_key_key unique index (issue #389). Same pattern/precedent as
+# test_media_mirror_service.py's "media_mirror_system_settings" group (a disjoint key
+# prefix, so it stays a separate group) and test_auth_config_integration.py's
+# "auth_config" group.
+pytestmark = pytest.mark.xdist_group("backup_system_settings")
 
 
 def _sample(name: str, labels: dict | None = None) -> float:

--- a/backend/tests/unit/test_backup_service.py
+++ b/backend/tests/unit/test_backup_service.py
@@ -20,6 +20,13 @@ from app.core import constants as C  # noqa: N812
 from app.services import backup_service as bs
 from app.services import system_settings_service as sss
 
+# This file, test_backup_metrics.py, and test_backup_alerts.py all upsert the same
+# backup.* SystemSettings keys (bs.KEY_*) with no coordination between them — under
+# `-n auto` two workers inserting overlapping keys in different orders can deadlock on
+# the system_settings_key_key unique index (issue #389). Same pattern/precedent as
+# test_media_mirror_service.py's "media_mirror_system_settings" group.
+pytestmark = pytest.mark.xdist_group("backup_system_settings")
+
 
 # =============================================================================
 # Settings round-trip (DB-backed)

--- a/backend/tests/unit/test_v377_migration_consistency.py
+++ b/backend/tests/unit/test_v377_migration_consistency.py
@@ -28,7 +28,11 @@ from sqlalchemy import text
 #: These suites perform schema DDL (dropping a column or constraint to recreate the
 #: pre-revision shape). Postgres takes an ACCESS EXCLUSIVE lock for that, so they must
 #: not run beside other database tests — `--dist loadgroup` keeps a group on one worker.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389 — dropping a column/constraint on
+#: `user` needs ACCESS EXCLUSIVE on the single most-written table in the suite).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v377_harden_user_auth_invariants"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"

--- a/backend/tests/unit/test_v378_migration_consistency.py
+++ b/backend/tests/unit/test_v378_migration_consistency.py
@@ -27,7 +27,10 @@ from sqlalchemy import text
 #: These suites perform schema DDL (dropping a column or constraint to recreate the
 #: pre-revision shape). Postgres takes an ACCESS EXCLUSIVE lock for that, so they must
 #: not run beside other database tests — `--dist loadgroup` keeps a group on one worker.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v378_idp_group_mapping"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"

--- a/backend/tests/unit/test_v380_migration_consistency.py
+++ b/backend/tests/unit/test_v380_migration_consistency.py
@@ -27,7 +27,10 @@ from sqlalchemy import text
 #: These suites perform schema DDL (dropping a column or constraint to recreate the
 #: pre-revision shape). Postgres takes an ACCESS EXCLUSIVE lock for that, so they must
 #: not run beside other database tests — `--dist loadgroup` keeps a group on one worker.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v380_oidc_identity_columns"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"

--- a/backend/tests/unit/test_v381_migration_consistency.py
+++ b/backend/tests/unit/test_v381_migration_consistency.py
@@ -32,7 +32,10 @@ from sqlalchemy import text
 #: These suites perform schema DDL (dropping a column or constraint to recreate the
 #: pre-revision shape). Postgres takes an ACCESS EXCLUSIVE lock for that, so they must
 #: not run beside other database tests — `--dist loadgroup` keeps a group on one worker.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v381_approval_state"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"

--- a/backend/tests/unit/test_v382_migration_consistency.py
+++ b/backend/tests/unit/test_v382_migration_consistency.py
@@ -22,7 +22,12 @@ from sqlalchemy import text
 #: These suites perform schema DDL (dropping a column or constraint to recreate the
 #: pre-revision shape). Postgres takes an ACCESS EXCLUSIVE lock for that, so they must
 #: not run beside other database tests — `--dist loadgroup` keeps a group on one worker.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389 — dropping `scim_token` also
+#: needs ACCESS EXCLUSIVE on `user`, since `scim_token.created_by` references it and
+#: dropping the table drops the FK's enforcement trigger defined on `user` too).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v382_scim_tokens"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"

--- a/backend/tests/unit/test_v383_migration_consistency.py
+++ b/backend/tests/unit/test_v383_migration_consistency.py
@@ -19,7 +19,10 @@ from sqlalchemy import text
 
 #: Schema DDL (dropping a column/constraint to recreate the pre-revision shape)
 #: takes an ACCESS EXCLUSIVE lock — must not run beside other database tests.
-pytestmark = pytest.mark.xdist_group("migration_ddl")
+#: That alone only protects against other `migration_ddl` tests; `ddl_exclusive` makes
+#: `db_session` take a DB-wide advisory lock so this group can't deadlock against an
+#: unrelated worker's ordinary DML either (issue #389).
+pytestmark = [pytest.mark.xdist_group("migration_ddl"), pytest.mark.ddl_exclusive]
 
 REVISION = "v383_saml_auth_type"
 _REVISION_PATH = Path(__file__).resolve().parents[2] / "alembic" / "versions" / f"{REVISION}.py"


### PR DESCRIPTION
## Summary

Root-causes and fixes both cross-worker Postgres deadlock modes from #389. Does **not** close #389 outright — a third, order-dependent flake described in the issue could not be reproduced despite thorough investigation (details below), so I'm leaving it open rather than claim a fix for something I can't demonstrate is broken.

## Failure 1a — DDL vs. DML cross-table deadlock (`test_v382_migration_consistency.py::test_detection_needs_the_table`)

Root cause: `scim_token` has no FK pointing *at* it, but it has an outbound FK *to* `user` (`scim_token.created_by`, `ON DELETE SET NULL`). Dropping a table with an outbound FK requires `ACCESS EXCLUSIVE` on the **referenced** table too — Postgres has to drop the FK's enforcement trigger, which lives on `user`. Verified this against the live dev DB's actual OIDs: the two relations named in the original deadlock report (`16404`, `118514`) resolve to `user` and `scim_token` respectively.

That means `DROP TABLE scim_token CASCADE` can deadlock against **any** unrelated worker that's mid-transaction on a `user` row — and nearly every test creates one via `normal_user`/`admin_user`/etc. The existing `xdist_group("migration_ddl")` marker only keeps the 7 migration-DDL suites off *each other*; it does nothing about the other ~thousands of unmarked tests running concurrently on other workers. Grepping the other 6 files in that group confirmed the blast radius is bigger than just `scim_token`/`user`: `test_v377_migration_consistency.py` and `test_v381_migration_consistency.py` `ALTER TABLE "user"` **directly**.

### Fix

A new `@pytest.mark.ddl_exclusive` marker (registered in `pyproject.toml`) on all six `test_v37{7,8}_*`/`test_v38{0,1,2,3}_migration_consistency.py` files. `tests/conftest.py`'s `db_session` fixture now takes a Postgres advisory lock as its first action:
- Ordinary tests take `pg_advisory_xact_lock_shared(990389, 1)` — many can hold it concurrently.
- `ddl_exclusive` tests take `pg_advisory_xact_lock(990389, 1)` — blocks until every in-flight ordinary test finishes, and blocks every new one from starting until the DDL transaction ends.

This is real mutual exclusion across every xdist worker (they all talk to the same Postgres instance), which `xdist_group` can't provide. `pg_advisory_xact_lock*` auto-releases on commit *or* rollback, so a failing test can't wedge the suite. The 2-key lock form is a separate namespace from `app/db/migrations.py`'s own `pg_advisory_lock(42)` startup guard — they can never collide.

## Failure 1b — SystemSettings unique-index deadlock (`test_backup_metrics.py::test_perform_backup_failure_lands_in_metrics`)

Root cause: `test_backup_metrics.py` had no `xdist_group` at all. Tracing `bs.KEY_*` usage found it shares the same `backup.*` SystemSettings keys with `test_backup_service.py` and `test_backup_alerts.py` (neither had a group either) — two workers each writing overlapping keys via `_set_settings_batch`-style calls, in different orders, is the textbook two-resource unique-index-insertion deadlock. Separately, `test_engine_settings.py` and `test_engine_settings_endpoints.py` both write the same `engine.boundary_*` keys through the same `POST /update` endpoint, with the same exposure.

### Fix

Two new `xdist_group`s, matching the existing `test_media_mirror_service.py` ("media_mirror_system_settings") / `test_auth_config_integration.py` ("auth_config") precedent:
- `"backup_system_settings"`: `test_backup_metrics.py`, `test_backup_service.py`, `test_backup_alerts.py`
- `"engine_system_settings"`: `test_engine_settings.py`, `test_engine_settings_endpoints.py`

## Failure 2 — order-dependent flake (NOT reproduced, NOT fixed here)

The issue describes `test_detection_needs_the_widened_check` intermittently failing only as part of the full 12-test single-process run of `test_v382_migration_consistency.py` (no xdist at all).

Investigation:
- `db_session`'s savepoint teardown always does a full outer-transaction `rollback()` regardless of what the test itself calls — and Postgres DDL is transactional, so this reliably undoes a mid-test `ALTER`/`DROP` either way.
- `_detect_schema_version` has no caching/memoization that could serve stale state across tests.
- No test-order-randomization plugin is installed (`pytest-xdist` only), so single-process ordering is deterministic file order.
- 125 repeated single-process runs of the file (25 + 100) against a clean, freshly-migrated, fully isolated throwaway Postgres instance: **zero failures**.

Leading hypothesis: this suite normally runs against the **live, shared dev Postgres instance**, which the live backend and celery-beat containers stay connected to throughout a local test run. `_detect_schema_version`'s ladder reads ambient state outside this test's own transaction (e.g. `has_legacy_oidc_config_keys` against `auth_config`) that isn't cleared by this file the way `test_backup_alerts.py`/`test_backup_service.py` clear `backup.*` before asserting. A concurrent interactive/automated write to one of those probed tables on the shared dev DB — not a bug in the savepoint/DDL-rollback mechanism — is the most likely explanation for a single anecdotal occurrence that didn't reproduce on the reporter's own second run either.

Left open rather than papered over. If it recurs, capturing `_detect_schema_version`'s intermediate `has_*` booleans at the moment of failure would confirm/refute this.

## Verification

Against an isolated, freshly-migrated throwaway Postgres instance (per `backend/tests/CLAUDE.md`'s documented pattern — this worktree can't reach the live dev stack's `.env` credentials):

- Exact repro command from the issue (`pytest <6 affected files> -n auto --dist loadgroup`) — **20/20 runs green** (two batches of 10)
- `test_v382_migration_consistency.py` alone, single-process — **125/125 runs green**
- Full fast suite (`tests/`, excluding `integration`/`gpu`/`e2e`) — green, no regressions

Not run against the live dev stack directly from this worktree (credential-access restriction); Postgres locking semantics are instance-independent, so this isn't expected to matter, but a confirmation run against `./opentr.sh start dev` before merge would remove all doubt.

## Files changed

- `backend/tests/conftest.py` — advisory-lock isolation in `db_session`
- `backend/pyproject.toml` — registers `ddl_exclusive` marker
- `backend/tests/unit/test_v37{7,8}_migration_consistency.py`, `test_v38{0,1,2,3}_migration_consistency.py` — add `ddl_exclusive`
- `backend/tests/unit/test_backup_{metrics,service,alerts}.py` — `xdist_group("backup_system_settings")`
- `backend/tests/test_engine_settings.py`, `backend/tests/api/test_engine_settings_endpoints.py` — `xdist_group("engine_system_settings")`
- `backend/tests/CLAUDE.md` — documents both mechanisms for future contributors

Refs #389
