### PR TITLE
fix(pki): fetch certificate info, which the panel never had

### DIFF
--- a/frontend/src/components/settings/CertificateInfo.svelte
+++ b/frontend/src/components/settings/CertificateInfo.svelte
@@ -1,11 +1,35 @@
 <script lang="ts">
-  import { user as userStore, type CertificateInfo } from '$stores/auth';
+  /**
+   * The signed-in user's certificate details, for PKI-authenticated accounts.
+   *
+   * Fetches its own data. It previously read `$userStore.certificate`, a field
+   * nothing ever set — `/api/auth/me` does not serve certificate metadata, only
+   * `/api/auth/me/certificate` does — so `hasCertificate` was permanently false
+   * and this panel silently rendered the no-certificate state for every user,
+   * including those with a valid certificate.
+   */
+  import { onMount } from 'svelte';
   import { t } from '$stores/locale';
+  import { getCertificateInfo, type CertificateInfo } from '$lib/api/certificate';
 
-  $: certificate = $userStore?.certificate as CertificateInfo | undefined;
+  let certificate: CertificateInfo | undefined;
+  let loadFailed = false;
+
+  onMount(async () => {
+    try {
+      certificate = await getCertificateInfo();
+    } catch {
+      // Non-fatal: the rest of the security panel is unaffected, so this
+      // degrades to showing nothing rather than breaking the page.
+      loadFailed = true;
+    }
+  });
+
   $: hasCertificate = certificate?.has_certificate || false;
 
-  function formatDate(dateString?: string): string {
+  // The backend returns JSON null for an absent field, so this takes null as
+  // well as undefined — the widened shape is the accurate one.
+  function formatDate(dateString?: string | null): string {
     if (!dateString) return $t('common.notAvailable');
     return new Date(dateString).toLocaleString();
   }

--- a/frontend/src/components/settings/CertificateInfo.test.ts
+++ b/frontend/src/components/settings/CertificateInfo.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+/**
+ * The panel renders certificate metadata for a PKI-authenticated user.
+ *
+ * These exist because the component previously read `$userStore.certificate` —
+ * a field nothing ever set, since `/api/auth/me` does not serve certificate
+ * metadata and only `/api/auth/me/certificate` does. `hasCertificate` was
+ * therefore permanently false and this panel silently rendered its empty state
+ * for every user, including those holding a valid certificate. The first test
+ * fails against that version.
+ */
+vi.mock('$stores/locale', async () => {
+  const { readable } = await import('svelte/store');
+  return { t: readable((key: string) => key) };
+});
+
+const api = vi.hoisted(() => ({ getCertificateInfo: vi.fn() }));
+vi.mock('$lib/api/certificate', () => api);
+
+import CertificateInfo from './CertificateInfo.svelte';
+
+const CERT = {
+  has_certificate: true,
+  subject_dn: 'CN=Ada Lovelace,O=Analytical Engines,C=GB',
+  common_name: 'Ada Lovelace',
+  serial_number: '0A1B2C',
+  issuer_dn: 'CN=Test CA',
+  organization: 'Analytical Engines',
+  organizational_unit: 'Research',
+  valid_from: '2026-01-01T00:00:00Z',
+  valid_until: '2099-01-01T00:00:00Z',
+  fingerprint: 'AA:BB:CC',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getCertificateInfo.mockResolvedValue(CERT);
+});
+
+describe('CertificateInfo', () => {
+  it('fetches the certificate endpoint and renders what it returns', async () => {
+    render(CertificateInfo);
+
+    await waitFor(() => expect(api.getCertificateInfo).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText('CN=Ada Lovelace,O=Analytical Engines,C=GB')).toBeInTheDocument()
+    );
+  });
+
+  it('renders nothing when the user holds no certificate', async () => {
+    api.getCertificateInfo.mockResolvedValue({ has_certificate: false });
+    const { container } = render(CertificateInfo);
+
+    await waitFor(() => expect(api.getCertificateInfo).toHaveBeenCalled());
+    expect(container.querySelector('.certificate-info')).toBeNull();
+  });
+
+  it('degrades quietly when the request fails', async () => {
+    // The rest of the security panel is unaffected by this one call, so a
+    // failure must not take the page down with it.
+    api.getCertificateInfo.mockRejectedValue(new Error('boom'));
+    const { container } = render(CertificateInfo);
+
+    await waitFor(() => expect(api.getCertificateInfo).toHaveBeenCalled());
+    expect(container.querySelector('.certificate-info')).toBeNull();
+  });
+});

--- a/frontend/src/lib/api/certificate.ts
+++ b/frontend/src/lib/api/certificate.ts
@@ -1,0 +1,35 @@
+/**
+ * API client for the current user's X.509 certificate metadata.
+ *
+ * `GET /api/auth/me/certificate` is the **only** source of this data — the user
+ * payload (`/api/auth/me`) does not carry it, because the fields are meaningless
+ * for the local/LDAP/OIDC majority and would be dead weight on every session
+ * probe.
+ */
+import axiosInstance from '../axios';
+
+/** Certificate metadata for a PKI-authenticated user. */
+export interface CertificateInfo {
+  has_certificate: boolean;
+  subject_dn?: string | null;
+  common_name?: string | null;
+  serial_number?: string | null;
+  issuer_dn?: string | null;
+  organization?: string | null;
+  organizational_unit?: string | null;
+  valid_from?: string | null;
+  valid_until?: string | null;
+  fingerprint?: string | null;
+}
+
+/**
+ * Fetch the caller's certificate metadata.
+ *
+ * Returns `{ has_certificate: false }` for a user who did not authenticate via
+ * PKI (or via an OIDC provider brokering X.509), so callers render the absence
+ * rather than treating it as an error.
+ */
+export async function getCertificateInfo(): Promise<CertificateInfo> {
+  const response = await axiosInstance.get('/auth/me/certificate');
+  return response.data;
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -21,18 +21,9 @@ function asAuthError(error: unknown): AuthRequestError {
   return (error ?? {}) as AuthRequestError;
 }
 
-// Certificate information for PKI authentication
-export interface CertificateInfo {
-  has_certificate: boolean;
-  subject_dn?: string;
-  serial_number?: string;
-  issuer_dn?: string;
-  organization?: string;
-  organizational_unit?: string;
-  valid_from?: string;
-  valid_until?: string;
-  fingerprint?: string;
-}
+// Certificate metadata lives with the endpoint that serves it
+// (`$lib/api/certificate`). It was declared here, and hung off the user type,
+// as though `/auth/me` returned it — it never has.
 
 // Define user interface
 interface User {
@@ -45,7 +36,6 @@ interface User {
   // keys off `auth_type === 'local'`.
   auth_type: 'local' | 'ldap' | 'oidc' | 'pki' | string;
   allow_local_fallback?: boolean;
-  certificate?: CertificateInfo;
   // Cloud-edition tenancy/billing context (populated by the backend from the
   // external IdP's org claim). Absent in the community edition.
   org_id?: string;


### PR DESCRIPTION
Closes #397.

## The bug

`components/settings/CertificateInfo.svelte` read `$userStore.certificate`. **Nothing has ever set that field** — `GET /api/auth/me` does not serve certificate metadata, only `GET /api/auth/me/certificate` does, and no call site existed anywhere in the SPA.

So `hasCertificate` was permanently `false` and the certificate panel silently rendered its empty state for **every** user, including PKI-authenticated ones holding a valid certificate. Nothing errored; the feature simply never appeared.

`tests/unit/test_route_has_a_caller.py` was pointing straight at it: the route had no frontend caller because the half that would have called it was never written.

Two declarations made it look wired, which is why it survived review:

- `certificate?: CertificateInfo` on the user type in `stores/auth.ts`
- a `CertificateInfo` interface in `stores/auth.ts` that no endpoint populates

## The fix

- New `$lib/api/certificate` client; the component fetches its own data on mount and degrades quietly on failure — the rest of the security panel is independent of this one call.
- Removed the misleading `certificate?:` field and the duplicate interface, so nothing reads a field that cannot be populated.
- `formatDate` now accepts `string | null`: the backend returns JSON null for absent fields, so the widened shape is the accurate one.

Certificate metadata was deliberately **not** added to `/auth/me` instead — the fields are meaningless for the local/LDAP/OIDC majority and would ride on every session probe.

## Verification

- `test_route_has_a_caller[/api/auth/me/certificate]` passes; the full route-caller suite is green (no failures, only the pre-existing xfails).
- Three component tests added, and all three **fail** against the previous behavior — verified by reverting the fetch and re-running, not assumed.
- Frontend: 389 tests, `svelte-check` clean, production build green.

## Scope

Frontend only, 4 files. Found while integrating #381 but deliberately kept off that branch: it is a `master` bug unrelated to tags, and mixing them would make both harder to review.