### PR TITLE
fix(services): replace gender-guesser (GPLv3) with global-gender-predictor (MIT)

### DIFF
--- a/backend/app/services/metadata_speaker_extractor.py
+++ b/backend/app/services/metadata_speaker_extractor.py
@@ -438,8 +438,9 @@ def cross_reference_attributes(
 ) -> list[dict]:
     """Cross-reference metadata hints with voice-predicted attributes.
 
-    Compares name-inferred gender (via gender-guesser library) with
-    audio-predicted gender to produce alignment/conflict indicators.
+    Compares name-inferred gender (via the global-gender-predictor library,
+    built on the WGND 2.0 dataset) with audio-predicted gender to produce
+    alignment/conflict indicators.
 
     Args:
         hints: Speaker hints extracted from metadata.
@@ -462,11 +463,11 @@ def cross_reference_attributes(
         ]
     """
     try:
-        import gender_guesser.detector as gender_detector
+        from global_gender_predictor import GlobalGenderPredictor
 
-        detector = gender_detector.Detector()
+        predictor = GlobalGenderPredictor()
     except ImportError:
-        logger.warning("gender-guesser not installed, skipping cross-reference")
+        logger.warning("global-gender-predictor not installed, skipping cross-reference")
         return []
 
     results = []
@@ -477,12 +478,12 @@ def cross_reference_attributes(
         if not first_name:
             continue
 
-        # Use gender-guesser to infer gender from name
-        name_gender_raw = detector.get_gender(first_name)
+        # Use global-gender-predictor (WGND 2.0 data) to infer gender from name
+        name_gender_raw = predictor.predict_gender(first_name)
 
-        # Map gender-guesser results to our categories
-        # gender-guesser returns: "male", "female", "mostly_male", "mostly_female",
-        # "andy" (androgynous), "unknown"
+        # Map global-gender-predictor results to our categories
+        # global-gender-predictor returns: "Male", "Female", "Unknown"
+        # (below its 0.6 default confidence threshold collapses to "Unknown")
         name_gender = _map_gender_guess(name_gender_raw)
 
         if name_gender == "unknown":
@@ -523,10 +524,12 @@ def cross_reference_attributes(
 
 
 def _map_gender_guess(raw: str) -> str:
-    """Map gender-guesser result to our simplified categories."""
-    if raw in ("male", "mostly_male"):
+    """Map a global-gender-predictor result ("Male"/"Female"/"Unknown") to our
+    simplified categories."""
+    lowered = (raw or "").lower()
+    if lowered == "male":
         return "male"
-    elif raw in ("female", "mostly_female"):
+    elif lowered == "female":
         return "female"
     else:
         return "unknown"

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -77,7 +77,7 @@ omegaconf>=2.3.1
 
 # Supporting libraries
 ffmpeg-python>=0.2.0
-gender-guesser>=0.4.0
+global-gender-predictor>=0.0.5
 sentencepiece>=0.2.1
 psutil>=7.2.2
 pyexiftool>=0.5.6

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -146,7 +146,7 @@ omegaconf>=2.3.1
 
 # Supporting libraries
 ffmpeg-python>=0.2.0
-gender-guesser>=0.4.0
+global-gender-predictor>=0.0.5
 sentencepiece>=0.2.1
 psutil>=7.2.2
 pyexiftool>=0.5.6

--- a/backend/tests/unit/test_metadata_speaker_extractor.py
+++ b/backend/tests/unit/test_metadata_speaker_extractor.py
@@ -424,22 +424,18 @@ class TestMapGenderGuess:
     """Test _map_gender_guess mapping."""
 
     def test_male_maps_to_male(self):
-        assert _map_gender_guess("male") == "male"
-
-    def test_mostly_male_maps_to_male(self):
-        assert _map_gender_guess("mostly_male") == "male"
+        assert _map_gender_guess("Male") == "male"
 
     def test_female_maps_to_female(self):
-        assert _map_gender_guess("female") == "female"
-
-    def test_mostly_female_maps_to_female(self):
-        assert _map_gender_guess("mostly_female") == "female"
-
-    def test_andy_maps_to_unknown(self):
-        assert _map_gender_guess("andy") == "unknown"
+        assert _map_gender_guess("Female") == "female"
 
     def test_unknown_maps_to_unknown(self):
-        assert _map_gender_guess("unknown") == "unknown"
+        assert _map_gender_guess("Unknown") == "unknown"
+
+    def test_lowercase_male_maps_to_male(self):
+        """global-gender-predictor always returns title-case, but the mapper
+        should not depend on that."""
+        assert _map_gender_guess("male") == "male"
 
     def test_empty_maps_to_unknown(self):
         assert _map_gender_guess("") == "unknown"
@@ -451,26 +447,26 @@ class TestMapGenderGuess:
 
 
 def _mock_gender_guesser_modules(gender_map: dict) -> dict:
-    """Build a fake sys.modules patch for gender_guesser.
+    """Build a fake sys.modules patch for global_gender_predictor.
 
     cross_reference_attributes does:
-        import gender_guesser.detector as gender_detector
-        detector = gender_detector.Detector()
-    so we need both 'gender_guesser' and 'gender_guesser.detector' in
-    sys.modules, with Detector() returning a mock that uses gender_map.
+        from global_gender_predictor import GlobalGenderPredictor
+        predictor = GlobalGenderPredictor()
+    so we need 'global_gender_predictor' in sys.modules, with
+    GlobalGenderPredictor() returning a mock whose predict_gender() uses
+    gender_map. gender_map values are the raw library return values
+    ("Male"/"Female"/"Unknown", case-sensitive as the real library returns).
     """
-    mock_detector_instance = MagicMock()
-    mock_detector_instance.get_gender.side_effect = lambda name: gender_map.get(name, "unknown")
+    mock_predictor_instance = MagicMock()
+    mock_predictor_instance.predict_gender.side_effect = lambda name: gender_map.get(
+        name, "Unknown"
+    )
 
-    mock_detector_module = MagicMock()
-    mock_detector_module.Detector.return_value = mock_detector_instance
-
-    mock_gender_guesser = MagicMock()
-    mock_gender_guesser.detector = mock_detector_module
+    mock_module = MagicMock()
+    mock_module.GlobalGenderPredictor.return_value = mock_predictor_instance
 
     return {
-        "gender_guesser": mock_gender_guesser,
-        "gender_guesser.detector": mock_detector_module,
+        "global_gender_predictor": mock_module,
     }
 
 
@@ -483,7 +479,7 @@ class TestCrossReferenceAttributes:
         hints = [_make_hint("Jane Doe", role="guest")]
         speaker_attrs = {"SPEAKER_01": {"predicted_gender": "female", "gender_confidence": 0.95}}
 
-        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Jane": "female"})):
+        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Jane": "Female"})):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
         matches = [r for r in results if r["alignment"] == "match"]
@@ -496,7 +492,7 @@ class TestCrossReferenceAttributes:
         hints = [_make_hint("Bob Smith", role="guest")]
         speaker_attrs = {"SPEAKER_00": {"predicted_gender": "female", "gender_confidence": 0.80}}
 
-        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Bob": "male"})):
+        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Bob": "Male"})):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
         mismatches = [r for r in results if r["alignment"] == "mismatch"]
@@ -504,14 +500,14 @@ class TestCrossReferenceAttributes:
         assert mismatches[0]["hint_name"] == "Bob Smith"
 
     def test_unknown_name_filtered_out(self):
-        """Androgynous/unknown name → entry removed from results (alignment='unknown' filtered)."""
+        """Ambiguous/unknown name → entry removed from results (alignment='unknown' filtered)."""
         hints = [_make_hint("Pat Kim", role="unknown")]
         speaker_attrs = {"SPEAKER_00": {"predicted_gender": "female", "gender_confidence": 0.75}}
 
-        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Pat": "andy"})):
+        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Pat": "Unknown"})):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
-        # 'andy' maps to 'unknown', so no results should be returned for Pat Kim
+        # "Unknown" maps to 'unknown', so no results should be returned for Pat Kim
         pat_results = [r for r in results if r["hint_name"] == "Pat Kim"]
         assert len(pat_results) == 0
 
@@ -528,7 +524,7 @@ class TestCrossReferenceAttributes:
 
         with patch.dict(
             "sys.modules",
-            _mock_gender_guesser_modules({"Bob": "male", "Jane": "female"}),
+            _mock_gender_guesser_modules({"Bob": "Male", "Jane": "Female"}),
         ):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
@@ -557,20 +553,20 @@ class TestCrossReferenceAttributes:
             for i in range(15)
         }
         # Every first name (Woman0, Woman1, ...) maps to "female"
-        gender_map = {f"Woman{i}": "female" for i in range(15)}
+        gender_map = {f"Woman{i}": "Female" for i in range(15)}
 
         with patch.dict("sys.modules", _mock_gender_guesser_modules(gender_map)):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
         assert len(results) <= 10
 
-    def test_gender_guesser_import_error_returns_empty(self):
-        """If gender_guesser is not installed, returns empty list (graceful fallback)."""
+    def test_global_gender_predictor_import_error_returns_empty(self):
+        """If global-gender-predictor is not installed, returns empty list (graceful fallback)."""
         hints = [_make_hint("Jane Doe")]
         speaker_attrs = {"SPEAKER_00": {"predicted_gender": "female"}}
 
         # Setting the module to None in sys.modules causes ImportError on `import`
-        with patch.dict("sys.modules", {"gender_guesser": None, "gender_guesser.detector": None}):
+        with patch.dict("sys.modules", {"global_gender_predictor": None}):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
         assert results == []
@@ -580,7 +576,7 @@ class TestCrossReferenceAttributes:
         hints = [_make_hint("Alice Walker", role="guest")]
         speaker_attrs = {"SPEAKER_00": {"predicted_gender": "female", "gender_confidence": 0.92}}
 
-        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Alice": "female"})):
+        with patch.dict("sys.modules", _mock_gender_guesser_modules({"Alice": "Female"})):
             results = cross_reference_attributes(hints, speaker_attrs, speaker_segments=[])
 
         matches = [r for r in results if r["alignment"] == "match"]


### PR DESCRIPTION
## Summary

Closes #471. Replaces `gender-guesser` (GPLv3 code + a separately GFDL-licensed
`nam_dict.txt` dataset) with `global-gender-predictor` (MIT, code and data both),
which is built independently on the WGND 2.0 dataset (CC0, 195 countries, 4.1M
names) — no lineage back to `gender-guesser`/`nam_dict.txt` at all.

This isn't a "must fix immediately" issue (GPLv3 is compatible with our current
AGPL-3.0 license), but it was the single dependency most likely to block a
future relicense. Full research trail is in issue #471's comments.

## Changes

- `backend/requirements.txt`, `backend/requirements-ci.txt`: swap the dependency
- `backend/app/services/metadata_speaker_extractor.py`:
  `cross_reference_attributes()` now calls `GlobalGenderPredictor().predict_gender()`
  instead of `gender_guesser.detector.Detector().get_gender()`. `_map_gender_guess()`
  updated for the new library's `"Male"`/`"Female"`/`"Unknown"` return values
  (vs. the old `"male"`/`"mostly_male"`/`"andy"`/etc. tiers).
- `backend/tests/unit/test_metadata_speaker_extractor.py`: mocks and assertions
  updated for the new library's API and return values.

## Verification

- Confirmed the MIT license directly from the installed package's
  `dist-info/licenses/LICENSE` (not just PyPI classifiers).
- Exercised the real (non-mocked) library end-to-end — correct match/mismatch
  cross-reference output confirmed against real `predict_gender()` calls.
- `pytest tests/unit/test_metadata_speaker_extractor.py` — 83 passed.
- `ruff check` / `ruff format --check` / `mypy` — clean.
- Full `./scripts/safe-precommit.sh run --all-files` — all hooks green (backend +
  frontend checks, mypy, bandit, import-linter, test-quality/session-lifetime
  auditors, shellcheck).

## What this feature does (for reviewers unfamiliar with it)

`cross_reference_attributes()` is part of the optional LLM speaker-identification
task (`speaker_identification_task.py`). It compares a name-inferred gender (from
metadata-extracted speaker name hints, e.g. "Interview with Jane Doe") against an
audio-derived predicted gender already stored on each `Speaker` row, and surfaces
match/mismatch as extra context fed to the LLM prompt plus a small confidence
boost/penalty. It's a soft enrichment signal only — never auto-applied, and the
task degrades gracefully (skips the enrichment, logs a warning) if the library
is missing.