### PR TITLE
test(e2e): pin the chat grounding invariant in a browser

### DIFF
--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -133,6 +133,28 @@ Why each piece:
 | `unit/test_llm_streaming.py`, `unit/test_chat_{prompting,retrieval,citations,redactor,hooks,limits}.py` | nothing — mocks only |
 | `unit/test_v374_migration_consistency.py`, `test_chat_{context_resolver,endpoints,user_settings,gdpr_erasure}.py` | Postgres |
 | `e2e/test_chat.py` (marker `chat`) | full stack + an LLM provider + a completed transcript |
+| `e2e/test_chat_grounding.py` (marker `chat`) | full stack + `--with-mock-llm` + a completed transcript |
+
+`test_chat_grounding.py` covers the #384 invariant end to end: **the citations a
+user can click are exactly the excerpts the model was given.** It registers its
+own per-test LLM config rather than reusing the shared provider, because the
+whole point is to control `max_tokens` — the user-declared context window the
+excerpt budget is computed against. A 512-token window (the API minimum) makes
+`budget_chars` floor at 0 against the ~2 KB base rules, so *no* excerpt fits and
+the `context_dropped` warning fires deterministically. `ROOMY_CONTEXT_WINDOW` is
+the control: same code path, opposite outcome, driven only by config — without it
+the suite would still pass if the notice were rendered unconditionally.
+
+**Two traps that read-order gets wrong** (both cost a debugging cycle):
+
+- **Retrieval diagnostics are not on screen mid-stream.** A streaming message
+  holds only what the SSE frames supplied; `msg_metadata.retrieved` /
+  `chunks_used` live on the persisted row and arrive when the thread is fetched.
+  Read the Details panel only after `_reload_thread()`, or it has no counts at all.
+- **Persisted citations ≠ offered citations.** `_persist_reply` stores
+  `used_citations` — the ones the answer actually referenced — so after a reload
+  the source cards are a *subset* of what the `sources` frame offered. Count
+  offered cards DURING the stream; compare against `chunks_used` read after.
 
 `test_chat_endpoints.py` patches `app.db.session_utils.session_scope` to the test session.
 The streaming service deliberately opens its **own** session (it outlives the request's

--- a/backend/tests/e2e/test_chat_grounding.py
+++ b/backend/tests/e2e/test_chat_grounding.py
@@ -1,0 +1,384 @@
+"""E2E: a chat answer must never claim more grounding than it has (issue #384).
+
+`test_chat.py` covers the happy path — a grounded, cited answer. This file covers
+the property underneath it: **the citations a user can see and click are exactly
+the excerpts the model was given.** That invariant is enforced in three separate
+places (`prompting.format_excerpts` returns the ids it emitted,
+`citations.build_offered_citations` maps from those ids, and `service.stream_reply`
+emits `sources` only after `build_messages`), and unit tests pin each one. What
+none of them can prove is that the three still line up once a real browser talks
+to a real backend — which is the failure that shipped.
+
+The interesting case is the one the unit tests reach by arithmetic and a user
+reaches with a small local model: the prompt budget leaves room for NO excerpt, so
+the answer is not grounded in the library at all. Before #384 that rendered as a
+normal, fully-cited answer. It must now announce itself.
+
+The trigger is deterministic rather than incidental. A config declaring a
+512-token context window gives
+``budget_chars = (512 - 256) * 4 - overhead``, and the base system rules alone
+exceed 1024 characters, so the budget floors at 0 no matter what retrieval found.
+That is a real, reachable configuration — not a mock — and it is why these tests
+register their own provider instead of reusing the module-wide one.
+
+Requirements:
+- Dev environment running: ./opentr.sh start dev --with-mock-llm
+- At least one COMPLETED transcript in the library (retrieval needs content)
+
+Run:
+    pytest backend/tests/e2e/test_chat_grounding.py -v
+    DISPLAY=:11 pytest backend/tests/e2e/test_chat_grounding.py -v --headed
+
+These tests must never persist changes to dev data: every conversation and every
+LLM config created here is deleted in the same test, and no transcript is touched.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import Iterator
+
+import pytest
+import requests
+
+# Absolute import — the e2e dir is not a package, so a relative import breaks
+# collection when invoked as `pytest backend/tests/e2e/` from the repo root.
+from conftest import TEST_ADMIN_EMAIL
+from conftest import TEST_ADMIN_PASSWORD
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.chat
+
+FRONTEND_URL = os.environ.get("E2E_FRONTEND_URL", "http://localhost:5173")
+BACKEND_URL = os.environ.get("E2E_BACKEND_URL", "http://localhost:5174")
+
+STREAM_TIMEOUT_MS = 90_000
+
+MOCK_LLM_PORT = 5199
+MOCK_LLM_URL_FOR_BACKEND = f"http://mock-llm:{MOCK_LLM_PORT}/v1"
+
+#: Smallest context window the API accepts. Chosen because it is the floor, so
+#: the budget cannot accidentally grow past zero if the base rules are ever
+#: shortened.
+STARVED_CONTEXT_WINDOW = 512
+#: Comfortably fits the base rules, history, question and several excerpts.
+ROOMY_CONTEXT_WINDOW = 32_000
+
+
+def _mock_llm_running() -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.3)
+        return sock.connect_ex(("127.0.0.1", MOCK_LLM_PORT)) == 0
+
+
+@pytest.fixture(scope="module")
+def api_session() -> requests.Session:
+    """An authenticated API session for arranging and cleaning up test state."""
+    session = requests.Session()
+    response = session.post(
+        f"{BACKEND_URL}/api/auth/token",
+        data={"username": TEST_ADMIN_EMAIL, "password": TEST_ADMIN_PASSWORD},
+        timeout=30,
+    )
+    assert response.status_code == 200, f"Login failed: {response.status_code}"
+
+    # Every mutation needs the CSRF header or the backend answers 403 — which
+    # would silently turn the cleanup DELETEs below into no-ops and leave this
+    # suite's conversations behind in dev data.
+    csrf_token = session.cookies.get("csrf_token")
+    assert csrf_token, "login did not set a csrf_token cookie"
+    session.headers["X-CSRF-Token"] = csrf_token
+    return session
+
+
+def _completed_transcripts_exist(api_session: requests.Session) -> bool:
+    try:
+        response = api_session.get(
+            f"{BACKEND_URL}/api/files",
+            params={"status": "completed", "page_size": "1"},
+            timeout=20,
+        )
+        if not response.ok:
+            return False
+        data = response.json()
+        items = data.get("items", data if isinstance(data, list) else [])
+        return len(items) > 0
+    except (requests.RequestException, ValueError):
+        return False
+
+
+@pytest.fixture
+def llm_config_factory(api_session: requests.Session) -> Iterator:
+    """Create mock-LLM configs with a chosen context window; delete them after.
+
+    A per-test provider rather than the shared one, because the whole point is
+    to control ``max_tokens`` — the user-declared context window the excerpt
+    budget is computed against.
+    """
+    created: list[str] = []
+
+    def _make(context_window: int, name: str) -> str:
+        response = api_session.post(
+            f"{BACKEND_URL}/api/llm-settings",
+            json={
+                "name": name,
+                "provider": "custom",
+                "model_name": "mock-gpt",
+                "base_url": MOCK_LLM_URL_FOR_BACKEND,
+                "api_key": "mock-key-not-secret",
+                "max_tokens": context_window,
+            },
+            timeout=30,
+        )
+        assert response.ok, f"Could not create LLM config: {response.status_code} {response.text}"
+        uuid = str(response.json()["uuid"])
+        created.append(uuid)
+        return uuid
+
+    yield _make
+
+    for uuid in created:
+        try:
+            api_session.delete(f"{BACKEND_URL}/api/llm-settings/config/{uuid}", timeout=30)
+        except requests.RequestException:
+            pass
+
+
+@pytest.fixture
+def conversation_factory(api_session: requests.Session) -> Iterator:
+    """Create conversations pinned to a given model; delete them after, pass or fail."""
+    created: list[str] = []
+
+    def _make(llm_config_uuid: str) -> str:
+        response = api_session.post(
+            f"{BACKEND_URL}/api/chat/conversations",
+            json={
+                "llm_config_uuid": llm_config_uuid,
+                # Empty scope = "all accessible transcripts", so retrieval has
+                # the whole library to find chunks in.
+                "scope": {
+                    "file_uuids": [],
+                    "collection_uuids": [],
+                    "tag_names": [],
+                    "speakers": [],
+                },
+                "settings": {"use_context": True},
+            },
+            timeout=30,
+        )
+        assert response.ok, f"Could not create conversation: {response.status_code} {response.text}"
+        uuid = str(response.json()["uuid"])
+        created.append(uuid)
+        return uuid
+
+    yield _make
+
+    for uuid in created:
+        try:
+            api_session.delete(f"{BACKEND_URL}/api/chat/conversations/{uuid}", timeout=15)
+        except requests.RequestException:
+            pass
+
+
+def _requirements_or_skip(api_session: requests.Session) -> None:
+    if not _mock_llm_running():
+        pytest.skip("Requires the mock LLM: ./opentr.sh start dev --with-mock-llm")
+    if not _completed_transcripts_exist(api_session):
+        pytest.skip("Requires at least one completed transcript for retrieval to find")
+
+
+def _ask(page: Page, conversation_uuid: str, question: str) -> None:
+    """Open a conversation, send one question, and wait for generation to finish."""
+    page.goto(f"{FRONTEND_URL}/chat/{conversation_uuid}")
+    composer = page.locator('[data-testid="chat-composer-input"]')
+    expect(composer).to_be_visible(timeout=30_000)
+
+    composer.fill(question)
+    page.locator('[data-testid="chat-send"]').click()
+
+    # Send morphs into Stop while streaming and back again when it completes.
+    expect(page.locator('[data-testid="chat-send"]')).to_be_visible(timeout=STREAM_TIMEOUT_MS)
+
+
+def _reload_thread(page: Page) -> None:
+    """Reload the conversation so the SERVER's view of the turn is on screen.
+
+    A message built during streaming carries only what the frames supplied. The
+    retrieval diagnostics (`retrieved`, `chunks_used`) live in `msg_metadata` on
+    the persisted row and reach the client when the thread is fetched — so the
+    Details panel is genuinely empty of them mid-stream, and reading it before a
+    reload measures nothing.
+    """
+    page.reload()
+    expect(page.locator('[data-testid="chat-message-assistant"]').last).to_be_visible(
+        timeout=30_000
+    )
+
+
+def _excerpts_used(page: Page) -> int:
+    """Read `chunks_used` out of the answer's Details panel. Reload first.
+
+    The panel renders `chunks_used / retrieved` straight from the server's
+    ``msg_metadata``, so this is the server's own account of how many excerpts
+    reached the prompt rather than a client-side guess.
+    """
+    page.locator('[data-testid="chat-meta-toggle"]').last.click()
+    grid = page.locator('[data-testid="chat-meta-grid"]').last
+    expect(grid).to_be_visible(timeout=10_000)
+
+    text = grid.inner_text()
+    for line in text.splitlines():
+        if "/" in line and line.replace("/", "").replace(" ", "").isdigit():
+            return int(line.split("/")[0].strip())
+    raise AssertionError(
+        "Could not find the 'used / retrieved' row in Details. Did you reload the "
+        f"thread first? Mid-stream the panel has no retrieval diagnostics.\n{text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The ungrounded-answer warning
+# ---------------------------------------------------------------------------
+
+
+def test_answer_with_no_room_for_excerpts_is_flagged_as_ungrounded(
+    gallery_page: Page,
+    api_session: requests.Session,
+    llm_config_factory,
+    conversation_factory,
+):
+    """A model whose window fits no excerpt must say the answer is not grounded.
+
+    This is the #384 regression in the shape a user meets it: retrieval succeeds,
+    the budget rejects everything it found, and the model answers from nothing.
+    Before the fix this rendered as a normal answer with a full set of clickable
+    citations attached.
+    """
+    _requirements_or_skip(api_session)
+
+    config_uuid = llm_config_factory(STARVED_CONTEXT_WINDOW, "Mock LLM starved window (e2e)")
+    conversation_uuid = conversation_factory(config_uuid)
+
+    _ask(gallery_page, conversation_uuid, "What topics are discussed in these recordings?")
+
+    notice = gallery_page.locator('[data-testid="chat-context-dropped"]')
+    expect(notice).to_be_visible(timeout=15_000)
+    assert notice.inner_text().strip(), "The notice rendered empty (missing i18n key?)"
+
+    # Nothing may be offered as a source, because nothing was read. Asserted while
+    # the streamed turn is still on screen, since that is when the `sources` frame
+    # would have populated it.
+    expect(gallery_page.locator('[data-testid="chat-sources-toggle"]')).to_have_count(0)
+
+    # The server's own count must agree with the warning it sent.
+    _reload_thread(gallery_page)
+    assert _excerpts_used(gallery_page) == 0
+
+
+def test_ungrounded_notice_survives_a_page_reload(
+    gallery_page: Page,
+    api_session: requests.Session,
+    llm_config_factory,
+    conversation_factory,
+):
+    """The warning is persisted state, not a property of the live stream.
+
+    It arrives as a `warning` SSE frame, but the store folds it into
+    `msg_metadata.context_dropped` — the same flag the server writes on the
+    message row. If the two ever diverge, the notice vanishes on refresh and the
+    answer silently becomes trustworthy-looking again.
+    """
+    _requirements_or_skip(api_session)
+
+    config_uuid = llm_config_factory(STARVED_CONTEXT_WINDOW, "Mock LLM starved reload (e2e)")
+    conversation_uuid = conversation_factory(config_uuid)
+
+    _ask(gallery_page, conversation_uuid, "Summarise the key decisions.")
+    expect(gallery_page.locator('[data-testid="chat-context-dropped"]')).to_be_visible(
+        timeout=15_000
+    )
+
+    gallery_page.reload()
+    expect(gallery_page.locator('[data-testid="chat-message-assistant"]').last).to_be_visible(
+        timeout=30_000
+    )
+    expect(gallery_page.locator('[data-testid="chat-context-dropped"]')).to_be_visible(
+        timeout=15_000
+    )
+
+
+# ---------------------------------------------------------------------------
+# The control: a normal window must NOT warn, and must cite what it read
+# ---------------------------------------------------------------------------
+
+
+def test_roomy_context_window_cites_sources_and_does_not_warn(
+    gallery_page: Page,
+    api_session: requests.Session,
+    llm_config_factory,
+    conversation_factory,
+):
+    """The control for the two tests above.
+
+    Without this they would still pass if the notice were rendered
+    unconditionally, and the warning has to stay rare enough to mean something.
+    """
+    _requirements_or_skip(api_session)
+
+    config_uuid = llm_config_factory(ROOMY_CONTEXT_WINDOW, "Mock LLM roomy window (e2e)")
+    conversation_uuid = conversation_factory(config_uuid)
+
+    _ask(gallery_page, conversation_uuid, "What topics are discussed in these recordings?")
+
+    expect(gallery_page.locator('[data-testid="chat-context-dropped"]')).to_have_count(0)
+    expect(gallery_page.locator('[data-testid="chat-sources-toggle"]')).to_be_visible(
+        timeout=15_000
+    )
+
+    _reload_thread(gallery_page)
+    assert _excerpts_used(gallery_page) > 0, "A roomy window must place excerpts in the prompt"
+
+
+def test_offered_sources_match_the_excerpts_the_model_was_given(
+    gallery_page: Page,
+    api_session: requests.Session,
+    llm_config_factory,
+    conversation_factory,
+):
+    """The #384 invariant, asserted through the UI: cited == used.
+
+    `sources` used to be emitted before the excerpt budget existed, so the count
+    of citation cards was the count of chunks RETRIEVED. It must now equal the
+    count that actually reached the prompt, which the Details panel reports from
+    the server's `msg_metadata`.
+    """
+    _requirements_or_skip(api_session)
+
+    config_uuid = llm_config_factory(ROOMY_CONTEXT_WINDOW, "Mock LLM cited-equals-used (e2e)")
+    conversation_uuid = conversation_factory(config_uuid)
+
+    _ask(gallery_page, conversation_uuid, "Summarise the key points across these recordings.")
+
+    # Counted DURING the stream: these are the OFFERED citations, straight from the
+    # `sources` frame. After a reload the cards show only the citations the answer
+    # actually referenced (`_persist_reply` stores `used_citations`), which is a
+    # subset — comparing that to `chunks_used` would prove nothing.
+    toggle = gallery_page.locator('[data-testid="chat-sources-toggle"]').last
+    expect(toggle).to_be_visible(timeout=15_000)
+    toggle.click()
+
+    source_links = gallery_page.locator('[data-testid="chat-source-link"]')
+    expect(source_links.first).to_be_visible(timeout=10_000)
+    offered = source_links.count()
+
+    # The server's count comes from the persisted row.
+    _reload_thread(gallery_page)
+    used = _excerpts_used(gallery_page)
+
+    assert offered == used, (
+        f"{offered} citations were offered to the user but the server reports "
+        f"{used} excerpts reached the prompt — the UI is showing sources the "
+        "model never saw (issue #384)."
+    )

--- a/backend/tests/e2e/test_chat_grounding.py
+++ b/backend/tests/e2e/test_chat_grounding.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import os
 import socket
+import uuid as uuid_pkg
 from collections.abc import Iterator
 
 import pytest
@@ -120,10 +121,15 @@ def llm_config_factory(api_session: requests.Session) -> Iterator:
     created: list[str] = []
 
     def _make(context_window: int, name: str) -> str:
+        # UUID-suffixed, like the user fixtures: config names are unique per user,
+        # so a fixed name 409s against the leftovers of any run that was killed
+        # before its teardown could delete them — turning an unrelated
+        # interruption into a permanent failure for everyone afterwards.
+        unique_name = f"{name} {uuid_pkg.uuid4().hex[:8]}"
         response = api_session.post(
             f"{BACKEND_URL}/api/llm-settings",
             json={
-                "name": name,
+                "name": unique_name,
                 "provider": "custom",
                 "model_name": "mock-gpt",
                 "base_url": MOCK_LLM_URL_FOR_BACKEND,
@@ -132,7 +138,9 @@ def llm_config_factory(api_session: requests.Session) -> Iterator:
             },
             timeout=30,
         )
-        assert response.ok, f"Could not create LLM config: {response.status_code} {response.text}"
+        assert response.ok, (
+            f"Could not create LLM config {unique_name!r}: {response.status_code} {response.text}"
+        )
         uuid = str(response.json()["uuid"])
         created.append(uuid)
         return uuid
@@ -190,16 +198,44 @@ def _requirements_or_skip(api_session: requests.Session) -> None:
 
 
 def _ask(page: Page, conversation_uuid: str, question: str) -> None:
-    """Open a conversation, send one question, and wait for generation to finish."""
+    """Open a conversation, send one question, and wait for the turn to COMPLETE.
+
+    Completion is read from the assistant bubble's ``data-status``, which the
+    store sets to ``complete`` on the `done` frame.
+
+    Deliberately NOT "wait for the Send button to come back": Send is already
+    visible before the click flips it to Stop, so that assertion can pass
+    instantly against the pre-click state and hand the test a half-rendered turn.
+    It made this suite flaky in exactly the runs where the retrieval cache was
+    warm and the whole turn finished in under a second.
+    """
     page.goto(f"{FRONTEND_URL}/chat/{conversation_uuid}")
     composer = page.locator('[data-testid="chat-composer-input"]')
     expect(composer).to_be_visible(timeout=30_000)
 
+    # Wait for the route to finish LOADING the conversation, not just for the
+    # composer to paint. `chatStore.sendMessage` falls back to creating a brand
+    # new conversation when `activeConversationId` is still null — so sending
+    # into that window silently starts a different thread, one with no pinned
+    # llm_config and therefore the DEFAULT context window. The test then asks a
+    # roomy model why it did not run out of room, and fails about one run in
+    # three.
+    page.wait_for_load_state("networkidle")
+
     composer.fill(question)
     page.locator('[data-testid="chat-send"]').click()
 
-    # Send morphs into Stop while streaming and back again when it completes.
-    expect(page.locator('[data-testid="chat-send"]')).to_be_visible(timeout=STREAM_TIMEOUT_MS)
+    completed = page.locator('[data-testid="chat-message-assistant"][data-status="complete"]')
+    expect(completed.last).to_be_visible(timeout=STREAM_TIMEOUT_MS)
+
+    # Belt and braces: if the race above ever recurs the URL moves to the newly
+    # created conversation, so this fails loudly instead of quietly measuring the
+    # wrong model. It also stops such a thread leaking past the fixture, which
+    # only deletes uuids it created itself.
+    assert conversation_uuid in page.url, (
+        f"The turn was sent to {page.url} instead of conversation {conversation_uuid} — "
+        "the store created a new conversation because the route had not loaded yet."
+    )
 
 
 def _reload_thread(page: Page) -> None:


### PR DESCRIPTION
Follow-up to #390. Adds the end-to-end coverage that #384 never had, plus the fixes needed to make it deterministic.

## Why

#390 fixed the "fabricated sources" defect and pinned it with unit tests at three layers — `format_excerpts` returns the ids it emitted, `build_offered_citations` maps from those ids, and `stream_reply` emits `sources` only after `build_messages`. What none of them can prove is that the three still line up **once a real browser talks to a real backend**, which is precisely the seam where the bug shipped. A manual look proves it today and nothing tomorrow.

## What it covers

`backend/tests/e2e/test_chat_grounding.py`, marker `chat`, 4 tests:

| Test | Asserts |
|---|---|
| `..._flagged_as_ungrounded` | 512-token window → no excerpt fits → notice renders, no sources offered, server reports `chunks_used == 0` |
| `..._survives_a_page_reload` | the notice comes from persisted `msg_metadata.context_dropped`, not live stream state — a divergence would make the answer look trustworthy again on refresh |
| `..._cites_sources_and_does_not_warn` | **the control**: a roomy window must cite and must NOT warn. Without it the two above would pass even if the notice were unconditional |
| `..._match_the_excerpts_the_model_was_given` | the #384 invariant read through the UI: offered citations == `chunks_used` |

The trigger is deterministic, not incidental: 512 tokens is the API minimum, so `budget_chars = (512 - 256) * 4 - overhead` floors at 0 against the ~2 KB base rules regardless of what retrieval found. That's a real, reachable small-local-model configuration. Each test registers its **own** LLM config rather than reusing the shared provider, because controlling `max_tokens` is the entire mechanism.

## Three flakiness causes found and fixed

Found by running the suite repeatedly, not by reading it. It went from ~1-in-3 failing to **5 consecutive green runs**.

1. **Sending before the route loaded the conversation.** `_ask` waited for the composer to *paint*, but `chatStore.sendMessage` creates a brand-new conversation while `activeConversationId` is still null. A fast fill+click landed in that window, so the turn went to a different thread — no pinned `llm_config`, therefore the **default** context window. The test then asked a roomy model why it hadn't run out of room. It also leaked that thread, since the fixture only deletes uuids it created. Now waits for `networkidle` **and asserts the URL still names the intended conversation**, so a recurrence fails loudly instead of quietly measuring the wrong model.
2. **"Send button visible" ≠ "generation finished."** Send is already visible before the click flips it to Stop, so the assertion could pass instantly against the pre-click state. Bit hardest when the retrieval cache was warm and the turn finished in under a second. Now waits for the assistant bubble's `data-status="complete"`.
3. **Fixed LLM config names.** Names are unique per user, so any run killed before teardown made every later run 400. UUID-suffixed now, matching the convention the user fixtures already use.

**The application code was never the flaky part.** An API-level probe hit the backend three times in a row and got `warning_frame: True`, `retrieved: 12`, `chunks_used: 0`, `context_dropped: True` every time — the #384 path is deterministic. All three faults were in the test.

## Two ordering traps, now documented in `tests/CLAUDE.md`

Both silently produce meaningless assertions, so they're written down rather than just worked around:

- **Retrieval diagnostics are absent mid-stream.** A streaming message holds only what the SSE frames supplied; `retrieved` / `chunks_used` reach the client with the persisted row. The Details panel must be read after a reload or it has no counts at all.
- **Persisted citations ≠ offered citations.** `_persist_reply` stores `used_citations` — the ones the answer actually referenced — a subset of what `sources` offered. Offered cards must be counted *during* the stream, `chunks_used` *after*.

## Verification

- 5 consecutive full-suite runs green against the live dev stack
- 22 passed / 3 skipped when run alongside `test_chat.py` — no interference
- `ruff check`, `ruff format`, `mypy` clean; full pre-commit chain on both commits
- Fixtures delete every config and conversation they create; dev data unchanged

Note E2E is local-only and not part of the GitHub checks, so CI here covers lint/type/unit only.