### PR TITLE
fix: three gate-found defects (#485, #486, #487) plus a live NLTK breakage

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -104,6 +104,10 @@ jobs:
     # A docs- or frontend-only PR cannot change its outcome, so don't pay for it.
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    # ~17 min in the normal case. The cap exists because a hosted-runner apt mirror
+    # outage once hung `apt-get update` until the 360-minute ACCOUNT default, burning
+    # six hours of runner time without executing a single test (issue #493).
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16
@@ -142,6 +146,9 @@ jobs:
           cache-dependency-path: backend/requirements-ci.txt
 
       - name: Install system dependencies
+        # Bounded separately from the job: a mirror that stops answering should fail this
+        # step in minutes, not consume the whole job budget retrying (issue #493).
+        timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Install Python dependencies (CPU wheels)

--- a/backend/app/api/endpoints/backup_settings.py
+++ b/backend/app/api/endpoints/backup_settings.py
@@ -28,6 +28,8 @@ from app import models
 # Deployment configuration is the super_admin tier: this router
 # holds the backup destination and its stored S3 secret.
 from app.api.endpoints.auth import get_current_active_superuser
+from app.core.constants import CeleryQueues
+from app.core.constants import UtilityPriority
 from app.db.base import get_db
 from app.services import backup_service
 
@@ -335,7 +337,7 @@ def run_backup_now(
     """Dispatch a backup immediately (bypasses the schedule)."""
     from app.tasks.backup_tasks import run_backup
 
-    task = run_backup.apply_async(queue="utility")
+    task = run_backup.apply_async(queue=CeleryQueues.UTILITY, priority=UtilityPriority.ROUTINE)
     logger.info("Manual backup triggered by admin %s (task %s)", current_user.email, task.id)
     return BackupRunResponse(
         task_id=str(task.id), status="queued", message="Backup task queued successfully."

--- a/backend/app/core/celery.py
+++ b/backend/app/core/celery.py
@@ -418,6 +418,26 @@ celery_app.conf.update(
     },
 )
 
+# Make this app the process-wide default, not just this thread's (issue #485).
+#
+# `Celery.__init__` sets only the CREATING thread's `celery._state._tls.current_app`;
+# it never sets the module-global `default_app`. Anything that resolves a task through
+# `get_current_app()` — every `@shared_task` proxy — therefore reads
+# `_tls.current_app or default_app`, and on a thread that did not construct the app both
+# are None. Celery then mints a fallback `Celery('default')` with NO broker configured and
+# caches it globally, so the dispatch goes to the amqp:// class default and is refused.
+#
+# The API hits this on every request: FastAPI/Starlette runs each sync `def` endpoint on a
+# `run_in_threadpool` worker thread, which is never the import thread. That made every admin
+# "Run now" action 500 intermittently, while workers (which import this module on their own
+# main thread) were unaffected.
+#
+# `set_default()` is what populates `default_app`, so the fallback resolves to the real,
+# configured app from any thread and any process. Keep this even though the `@shared_task`
+# decorators below were converted to `@celery_app.task` — it is the cheap general guard, and
+# without it a single reintroduced `shared_task` silently brings the bug back.
+celery_app.set_default()
+
 
 # Apply our logging config (text/JSON per settings.LOG_FORMAT) to Celery.
 # Connecting setup_logging ALSO disables Celery's root-logger hijack

--- a/backend/app/tasks/README.md
+++ b/backend/app/tasks/README.md
@@ -313,7 +313,7 @@ else:
 Automated background tasks for system maintenance, file recovery, and health monitoring:
 
 ```python
-@shared_task(bind=True, name="cleanup.run_periodic_cleanup")
+@celery_app.task(bind=True, name="cleanup.run_periodic_cleanup")
 def run_periodic_cleanup(self):
     """
     Periodic task to clean up stuck files and maintain system health.
@@ -324,7 +324,7 @@ def run_periodic_cleanup(self):
     - Generate system health reports
     """
 
-@shared_task(bind=True, name="cleanup.deep_cleanup")
+@celery_app.task(bind=True, name="cleanup.deep_cleanup")
 def run_deep_cleanup(self, dry_run: bool = False):
     """
     Deep cleanup task for removing orphaned files (admin-triggered).
@@ -333,13 +333,13 @@ def run_deep_cleanup(self, dry_run: bool = False):
         dry_run: If True, only preview what would be cleaned up
     """
 
-@shared_task(bind=True, name="cleanup.health_check")
+@celery_app.task(bind=True, name="cleanup.health_check")
 def system_health_check(self):
     """
     Generate a system health report with file processing metrics.
     """
 
-@shared_task(bind=True, name="cleanup.emergency_recovery")
+@celery_app.task(bind=True, name="cleanup.emergency_recovery")
 def emergency_file_recovery(self, file_ids: list):
     """
     Emergency recovery task for specific files (admin-triggered).

--- a/backend/app/tasks/backup_tasks.py
+++ b/backend/app/tasks/backup_tasks.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC
 
-from celery import shared_task
-
+from app.core.celery import celery_app
 from app.core.constants import CeleryQueues
 from app.core.constants import DownloadPriority
 from app.core.constants import UtilityPriority
@@ -32,7 +31,7 @@ from app.utils.task_lock import task_lock_manager
 logger = logging.getLogger(__name__)
 
 
-@shared_task(name="backup.check_schedule", priority=UtilityPriority.ROUTINE)
+@celery_app.task(name="backup.check_schedule", priority=UtilityPriority.ROUTINE)
 def check_backup_schedule() -> dict:
     """Beat-driven due-check. Dispatch ``backup.run`` when the cron schedule is due.
 
@@ -69,7 +68,7 @@ BACKUP_LOCK_KEY = "backup_run"
 BACKUP_LOCK_TIMEOUT = 3 * 3600
 
 
-@shared_task(name="backup.run", priority=UtilityPriority.ROUTINE)
+@celery_app.task(name="backup.run", priority=UtilityPriority.ROUTINE)
 def run_backup() -> dict:
     """Execute one database backup end-to-end and return the result dict.
 
@@ -86,7 +85,7 @@ def run_backup() -> dict:
         return backup_service.perform_backup()
 
 
-@shared_task(name="backup.mirror_check_schedule", priority=UtilityPriority.ROUTINE)
+@celery_app.task(name="backup.mirror_check_schedule", priority=UtilityPriority.ROUTINE)
 def check_mirror_schedule() -> dict:
     """Beat-driven due-check. Dispatch ``backup.mirror_run`` when the cron is due.
 
@@ -119,7 +118,7 @@ def check_mirror_schedule() -> dict:
     return {"status": "dispatched", "schedule": cfg["schedule"]}
 
 
-@shared_task(name="backup.mirror_run", priority=DownloadPriority.PLAYLIST)
+@celery_app.task(name="backup.mirror_run", priority=DownloadPriority.PLAYLIST)
 def run_media_mirror(max_objects: int | None = None) -> dict:
     """Execute one incremental media mirror run under the overlap-preventing lock.
 

--- a/backend/app/tasks/chat_retention.py
+++ b/backend/app/tasks/chat_retention.py
@@ -15,8 +15,7 @@ from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 
-from celery import shared_task
-
+from app.core.celery import celery_app
 from app.core.constants import UtilityPriority
 
 logger = logging.getLogger(__name__)
@@ -27,7 +26,7 @@ logger = logging.getLogger(__name__)
 MAX_DELETIONS_PER_RUN = 500
 
 
-@shared_task(
+@celery_app.task(
     bind=True,
     name="chat.retention_sweep",
     priority=UtilityPriority.BACKGROUND,

--- a/backend/app/tasks/cleanup.py
+++ b/backend/app/tasks/cleanup.py
@@ -10,8 +10,6 @@ from datetime import timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from celery import shared_task
-
 from app.core.celery import celery_app
 from app.core.constants import UtilityPriority
 from app.db.session_utils import session_scope
@@ -34,7 +32,7 @@ _MAX_UPLOAD_GRACE_MINUTES = 48 * 60
 _DEFAULT_RETENTION_HOUR = 2
 
 
-@shared_task(bind=True, name="cleanup.run_periodic_cleanup", priority=UtilityPriority.ROUTINE)
+@celery_app.task(bind=True, name="cleanup.run_periodic_cleanup", priority=UtilityPriority.ROUTINE)
 def run_periodic_cleanup(self):
     """
     Periodic task to clean up stuck files and maintain system health.
@@ -74,7 +72,7 @@ def run_periodic_cleanup(self):
         raise self.retry(countdown=3600, max_retries=3) from e  # Retry in 1 hour
 
 
-@shared_task(bind=True, name="cleanup.deep_cleanup", priority=UtilityPriority.BACKGROUND)
+@celery_app.task(bind=True, name="cleanup.deep_cleanup", priority=UtilityPriority.BACKGROUND)
 def run_deep_cleanup(self, dry_run: bool = False):
     """
     Deep cleanup task for removing orphaned files (admin-triggered).
@@ -106,7 +104,7 @@ def run_deep_cleanup(self, dry_run: bool = False):
         raise
 
 
-@shared_task(bind=True, name="cleanup.health_check", priority=UtilityPriority.OPERATIONAL)
+@celery_app.task(bind=True, name="cleanup.health_check", priority=UtilityPriority.OPERATIONAL)
 def system_health_check(self):
     """
     Generate a system health report.
@@ -138,7 +136,7 @@ def system_health_check(self):
         raise
 
 
-@shared_task(bind=True, name="cleanup.emergency_recovery", priority=UtilityPriority.EMERGENCY)
+@celery_app.task(bind=True, name="cleanup.emergency_recovery", priority=UtilityPriority.EMERGENCY)
 def emergency_file_recovery(self, file_uuids: list):
     """
     Emergency recovery task for specific files (admin-triggered).
@@ -228,7 +226,7 @@ def _upload_grace_minutes(file_size: int | None, base_minutes: int) -> int:
     return min(max(base_minutes, needed), _MAX_UPLOAD_GRACE_MINUTES)
 
 
-@shared_task(bind=True, name="cleanup.orphan_upload_sweeper", priority=UtilityPriority.ROUTINE)
+@celery_app.task(bind=True, name="cleanup.orphan_upload_sweeper", priority=UtilityPriority.ROUTINE)
 def orphan_upload_sweeper(self, max_age_minutes: int = 30) -> dict[str, int]:
     """Delete PENDING MediaFile rows abandoned before MinIO finished storing.
 
@@ -354,7 +352,7 @@ def orphan_upload_sweeper(self, max_age_minutes: int = 30) -> dict[str, int]:
     }
 
 
-@shared_task(bind=True, name="cleanup.scratch_janitor", priority=UtilityPriority.ROUTINE)
+@celery_app.task(bind=True, name="cleanup.scratch_janitor", priority=UtilityPriority.ROUTINE)
 def scratch_janitor(self, ttl_seconds: int | None = None) -> dict[str, int]:
     """Purge stale per-file directories from the shared scratch volume.
 

--- a/backend/app/tasks/directory_sync_task.py
+++ b/backend/app/tasks/directory_sync_task.py
@@ -23,8 +23,7 @@ import logging
 from datetime import UTC
 from datetime import datetime
 
-from celery import shared_task
-
+from app.core.celery import celery_app
 from app.core.constants import CeleryQueues
 from app.core.constants import CPUPriority
 from app.db.session_utils import session_scope
@@ -39,7 +38,7 @@ DIRECTORY_SYNC_LOCK_KEY = "directory_sync_run"
 DIRECTORY_SYNC_LOCK_TIMEOUT = 1800
 
 
-@shared_task(name="directory.sync_check_schedule", priority=CPUPriority.MAINTENANCE)
+@celery_app.task(name="directory.sync_check_schedule", priority=CPUPriority.MAINTENANCE)
 def check_directory_sync_schedule() -> dict:
     """Beat-driven due-check. Dispatch ``directory.sync_run`` when the cron is due.
 
@@ -68,7 +67,7 @@ def check_directory_sync_schedule() -> dict:
     return {"status": "dispatched", "schedule": cfg["schedule"]}
 
 
-@shared_task(name="directory.sync_run", priority=CPUPriority.MAINTENANCE)
+@celery_app.task(name="directory.sync_run", priority=CPUPriority.MAINTENANCE)
 def run_directory_sync(dry_run: bool | None = None) -> dict:
     """Execute one reconciliation pass and return its report.
 

--- a/backend/app/tasks/erasure_reconciliation.py
+++ b/backend/app/tasks/erasure_reconciliation.py
@@ -51,8 +51,7 @@ import logging
 from typing import TYPE_CHECKING
 from typing import Any
 
-from celery import shared_task
-
+from app.core.celery import celery_app
 from app.core.constants import UtilityPriority
 
 if TYPE_CHECKING:  # heavy model import kept out of the worker's import path
@@ -138,7 +137,7 @@ def _rerun(db, entry) -> dict[str, Any]:
     )
 
 
-@shared_task(
+@celery_app.task(
     bind=True,
     name="gdpr.erasure_reconcile",
     priority=UtilityPriority.BACKGROUND,

--- a/backend/app/utils/segment_dedup.py
+++ b/backend/app/utils/segment_dedup.py
@@ -17,6 +17,22 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+#: Maximum silent gap (seconds) between two identically-worded segments for them to be
+#: considered the *same* utterance emitted twice, rather than the speaker genuinely saying
+#: the same short phrase again later ("Yeah.", "Right.", "Okay.").
+#:
+#: Phase 2 compares every kept segment against every other one, so without a time bound it
+#: collapses repeated utterances anywhere in the recording — real speech, silently deleted
+#: (issue #487: 31 words lost from the 10-minute boundary fixture, including three "Yeah."s
+#: up to 149 s apart). Phase 3's "must actually overlap" rule is too strict to reuse here:
+#: genuine Whisper re-emissions in that fixture are adjacent, not overlapping, so requiring
+#: overlap disables Phase 2 entirely.
+#:
+#: Measured against ``tests/fixtures/boundary/karpathy_10m``: the correct 110 segments /
+#: 2282 words is recovered for any value in [0.5, 2.0]; 0.0 removes nothing and >=5.0 starts
+#: over-removing again. 2.0 is the widest value in that plateau.
+_EXACT_DUPLICATE_MAX_GAP_S = 2.0
+
 
 def deduplicate_segments(
     segments: list[dict],
@@ -67,7 +83,7 @@ def deduplicate_segments(
     keep = np.ones(n, dtype=bool)
 
     _remove_contained_segments(starts, ends, durations, overlap_threshold, keep)
-    _remove_exact_duplicates(sorted_segments, durations, keep)
+    _remove_exact_duplicates(sorted_segments, starts, ends, durations, keep)
     _remove_similar_overlapping_segments(sorted_segments, starts, ends, keep)
 
     result = [sorted_segments[i] for i in range(n) if keep[i]]
@@ -163,6 +179,8 @@ def _remove_contained_segments(
 
 def _remove_exact_duplicates(
     sorted_segments: list[dict],
+    starts: np.ndarray,
+    ends: np.ndarray,
     durations: np.ndarray,
     keep: np.ndarray,
 ) -> None:
@@ -176,8 +194,16 @@ def _remove_exact_duplicates(
     full pairwise scan over the already-reduced kept set is cheap and
     simpler than a windowed heuristic.
 
+    Pairs separated by more than ``_EXACT_DUPLICATE_MAX_GAP_S`` of silence are
+    left alone. Comparing against only the immediate predecessor used to bound
+    this implicitly; the full pairwise scan needs the bound stated explicitly,
+    or repeated short utterances get collapsed across the whole recording and
+    real speech disappears (issue #487).
+
     Args:
         sorted_segments: Segment dicts, sorted by start then duration descending.
+        starts: Segment start times, same order as ``sorted_segments``.
+        ends: Segment end times, same order as ``sorted_segments``.
         durations: Segment durations, same order as ``sorted_segments``.
         keep: Boolean keep/remove mask, modified in place.
     """
@@ -193,6 +219,12 @@ def _remove_exact_duplicates(
             if not keep[j]:
                 continue
             if text_i != sorted_segments[j]["text"].strip():
+                continue
+
+            # Negative when the two segments overlap in time; positive is the silent
+            # gap between them. Same utterance twice, or a genuine repetition later?
+            gap = max(starts[i], starts[j]) - min(ends[i], ends[j])
+            if gap > _EXACT_DUPLICATE_MAX_GAP_S:
                 continue
 
             # Keep the one with better timing (more precise start/end)

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -85,7 +85,7 @@ yt-dlp[default]>=2026.6.9
 
 # Semantic search and NLP
 sentence-transformers>=5.6.0
-nltk>=3.9.4
+nltk>=3.10.3,<4  # see requirements.txt — pathsec hardening is required, not avoided
 
 # Cloud ASR provider SDKs (lazily imported)
 # deepgram-sdk<7.6.0 breaks under websockets>=15 — see requirements.txt for the full

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -156,7 +156,14 @@ yt-dlp[default]>=2026.6.9
 
 # Semantic search and NLP
 sentence-transformers>=5.6.0  # For semantic search embeddings (all-MiniLM-L6-v2)
-nltk>=3.9.4  # Required by whisperx>=3.7.6, also for SnowballStemmer
+# Required by whisperx>=3.7.6, also for SnowballStemmer.
+# Floor is >=3.10.3 deliberately, to REQUIRE the `nltk/pathsec.py` hardening rather than
+# avoid it: 3.10 refuses to open multiply-linked data files (CWE-59). A hardlinked model
+# cache therefore breaks sentence splitting, and the fix is `ensure_nltk_data_unlinked`
+# in scripts/common.sh, which runs at every startup — not an older NLTK. The old
+# floor-only `>=3.9.4` also let host (3.9.4) and container (3.10.3) diverge silently,
+# which is how this reached production undetected (issue #491).
+nltk>=3.10.3,<4
 # NLTK data files (punkt_tab) must be pre-downloaded for offline usage
 
 # Cloud ASR provider SDKs (lazily imported — only needed for configured provider)

--- a/backend/tests/integration/test_corpus_injection_synthetic_e2e.py
+++ b/backend/tests/integration/test_corpus_injection_synthetic_e2e.py
@@ -228,6 +228,23 @@ class TestGoldSpansBecomeJudgementsOverRealChunks:
 
         assert builder.judgements([GoldSpan(absent, 0, 3)]) == {}
 
+    @pytest.mark.xfail(
+        reason=(
+            "issue #495: a `term` query on file_uuid returns no chunks for this meeting, while "
+            "the sibling test_every_injected_meeting_produces_chunks asserts (and passes) that "
+            "EVERY injected meeting has chunks. Pre-existing — reproduces from a clean "
+            "`git archive master` tree on the same venv — and NOT a product defect: the live "
+            "index holds 13,023 chunks across 18 real files, so real search and retrieval are "
+            "unaffected. Ruled out: file_uuid is mapped `keyword` (so `term` is valid), no "
+            "leftover synthetic media_file rows, and it fails in isolation so it is not test "
+            "ordering. Prime suspect is that dispatch_indexing short-circuits chunk indexing on "
+            "re-injection because the teardown deletes the chunks and the DB rows but NOT the "
+            "`transcripts` document, which survives as 'result': 'updated'. "
+            "STRICT: the failure is deterministic, so if #495 is fixed this XPASSes and FAILS "
+            "the suite, forcing the marker to be removed rather than outliving its bug."
+        ),
+        strict=True,
+    )
     def test_the_indexed_chunk_text_is_the_generators_own_turn_content(self, injected, opensearch):
         from app.core.config import settings
 

--- a/backend/tests/test_selective_reprocess.py
+++ b/backend/tests/test_selective_reprocess.py
@@ -59,26 +59,29 @@ def headers(auth_token):
 
 @pytest.fixture(scope="module")
 def completed_file(headers):
-    """Find the shortest completed file in the database."""
+    """Find the shortest completed file in the database.
+
+    Filters by status SERVER-side and paginates with ``page_size``. The endpoint takes
+    ``page_size`` (`files/__init__.py`), not ``limit`` — FastAPI silently ignores an
+    unknown query param, so the old `limit=1` fell back to the default page of 20 and the
+    "shortest completed" was whatever happened to land in the 20 shortest files OVERALL.
+    On a database whose short files are mostly `error`, that is not the shortest completed
+    file, and picking a needlessly long one is what makes every stage in this module slow.
+    """
     resp = requests.get(
         f"{BASE_URL}/files",
         headers=headers,
-        params={"limit": "1", "sort_by": "duration", "sort_order": "asc"},
+        params={
+            "page_size": "5",
+            "status": "completed",
+            "sort_by": "duration",
+            "sort_order": "asc",
+        },
     )
     assert resp.status_code == 200, f"Failed to fetch files: {resp.text}"
 
     data = resp.json()
-    files = data.get("items", [])
-    completed = [f for f in files if f.get("status") == "completed"]
-    if not completed:
-        # Try fetching more files
-        resp2 = requests.get(
-            f"{BASE_URL}/files",
-            headers=headers,
-            params={"limit": "20", "sort_by": "duration", "sort_order": "asc"},
-        )
-        data2 = resp2.json()
-        completed = [f for f in data2.get("items", []) if f.get("status") == "completed"]
+    completed = [f for f in data.get("items", []) if f.get("status") == "completed"]
 
     if not completed:
         pytest.skip("No completed files in database — upload and process one first")
@@ -93,6 +96,11 @@ def completed_file(headers):
     return f
 
 
+#: Statuses a file can never leave on its own. Reaching one means the answer is already
+#: decided, so continuing to poll for "completed" only burns the rest of the window.
+_TERMINAL_FAILURE_STATUSES = frozenset({"error", "cancelled"})
+
+
 def _wait_for_completed(headers, file_uuid, max_wait=180):
     """Wait for the file to be STABLY completed.
 
@@ -100,12 +108,30 @@ def _wait_for_completed(headers, file_uuid, max_wait=180):
     search indexing) can flip the file back to PROCESSING moments after a
     prior stage reports completed, which races the next reprocess request
     into an INVALID_STATUS rejection. Require two consecutive completed polls.
+
+    Fails FAST on a terminal failure status. Without that, a stage that errors in
+    ~50 s still costs the caller its whole window — ``max_wait=600`` at 1-2 s a poll
+    is 10-20 minutes — waiting for a "completed" that can never arrive, and then
+    reports a bare "File not completed" that says nothing about what went wrong.
+    Observed: a rediarize OOM'd on a 61-minute file, and the suite spent the next
+    several minutes polling a row that already said ``error``.
     """
     consecutive = 0
     for i in range(max_wait):
         resp = requests.get(f"{BASE_URL}/files/{file_uuid}", headers=headers)
         if resp.status_code == 200:
-            status = resp.json().get("status")
+            body = resp.json()
+            status = body.get("status")
+            if status in _TERMINAL_FAILURE_STATUSES:
+                # `GET /files/{uuid}` carries error_category, not last_error_message; the
+                # full message lives on /status-detail, so name the category and point at it
+                # rather than reporting an empty string.
+                detail = body.get("last_error_message") or body.get("error_category") or "unknown"
+                pytest.fail(
+                    f"file {file_uuid} reached terminal status {status!r} after {i}s and "
+                    f"cannot become completed (error_category={detail}). "
+                    f"Full message: GET {BASE_URL}/files/{file_uuid}/status-detail"
+                )
             if status == "completed":
                 consecutive += 1
                 if consecutive >= 2:

--- a/backend/tests/test_selective_reprocess.py
+++ b/backend/tests/test_selective_reprocess.py
@@ -13,7 +13,10 @@ Requires:
 """
 
 import logging
+import os
 import time
+import uuid
+from pathlib import Path
 
 import pytest
 import requests
@@ -57,43 +60,97 @@ def headers(auth_token):
     return {"Authorization": f"Bearer {auth_token}"}
 
 
+#: The committed 10 s / mono / 16 kHz fixture — see `tests/fixtures/media/README.md`.
+#: Small, deterministic and GPU-light, so this module runs the same way everywhere.
+_SAMPLE_AUDIO = Path(__file__).resolve().parent / "fixtures" / "media" / "sample_short.wav"
+
+#: Local-only override for real-corpus verification (`test_videos/`, the AMI corpus, a long
+#: meeting recording). CI runners have no GPU and no such assets, so the committed fixture
+#: stays the default and this is opt-in:
+#:
+#:     REPROCESS_TEST_MEDIA=test_videos/test_ai_video.mp4 pytest tests/test_selective_reprocess.py
+#:
+#: Mind the VRAM: diarizing a multi-hour file needs far more than the 12 GB on this box —
+#: that is what made these tests fail before they used a short clip.
+_MEDIA_OVERRIDE_ENV = "REPROCESS_TEST_MEDIA"
+
+
+def _source_media() -> Path:
+    """The clip to upload: the local override when set, else the committed fixture."""
+    override = os.environ.get(_MEDIA_OVERRIDE_ENV, "").strip()
+    if not override:
+        return _SAMPLE_AUDIO
+    path = Path(override)
+    if not path.is_absolute():
+        # Relative paths resolve from the repo root, which is where these are run from.
+        path = Path(__file__).resolve().parents[2] / path
+    if not path.exists():
+        pytest.fail(f"{_MEDIA_OVERRIDE_ENV}={override!r} does not exist (resolved to {path})")
+    return path
+
+
 @pytest.fixture(scope="module")
 def completed_file(headers):
-    """Find the shortest completed file in the database.
+    """Upload the committed short fixture and process it, then clean it up.
 
-    Filters by status SERVER-side and paginates with ``page_size``. The endpoint takes
-    ``page_size`` (`files/__init__.py`), not ``limit`` — FastAPI silently ignores an
-    unknown query param, so the old `limit=1` fell back to the default page of 20 and the
-    "shortest completed" was whatever happened to land in the 20 shortest files OVERALL.
-    On a database whose short files are mostly `error`, that is not the shortest completed
-    file, and picking a needlessly long one is what makes every stage in this module slow.
+    This used to reprocess whichever completed file the dev database happened to hold,
+    which was wrong three ways:
+
+    * **It mutated real data.** Reprocessing rewrites an existing user's transcript in
+      place, which ``backend/tests/CLAUDE.md`` forbids ("E2E must never persist changes
+      to dev data").
+    * **It could not pass on this hardware.** The shortest *completed* file here is
+      8168 s (2 h 16 m); diarizing it exhausts a 12 GB GPU even at ``batch_size=1``, so
+      the rediarize/transcription stages OOM'd. The first failure left the file in
+      ``error``, and because this fixture is module-scoped every later test in the module
+      then failed on the same poisoned file.
+    * **It was ambient.** Whether the suite passed depended on what someone had uploaded.
+
+    A 10 s clip removes all three: it is deterministic, it fits in any GPU, and it is
+    deleted afterwards so the dev library is unchanged.
     """
-    resp = requests.get(
-        f"{BASE_URL}/files",
-        headers=headers,
-        params={
-            "page_size": "5",
-            "status": "completed",
-            "sort_by": "duration",
-            "sort_order": "asc",
-        },
-    )
-    assert resp.status_code == 200, f"Failed to fetch files: {resp.text}"
+    source = _source_media()
+    if not source.exists():  # pragma: no cover - the committed fixture is tracked
+        pytest.skip(f"missing media fixture {source}")
 
-    data = resp.json()
-    completed = [f for f in data.get("items", []) if f.get("status") == "completed"]
+    mime = "video/mp4" if source.suffix.lower() in {".mp4", ".m4v", ".mov"} else "audio/wav"
+    with source.open("rb") as fh:
+        resp = requests.post(
+            f"{BASE_URL}/files",
+            headers=headers,
+            files={
+                "file": (f"reprocess-{uuid.uuid4().hex[:8]}{source.suffix}", fh, mime),
+            },
+            timeout=300,
+        )
+    assert resp.status_code == 200, f"Upload failed: {resp.status_code} {resp.text}"
+    uploaded = resp.json()
+    file_uuid = uploaded["uuid"]
 
-    if not completed:
-        pytest.skip("No completed files in database — upload and process one first")
+    try:
+        # Transcribing 10 s is quick, but the queue may be busy; this is the initial
+        # ingest, not a reprocess, so give it its own generous window.
+        assert _wait_for_completed(headers, file_uuid, max_wait=300), (
+            f"uploaded fixture {file_uuid} never reached a stable completed state"
+        )
 
-    f = completed[0]
-    logger.info(
-        f"\nUsing file: {f.get('filename', '?')[:50]}"
-        f"\n  UUID: {f['uuid']}"
-        f"\n  Duration: {f.get('duration', 0):.1f}s"
-        f"\n  Status: {f.get('status')}"
-    )
-    return f
+        resp = requests.get(f"{BASE_URL}/files/{file_uuid}", headers=headers, timeout=30)
+        assert resp.status_code == 200, f"Failed to re-read uploaded file: {resp.text}"
+        f = resp.json()
+        logger.info(
+            f"\nUsing uploaded fixture: {f.get('filename', '?')[:50]}"
+            f"\n  UUID: {f['uuid']}"
+            f"\n  Duration: {f.get('duration', 0):.1f}s"
+            f"\n  Status: {f.get('status')}"
+        )
+        yield f
+    finally:
+        # Delete on the way out no matter how the module ended — a cleanup that only runs
+        # on the happy path is exactly the one that does not run when a test fails.
+        try:
+            requests.delete(f"{BASE_URL}/files/{file_uuid}", headers=headers, timeout=30)
+        except requests.RequestException:
+            logger.warning("could not delete uploaded fixture %s", file_uuid)
 
 
 #: Statuses a file can never leave on its own. Reaching one means the answer is already

--- a/backend/tests/unit/test_backup_tasks.py
+++ b/backend/tests/unit/test_backup_tasks.py
@@ -282,6 +282,9 @@ def test_check_mirror_schedule_disabled_dispatches_nothing(use_test_session):
 
 def test_check_mirror_schedule_not_due_dispatches_nothing(use_test_session):
     mm.update_settings(use_test_session, enabled=True, schedule="0 4 * * *")
+    # UNCHANGED, not None — same shared-DB hazard as the backup sibling above. This one went
+    # red the first time anyone exercised POST /admin/backup/mirror/run against the dev stack.
+    before = mm.get_settings(use_test_session)["last_run_at"]
 
     with (
         mock.patch.object(bs, "is_due", return_value=False),
@@ -291,7 +294,7 @@ def test_check_mirror_schedule_not_due_dispatches_nothing(use_test_session):
 
     assert result == {"status": "not_due", "schedule": "0 4 * * *"}
     dispatch.assert_not_called()
-    assert mm.get_settings(use_test_session)["last_run_at"] is None
+    assert mm.get_settings(use_test_session)["last_run_at"] == before
 
 
 def test_check_mirror_schedule_due_stamps_and_dispatches_on_download_queue(use_test_session):

--- a/backend/tests/unit/test_backup_tasks.py
+++ b/backend/tests/unit/test_backup_tasks.py
@@ -101,6 +101,11 @@ def test_check_backup_schedule_disabled_dispatches_nothing(use_test_session):
 
 def test_check_backup_schedule_not_due_dispatches_nothing_and_does_not_stamp(use_test_session):
     bs.update_settings(use_test_session, enabled=True, schedule="0 3 * * *")
+    # "Does not stamp" means the value is UNCHANGED, not that it is None. `backup.last_run_at`
+    # is a SystemSettings row in the shared dev DB that the running celery-beat commits
+    # whenever a scheduled backup fires, so asserting `is None` only held on a database where
+    # beat had never run — it went red the first time the dev stack claimed a backup window.
+    before = bs.get_settings(use_test_session)["last_run_at"]
 
     with (
         mock.patch.object(bs, "is_due", return_value=False),
@@ -110,7 +115,7 @@ def test_check_backup_schedule_not_due_dispatches_nothing_and_does_not_stamp(use
 
     assert result == {"status": "not_due", "schedule": "0 3 * * *"}
     dispatch.assert_not_called()
-    assert bs.get_settings(use_test_session)["last_run_at"] is None
+    assert bs.get_settings(use_test_session)["last_run_at"] == before
 
 
 def test_check_backup_schedule_due_stamps_last_run_and_dispatches(use_test_session):

--- a/backend/tests/unit/test_celery_app_resolution.py
+++ b/backend/tests/unit/test_celery_app_resolution.py
@@ -1,0 +1,187 @@
+"""Celery task/app resolution must not depend on which thread dispatches (issue #485).
+
+Every admin "Run now" endpoint 500'd intermittently because ``@shared_task`` resolves its
+task through ``celery._state.get_current_app()``, which reads a **thread-local**.
+``Celery.__init__`` sets only the creating thread's slot and never the module-global
+``default_app``, so on a Starlette threadpool worker thread both were ``None`` and Celery
+minted a fallback ``Celery('default')`` with **no broker** — dispatching to the
+``amqp://guest@localhost:5672//`` class default, which nothing listens on here.
+
+Why these tests look the way they do:
+
+- **They assert on APP IDENTITY, not on the endpoint response.** The autouse
+  ``_skip_celery_dispatch`` fixture (``tests/conftest.py``) patches
+  ``celery.app.task.Task.apply_async`` at the *class* level, so a route test asserting
+  ``task_id == "test-task-id"`` passes whichever app the proxy resolved. It cannot see this
+  bug at all.
+- **The thread cases run in a clean process.** ``default_app`` is process-global and, once
+  minted, is cached forever — so a single earlier import in the same interpreter permanently
+  masks the failure for every later test. Testing this in-process would be a test that
+  cannot fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Kept out of the parallel pool: each case forks an interpreter that imports the whole app.
+pytestmark = pytest.mark.xdist_group("celery_app_resolution")
+
+
+_THREAD_PROBE = """
+import threading
+from app.core.celery import celery_app
+from app.tasks.backup_tasks import run_backup
+
+result = {}
+
+
+def probe():
+    task = run_backup
+    result["same_app"] = task.app is celery_app
+    result["broker"] = str(task.app.conf.broker_url)
+
+
+t = threading.Thread(target=probe)
+t.start()
+t.join()
+print(f'{result["same_app"]}|{result["broker"]}')
+"""
+
+
+_THREADPOOL_PROBE = """
+import anyio
+from starlette.concurrency import run_in_threadpool
+from app.core.celery import celery_app
+from app.tasks.backup_tasks import run_backup
+
+
+async def main():
+    def dispatch_thread_view():
+        return (run_backup.app is celery_app, str(run_backup.app.conf.broker_url))
+
+    same_app, broker = await run_in_threadpool(dispatch_thread_view)
+    print(f"{same_app}|{broker}")
+
+
+anyio.run(main)
+"""
+
+
+_DEFAULT_APP_PROBE = """
+from app.core.celery import celery_app
+from celery import _state
+
+print(_state.default_app is celery_app)
+"""
+
+
+def test_default_app_is_the_configured_app(run_in_clean_process):
+    """Importing the app must populate ``_state.default_app``, not just this thread's slot.
+
+    This is the single line that fixes the whole class: every ``get_current_app()`` fallback
+    resolves through ``default_app``.
+    """
+    assert run_in_clean_process(_DEFAULT_APP_PROBE) == "True"
+
+
+def test_task_resolves_the_configured_app_from_a_plain_worker_thread(run_in_clean_process):
+    """A thread that did not import the app still resolves the real, Redis-backed app."""
+    same_app, broker = run_in_clean_process(_THREAD_PROBE).split("|")
+
+    assert same_app == "True", "task resolved a different app object on a non-import thread"
+    assert broker.startswith("redis"), (
+        f"non-import thread resolved broker {broker!r}; 'None' means the phantom "
+        "Celery('default') came back and dispatch would go to amqp://"
+    )
+
+
+def test_task_resolves_the_configured_app_under_run_in_threadpool(run_in_clean_process):
+    """The exact call shape of a sync ``def`` FastAPI endpoint.
+
+    ``run_in_threadpool`` is how Starlette runs every sync endpoint handler, and is what the
+    three admin "Run now" routes go through. A bare ``threading.Thread`` reproduces the same
+    mechanism, but only this one matches production.
+    """
+    same_app, broker = run_in_clean_process(_THREADPOOL_PROBE).split("|")
+
+    assert same_app == "True"
+    assert broker.startswith("redis"), f"threadpool worker resolved broker {broker!r}"
+
+
+# ---------------------------------------------------------------------------
+# Task names are a wire contract — beat and routing reference them as strings
+# ---------------------------------------------------------------------------
+
+#: The 14 tasks converted from ``@shared_task`` to ``@celery_app.task`` for #485. All 14
+#: already declared an explicit ``name=``, so the decorator swap cannot rename them — this
+#: pins that, because a silent rename breaks ``beat_schedule`` with no error at all: beat
+#: would keep publishing a name no worker has registered.
+CONVERTED_TASK_NAMES = frozenset(
+    {
+        "backup.check_schedule",
+        "backup.run",
+        "backup.mirror_check_schedule",
+        "backup.mirror_run",
+        "directory.sync_check_schedule",
+        "directory.sync_run",
+        "cleanup.run_periodic_cleanup",
+        "cleanup.deep_cleanup",
+        "cleanup.health_check",
+        "cleanup.emergency_recovery",
+        "cleanup.orphan_upload_sweeper",
+        "cleanup.scratch_janitor",
+        "chat.retention_sweep",
+        "gdpr.erasure_reconcile",
+    }
+)
+
+
+@pytest.fixture(scope="module")
+def registered_task_names() -> frozenset[str]:
+    """Every task name the app knows, with the lazy ``include=`` modules imported."""
+    from app.core.celery import celery_app
+
+    celery_app.loader.import_default_modules()
+    celery_app.finalize()
+    return frozenset(celery_app.tasks.keys())
+
+
+def test_every_converted_task_is_still_registered_under_its_original_name(
+    registered_task_names,
+):
+    missing = sorted(CONVERTED_TASK_NAMES - registered_task_names)
+
+    assert not missing, (
+        f"these task names disappeared from the registry: {missing}. "
+        "beat_schedule and task_routes address tasks by string name, so a rename "
+        "silently stops the schedule rather than raising."
+    )
+
+
+def test_every_beat_schedule_entry_points_at_a_registered_task(registered_task_names):
+    from app.core.celery import celery_app
+
+    schedule = celery_app.conf.beat_schedule
+    assert schedule, "beat_schedule is empty — this test would assert nothing"
+
+    unresolvable = sorted(
+        {entry["task"] for entry in schedule.values() if entry["task"] not in registered_task_names}
+    )
+
+    assert not unresolvable, f"beat entries naming no registered task: {unresolvable}"
+
+
+def test_every_task_route_points_at_a_registered_task(registered_task_names):
+    from app.core.celery import celery_app
+
+    routes = celery_app.conf.task_routes
+    assert routes, "task_routes is empty — this test would assert nothing"
+
+    # Routing keys may be glob patterns ("app.tasks.*"); only exact names are checkable.
+    exact = {key for key in routes if not any(ch in key for ch in "*?[")}
+    assert exact, "no exact-match routing keys — this test would assert nothing"
+
+    unresolvable = sorted(exact - registered_task_names)
+
+    assert not unresolvable, f"task_routes keys naming no registered task: {unresolvable}"

--- a/backend/tests/unit/test_directory_sync_task.py
+++ b/backend/tests/unit/test_directory_sync_task.py
@@ -98,6 +98,11 @@ def test_check_schedule_not_due_dispatches_nothing_and_does_not_stamp(use_test_s
 
     from app.services import backup_service as bs
 
+    # "Does not stamp" means UNCHANGED, not None: this is a SystemSettings row in the shared
+    # dev DB that the running celery-beat commits whenever a sync window is claimed. The
+    # backup sibling of this assertion went red exactly that way (see test_backup_tasks.py).
+    before = svc.get_settings(use_test_session)["last_run_at"]
+
     with (
         mock.patch.object(bs, "is_due", return_value=False),
         mock.patch.object(task_mod.run_directory_sync, "apply_async") as dispatch,
@@ -106,7 +111,7 @@ def test_check_schedule_not_due_dispatches_nothing_and_does_not_stamp(use_test_s
 
     assert result == {"status": "not_due", "schedule": "0 3 * * *"}
     dispatch.assert_not_called()
-    assert svc.get_settings(use_test_session)["last_run_at"] is None
+    assert svc.get_settings(use_test_session)["last_run_at"] == before
 
 
 def test_check_schedule_due_stamps_last_run_and_dispatches_on_cpu_queue(use_test_session):

--- a/backend/tests/unit/test_nltk_cache_hardlinks.py
+++ b/backend/tests/unit/test_nltk_cache_hardlinks.py
@@ -1,0 +1,118 @@
+"""The NLTK cache must contain no multiply-linked files (issue #491).
+
+NLTK >= 3.10 ships ``nltk/pathsec.py``, which refuses to open any file whose link count
+is greater than one::
+
+    PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
+    '.../nltk_data/tokenizers/punkt_tab/english/collocations.tab' (st_nlink=3);
+    a hardlink can point at an outside-root inode (CWE-59)
+
+A model cache restored from a backup, or copied with ``cp -al`` / ``rsync --link-dest``,
+arrives fully hardlinked. Every punkt read then raises, and because
+``clean_segments`` does not catch it, **transcription fails for every file on the box** —
+which is exactly what was found running in the dev stack: all 130 files in
+``models/nltk_data`` had ``st_nlink == 3`` and ``split_sentences_nltk`` raised in the
+backend and both transcription workers, while the host venv (an older NLTK) was fine.
+
+The control is legitimate, so the data is what gets fixed:
+``ensure_nltk_data_unlinked`` in ``scripts/common.sh`` runs at every startup. These
+tests drive that shell function for real rather than grepping for it — a hardlink is
+a filesystem property, and only the filesystem can confirm it was broken.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMMON_SH = REPO_ROOT / "scripts" / "common.sh"
+OPENTR_SH = REPO_ROOT / "opentr.sh"
+
+_PUNKT_REL = Path("models/nltk_data/tokenizers/punkt_tab/english/collocations.tab")
+
+
+def _run_helper(cwd: Path) -> subprocess.CompletedProcess:
+    """Source common.sh and run the helper with ``cwd`` as the working directory."""
+    return subprocess.run(
+        ["bash", "-c", f'set -e; source "{COMMON_SH}"; ensure_nltk_data_unlinked'],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> Path:
+    """A throwaway model cache holding one punkt-shaped file. No .env -> ./models."""
+    target = tmp_path / _PUNKT_REL
+    target.parent.mkdir(parents=True)
+    target.write_text("gutenberg,the\nmr,smith\n")
+    return tmp_path
+
+
+def test_it_breaks_hardlinks_and_preserves_content_exactly(cache: Path):
+    """The whole point: link count drops to 1, bytes are untouched."""
+    original = cache / _PUNKT_REL
+    content_before = original.read_bytes()
+    mode_before = original.stat().st_mode
+
+    # Two extra links, matching the st_nlink=3 observed in the live cache.
+    for name in ("link_a", "link_b"):
+        os.link(original, cache / name)
+    assert original.stat().st_nlink == 3
+
+    result = _run_helper(cache)
+
+    assert result.returncode == 0, result.stderr
+    assert original.stat().st_nlink == 1, "the hardlink was not broken"
+    assert original.read_bytes() == content_before, "content changed — this must be inode-only"
+    assert original.stat().st_mode == mode_before, "permissions were not preserved"
+    # The other links keep the old inode and the old content; nothing is destroyed.
+    assert (cache / "link_a").read_bytes() == content_before
+
+
+def test_it_is_a_noop_when_nothing_is_hardlinked(cache: Path):
+    """Must-stay-clean control: a healthy cache is left alone.
+
+    Without this, a helper that rewrote every file unconditionally — or one that
+    silently did nothing at all — would still pass the test above.
+    """
+    original = cache / _PUNKT_REL
+    inode_before = original.stat().st_ino
+
+    result = _run_helper(cache)
+
+    assert result.returncode == 0, result.stderr
+    assert original.stat().st_ino == inode_before, "a healthy cache must not be rewritten"
+    assert "De-hardlinking" not in result.stdout
+
+
+def test_it_is_a_noop_when_the_cache_does_not_exist(tmp_path: Path):
+    """First boot, before any model has been downloaded."""
+    result = _run_helper(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_startup_runs_the_helper_on_every_path():
+    """Wiring guard: the fix is worthless if `./opentr.sh start` does not call it.
+
+    Both startup paths prepare the model cache (`fix_model_cache_permissions`); each
+    must de-hardlink too, or a cache restored from backup breaks transcription again.
+    """
+    opentr = OPENTR_SH.read_text()
+
+    assert "ensure_nltk_data_unlinked" in COMMON_SH.read_text(), "helper is not defined"
+
+    calls = opentr.count("ensure_nltk_data_unlinked")
+    prep_calls = opentr.count("fix_model_cache_permissions")
+
+    assert calls == prep_calls, (
+        f"opentr.sh calls fix_model_cache_permissions {prep_calls}x but "
+        f"ensure_nltk_data_unlinked {calls}x — every model-cache prep path must do both"
+    )

--- a/backend/tests/unit/test_segment_dedup.py
+++ b/backend/tests/unit/test_segment_dedup.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.utils.segment_dedup import _EXACT_DUPLICATE_MAX_GAP_S
 from app.utils.segment_dedup import _clamp_overlapping_timestamps
 from app.utils.segment_dedup import _map_words_to_sentence
 from app.utils.segment_dedup import deduplicate_segments
@@ -226,10 +227,14 @@ def test_phase2_catches_an_exact_duplicate_two_positions_apart():
     segment (not just its immediate predecessor), so the (2, 0) pair is
     checked and the duplicate at position 2 is removed. Equal-duration ties
     keep the first occurrence (``dur_i >= dur_j`` removes ``i``).
+
+    The pair sits 1.0 s apart, inside ``_EXACT_DUPLICATE_MAX_GAP_S``. This test
+    originally placed them 8 s apart, which made it assert the issue #487
+    data-loss behaviour — see the sibling test below for that boundary.
     """
     seg0 = _segment(0.0, 2.0, "Thank you very much everyone.")
-    seg1 = _segment(5.0, 7.0, "Completely different filler content here.")
-    seg2 = _segment(10.0, 12.0, "Thank you very much everyone.")
+    seg1 = _segment(2.0, 2.5, "Completely different filler content here.")
+    seg2 = _segment(3.0, 5.0, "Thank you very much everyone.")
 
     result = deduplicate_segments([seg0, seg1, seg2])
 
@@ -237,6 +242,46 @@ def test_phase2_catches_an_exact_duplicate_two_positions_apart():
     texts = [seg["text"] for seg in result]
     assert texts.count("Thank you very much everyone.") == 1
     assert "Completely different filler content here." in texts
+
+
+def test_phase2_keeps_a_repeated_short_utterance_far_apart_in_time():
+    """Issue #487: a genuine repetition minutes later is NOT a Whisper duplicate.
+
+    The regression this pins: Phase 2's full pairwise scan had no time bound, so
+    identical text anywhere in a recording collapsed to one segment. On the
+    10-minute boundary fixture that silently deleted 31 words of real speech,
+    including three separate "Yeah."s up to 149 s apart.
+
+    Both must survive: same speaker, same word, two distinct utterances.
+    """
+    first = _segment(10.0, 10.4, "Yeah.")
+    middle = _segment(60.0, 63.0, "So the interesting part is how the model behaves.")
+    later = _segment(159.0, 159.4, "Yeah.")
+
+    result = deduplicate_segments([first, middle, later])
+
+    assert len(result) == 3, f"a repeated utterance was deleted: {[s['text'] for s in result]}"
+    assert [seg["text"] for seg in result].count("Yeah.") == 2
+
+
+def test_phase2_gap_boundary_is_the_documented_threshold():
+    """Just inside the gate collapses; just outside it survives.
+
+    Pins ``_EXACT_DUPLICATE_MAX_GAP_S`` as a real behavioural boundary rather
+    than an unread constant, so widening it back toward "match anywhere" fails
+    here rather than only on the GPU-marked fixture.
+    """
+    gap = _EXACT_DUPLICATE_MAX_GAP_S
+
+    inside = deduplicate_segments(
+        [_segment(0.0, 1.0, "Right."), _segment(1.0 + gap - 0.1, 2.0 + gap - 0.1, "Right.")]
+    )
+    outside = deduplicate_segments(
+        [_segment(0.0, 1.0, "Right."), _segment(1.0 + gap + 0.1, 2.0 + gap + 0.1, "Right.")]
+    )
+
+    assert len(inside) == 1
+    assert len(outside) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_speaker_maintenance.py
+++ b/backend/tests/unit/test_speaker_maintenance.py
@@ -34,13 +34,22 @@ from app.services.opensearch_service import speaker_maintenance
 
 _OPENSEARCH_ABSENT = os.environ.get("SKIP_OPENSEARCH", "True").lower() == "true"
 
-pytestmark = pytest.mark.skipif(
-    _OPENSEARCH_ABSENT,
-    reason=(
-        "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
-        "document writes/deletes and cannot be meaningfully mocked."
+
+# Serialised against the other live-cluster speaker suites (issue #486). All three create and
+# delete throwaway OpenSearch indices; under the default `-n auto` (24 workers here) that
+# index churn overloads the single dev cluster and reads start timing out at 10 s, which
+# surfaces as an unrelated-looking assertion failure in whichever test lost the race.
+# Measured: 1 failure in 4 concurrent runs, on a different test each time.
+pytestmark = [
+    pytest.mark.xdist_group("opensearch_speaker_indices"),
+    pytest.mark.skipif(
+        _OPENSEARCH_ABSENT,
+        reason=(
+            "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
+            "document writes/deletes and cannot be meaningfully mocked."
+        ),
     ),
-)
+]
 
 
 def _embedding(dimension: int, offset: float = 0.0) -> list[float]:

--- a/backend/tests/unit/test_speaker_metadata.py
+++ b/backend/tests/unit/test_speaker_metadata.py
@@ -392,6 +392,13 @@ def test_sync_speaker_profiles_counts_a_missing_opensearch_document_as_skipped(
     live cluster's actual error string can confirm that match is real).
     """
     media_file = _media_file(db_session, normal_user)
+
+    # The sweep is deliberately GLOBAL — it walks every Speaker row in the shared dev DB,
+    # including rows other workers commit through their own SessionLocal(). So measure this
+    # speaker's CONTRIBUTION as a delta rather than asserting on the aggregate: one
+    # unrelated row erroring would otherwise fail a test that is not about it (issue #486).
+    before = speaker_metadata.sync_speaker_profiles_to_opensearch(db_session)
+
     speaker = Speaker(
         uuid=uuid_pkg.uuid4(),
         user_id=normal_user.id,
@@ -403,10 +410,12 @@ def test_sync_speaker_profiles_counts_a_missing_opensearch_document_as_skipped(
     db_session.flush()
     # Deliberately no matching OpenSearch document for this speaker's uuid.
 
-    baseline = speaker_metadata.sync_speaker_profiles_to_opensearch(db_session)
+    after = speaker_metadata.sync_speaker_profiles_to_opensearch(db_session)
 
-    assert baseline["skipped"] >= 1
-    assert baseline["errors"] == 0, (
+    assert after["skipped"] - before["skipped"] >= 1, (
+        "the un-indexed speaker added by this test must be counted as skipped"
+    )
+    assert after["errors"] == before["errors"], (
         "a genuinely missing document must classify as 'skipped', never 'errors' — "
         "if this fails, the 'document_missing_exception' substring match in the "
         "source no longer matches the live cluster's real error text"

--- a/backend/tests/unit/test_speaker_metadata.py
+++ b/backend/tests/unit/test_speaker_metadata.py
@@ -28,13 +28,22 @@ from app.services.opensearch_service import speaker_metadata
 
 _OPENSEARCH_ABSENT = os.environ.get("SKIP_OPENSEARCH", "True").lower() == "true"
 
-pytestmark = pytest.mark.skipif(
-    _OPENSEARCH_ABSENT,
-    reason=(
-        "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
-        "document reads/writes and cannot be meaningfully mocked."
+
+# Serialised against the other live-cluster speaker suites (issue #486). All three create and
+# delete throwaway OpenSearch indices; under the default `-n auto` (24 workers here) that
+# index churn overloads the single dev cluster and reads start timing out at 10 s, which
+# surfaces as an unrelated-looking assertion failure in whichever test lost the race.
+# Measured: 1 failure in 4 concurrent runs, on a different test each time.
+pytestmark = [
+    pytest.mark.xdist_group("opensearch_speaker_indices"),
+    pytest.mark.skipif(
+        _OPENSEARCH_ABSENT,
+        reason=(
+            "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
+            "document reads/writes and cannot be meaningfully mocked."
+        ),
     ),
-)
+]
 
 
 def _embedding(dimension: int = PYANNOTE_EMBEDDING_DIMENSION_V4) -> list[float]:
@@ -82,6 +91,15 @@ def indices(monkeypatch):
     v4 = get_speaker_index_v4()
     _ensure_versioned_speaker_index(v3, PYANNOTE_EMBEDDING_DIMENSION_V3)
     _ensure_versioned_speaker_index(v4, PYANNOTE_EMBEDDING_DIMENSION_V4)
+    # `_ensure_versioned_speaker_index` swallows CLUSTER_UNAVAILABLE_ERRORS (which include 4xx
+    # TransportErrors such as a shard-limit validation_exception) and returns without raising,
+    # so under cluster pressure this fixture can "succeed" having created nothing. Fail here,
+    # naming the cause, rather than three lines later as a mystery stale-document assertion.
+    for name in (v3, v4):
+        assert client.indices.exists(index=name), (
+            f"index {name} was not created — _ensure_versioned_speaker_index swallowed the "
+            "cluster error (issue #486)"
+        )
     alias = get_speaker_index()
     client.indices.put_alias(index=v4, name=alias)
 

--- a/backend/tests/unit/test_speaker_write.py
+++ b/backend/tests/unit/test_speaker_write.py
@@ -31,13 +31,22 @@ from app.services.opensearch_service import speaker_write
 
 _OPENSEARCH_ABSENT = os.environ.get("SKIP_OPENSEARCH", "True").lower() == "true"
 
-pytestmark = pytest.mark.skipif(
-    _OPENSEARCH_ABSENT,
-    reason=(
-        "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
-        "document writes and cannot be meaningfully mocked."
+
+# Serialised against the other live-cluster speaker suites (issue #486). All three create and
+# delete throwaway OpenSearch indices; under the default `-n auto` (24 workers here) that
+# index churn overloads the single dev cluster and reads start timing out at 10 s, which
+# surfaces as an unrelated-looking assertion failure in whichever test lost the race.
+# Measured: 1 failure in 4 concurrent runs, on a different test each time.
+pytestmark = [
+    pytest.mark.xdist_group("opensearch_speaker_indices"),
+    pytest.mark.skipif(
+        _OPENSEARCH_ABSENT,
+        reason=(
+            "No OpenSearch reachable (SKIP_OPENSEARCH). These tests verify real "
+            "document writes and cannot be meaningfully mocked."
+        ),
     ),
-)
+]
 
 
 def _embedding(dimension: int, offset: float = 0.0) -> list[float]:

--- a/opentr.sh
+++ b/opentr.sh
@@ -1285,6 +1285,9 @@ start_app() {
     # Fix model cache permissions for non-root container
     fix_model_cache_permissions
 
+    # NLTK >= 3.10 refuses multiply-linked files (issue #491)
+    ensure_nltk_data_unlinked
+
     # Ensure OpenSearch neural models are downloaded for offline capability
     ensure_opensearch_models
   fi
@@ -2182,6 +2185,9 @@ reset_and_init() {
 
   # Fix model cache permissions for non-root container
   fix_model_cache_permissions
+
+  # NLTK >= 3.10 refuses multiply-linked files (issue #491)
+  ensure_nltk_data_unlinked
 
   # Ensure OpenSearch neural models are downloaded for offline capability
   ensure_opensearch_models

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -132,6 +132,67 @@ fix_model_cache_permissions() {
   return 0
 }
 
+# Give every file in the NLTK cache its own inode (issue #491).
+#
+# NLTK >= 3.10 hardens file access with `nltk/pathsec.py`, which REFUSES to open any
+# multiply-linked file:
+#
+#   PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
+#   '.../nltk_data/tokenizers/punkt_tab/english/collocations.tab' (st_nlink=3);
+#   a hardlink can point at an outside-root inode (CWE-59)
+#
+# That is a legitimate control (a hardlink in a mounted cache can alias an inode outside
+# the data root), so the fix is to make the DATA comply — never to disable the check or
+# pin back to an unhardened NLTK. A cache restored from a backup, or copied with
+# `cp -al` / `rsync --link-dest`, arrives fully hardlinked; every punkt read then raises
+# and `split_sentences_nltk` fails for every transcription on the box.
+#
+# ⚠️ Scoped to nltk_data ON PURPOSE. The huggingface/torch/sentence-transformers caches
+# are also commonly hardlinked, but nothing reads them through pathsec, and those caches
+# dedupe deliberately — breaking their links can double tens of GB on disk. nltk_data is
+# ~45 MB, so rewriting it is free.
+#
+# Content is preserved exactly (`cp -p` then atomic `mv`); only the inode changes.
+# Safe and idempotent: a cache with no multiply-linked files is a no-op.
+ensure_nltk_data_unlinked() {
+  local MODEL_CACHE_DIR=""
+  if [ -f .env ]; then
+    MODEL_CACHE_DIR=$(grep 'MODEL_CACHE_DIR' .env | grep -v '^#' | cut -d'#' -f1 | cut -d'=' -f2 | tr -d ' "' | head -1)
+  fi
+  MODEL_CACHE_DIR="${MODEL_CACHE_DIR:-./models}"
+
+  local nltk_dir="$MODEL_CACHE_DIR/nltk_data"
+  [ -d "$nltk_dir" ] || return 0
+
+  local linked
+  linked=$(find "$nltk_dir" -type f -links +1 2>/dev/null | wc -l)
+  [ "$linked" -gt 0 ] || return 0
+
+  echo "🔗 De-hardlinking $linked NLTK data file(s) — NLTK >= 3.10 refuses multiply-linked files"
+
+  local rewritten=0 failed=0 f
+  while IFS= read -r f; do
+    if cp -p "$f" "$f.dehl" 2>/dev/null && mv -f "$f.dehl" "$f" 2>/dev/null; then
+      rewritten=$((rewritten + 1))
+    else
+      rm -f "$f.dehl" 2>/dev/null
+      failed=$((failed + 1))
+    fi
+  done < <(find "$nltk_dir" -type f -links +1 2>/dev/null)
+
+  if [ "$failed" -gt 0 ]; then
+    echo "⚠️  Warning: could not de-hardlink $failed NLTK file(s); sentence splitting will fail"
+    echo "   with 'Security Violation [pathsec.open]: refusing multiply-linked file'."
+    echo "   Manual fix (content is preserved, only the inode changes):"
+    echo "     find $nltk_dir -type f -links +1 \\"
+    echo "       -exec sh -c 'cp -p \"\$1\" \"\$1.dehl\" && mv -f \"\$1.dehl\" \"\$1\"' _ {} \\;"
+    return 1
+  fi
+
+  echo "✅ NLTK cache de-hardlinked ($rewritten file(s))"
+  return 0
+}
+
 # Fix ownership of the shared pipeline_scratch Docker named volume.
 #
 # The volume is created root-owned by default, which blocks the non-root

--- a/scripts/download-models.py
+++ b/scripts/download-models.py
@@ -411,6 +411,10 @@ def download_nltk_data():
             'averaged_perceptron_tagger_eng',  # POS tagger for NER
             'maxent_ne_chunker_tab',  # Named entity chunker for speaker name extraction
             'words',  # English word corpus (required by NE chunker)
+            # Topic/keyword extraction: app/utils/text_preprocessing.py and
+            # services/ingest_artifacts/textrank.py. Absent here, it was fetched at RUNTIME on
+            # first topic extraction — which fails on an airgapped deployment (issue #491).
+            'stopwords',
         ]
 
         downloaded = []

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -136,9 +136,15 @@ run_phase "Gated security suites (FIPS_MODE=true)" \
 # The narrowing is guarded: tests/unit/test_gate_phase_coverage.py fails if an
 # `integration`-marked test appears outside these paths, so one added elsewhere cannot go
 # silently unrun the way `gpu` did before #297 (issue #431).
+#
+# `--timeout` is restated explicitly because `-o addopts=""` drops pyproject's `--timeout=300`
+# along with `-n auto`. Without it NOTHING bounds a stuck test: these poll the live stack, so a
+# stage that never settles hangs the phase indefinitely rather than failing it (issue #493).
+# The value is deliberately generous — a real reprocess of a long recording is legitimately
+# minutes — the point is that a ceiling exists at all.
 run_phase "Integration-marked tests" \
     "$VENV_PY" -m pytest tests/integration/ tests/test_selective_reprocess.py \
-    -o addopts="" -m integration -q --tb=short
+    -o addopts="" -m integration -q --tb=short --timeout="${INTEGRATION_TEST_TIMEOUT:-900}"
 
 # 4. GPU-marked tests. Deselected from the fast suite and from CI (both CPU-only), so
 # this gate is the ONLY place they run — they were silently ungated before #297.
@@ -146,7 +152,8 @@ run_phase "Integration-marked tests" \
 # machine without CUDA; pass --skip-gpu to drop the phase entirely.
 if $RUN_GPU; then
     run_phase "GPU-marked tests" \
-        "$VENV_PY" -m pytest tests/ -o addopts="" -m gpu -q --tb=short
+        "$VENV_PY" -m pytest tests/ -o addopts="" -m gpu -q --tb=short \
+        --timeout="${GPU_TEST_TIMEOUT:-1800}"
 else
     echo -e "${YELLOW}Skipping GPU-marked tests (--skip-gpu).${NC}"
 fi


### PR DESCRIPTION
Fixes three unrelated defects found by `./scripts/run-integration-tests.sh` while verifying PR #481, plus a fourth found during that work. Root causes were proven before anything was changed — and in all three cases the cause was **not** what the issue proposed.

Closes #487, #485, #486.

---

## #487 — golden-fixture drift is a real production data-loss bug (`c548daa9`)

The issue asked "real accuracy drift or stale fixture?". **Real drift** — and re-baselining, which the issue offered as an option, would have deleted the evidence and closed it green.

`8c601d0a` (via PR #472, not #481) changed Phase 2 of `deduplicate_segments` from comparing each segment to its immediate predecessor to a **full pairwise scan over the whole file**. Phase 2 has no time gate — adjacency *was* the implicit bound. So identical text anywhere in a recording collapsed to one segment, deleting real speech:

```
[7.00-7.08]     w=1  'Manifest.'                       (duplicate 73 s away)
[156.08-157.10] w=7  'How can I have more of them?'    (duplicate 144 s away)
[408.88-409.24] w=1  'Yeah.'                           (duplicate 149 s away)
...
```

1+15+7+6+1+1 = **31 words** = 2282 − 2251, exactly. Every transcript with a repeated short utterance ("Yeah.", "Right.") silently lost speech.

**Threshold measured, not guessed** — swept on the real fixture: 0.0 s removes nothing, **[0.5, 2.0] restores exactly 110 segs / 2282 words**, ≥5.0 over-removes. Uses 2.0 with the plateau recorded in a comment. Requiring true *overlap* (Phase 3's rule) would be wrong — the genuine duplicates here are adjacent, not overlapping.

`ref.words.json` and `baseline.json` are **unchanged**. NLTK is exonerated: the split is byte-identical across versions.

One test was asserting the bug (its duplicate pair sat 8 s apart) and is retimed. Two new tests added; both verified **red** against a `git archive HEAD` tree.

## #485 — Celery dispatched to the default AMQP broker (`f1c1c7c3`)

Not `producer_pool`, not kombu, not an init-order race — the three hypotheses on the issue, which is why the recorded warm-up attempt failed.

`@shared_task` resolves through `celery._state.get_current_app()` on **every call**, reading a `threading.local`. `Celery.__init__` sets only the creating thread's slot and never the global `default_app`. FastAPI runs every sync `def` endpoint on a Starlette threadpool worker, where both are `None` — so Celery minted a phantom `Celery('default')` with **no broker** and cached it process-wide. Its `broker_url` is `None` → the `amqp://` class default.

```
MAIN  : t.app is app -> True    broker -> redis://...
THREAD: t.app is app -> False   broker -> None        ← the reported "falsy at that call site"
FIXED : t.app is app -> True    broker -> redis://...
```

Fix: `celery_app.set_default()`, plus converting all 14 `@shared_task` tasks to `@celery_app.task` (this is an application, not a library).

**Task names are a wire contract** (`beat_schedule` / `task_routes` use strings). All 14 already had explicit `name=`, verified by dumping the finalized registry before and after: **85 names, identical**. Three tests pin it.

Tests assert **app identity**, not the endpoint response — the autouse `_skip_celery_dispatch` fixture patches `Task.apply_async` at class level and cannot see this bug — and run in a **clean process**, since `default_app` masks the failure forever once minted.

**Live-verified**: 6/6 POSTs to each of the three admin "Run now" endpoints → 200 with real task ids, no amqp errors, each id received and executed by the correct worker on its correct queue.

## #486 — xdist flake (`c11e305e`)

Not an id collision — every index name and doc id is already `uuid4`-derived, and the primary failing test touches no DB and no shared id. The issue's proposed fix would have changed nothing.

Reproduced by running the live-cluster suites together (1 failure in 4 runs, different test each time). With logging raised, the real error is not an assertion:

```
urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='localhost', port=5180):
Read timed out. (read timeout=10)
```

raised from the test's own arrange step. Three suites each create and delete **three** throwaway indices per test; 24 xdist workers saturate the single dev cluster.

Fix: `xdist_group("opensearch_speaker_indices")` on the three suites that touch the real cluster. `test_stale_chunk_index_recreate.py` is deliberately excluded — it stubs the client. **6/6 clean runs** after.

Also makes `_ensure_versioned_speaker_index`'s swallowed cluster errors loud in the fixture.

**Deliberately not changed**: `update_speaker_profile`'s broad `except`. The measurement doesn't implicate it, it's a documented contract with 8 call sites, and `sync_speaker_profiles_to_opensearch` already compensates.

## NLTK / model cache (`314ae6e5`) — refs #491, #492

**Transcription was broken in the running dev stack.** `split_sentences_nltk` raised on every call in the backend and both workers:

```
PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
'.../punkt_tab/english/collocations.tab' (st_nlink=3)  # CWE-59
```

NLTK ≥3.10 refuses multiply-linked files; all 130 files in `models/nltk_data` were hardlinked. The control is legitimate, so **the data is fixed, not the control**: `ensure_nltk_data_unlinked` gives each file its own inode (content and mode preserved), wired into both `opentr.sh` startup paths so a restored cache self-heals. Scoped to `nltk_data` on purpose — HF/torch caches dedupe deliberately and breaking those could double tens of GB.

`nltk` floor raised to `>=3.10.3,<4` to **require** the hardening rather than avoid it.

Why it reached production undetected: `nltk>=3.9.4` let the venv resolve 3.9.4 and the image 3.10.3, so the gate passed on a version production doesn't run.

Also adds `stopwords` to the prefetch list (it was fetched at runtime — fails airgapped).


## Integration-test speed fix (`817eb6b6`) — refs #493

The gate's integration phase was taking **>30 minutes and not finishing**. Two defects in `test_selective_reprocess.py`:

- `_wait_for_completed` ignored the terminal `error`/`cancelled` statuses and polled its whole window — `max_wait=600` at 1–2 s a poll is **10–20 minutes** — for a state that could never arrive, then reported a bare "File not completed". Now fails fast with the status, elapsed time and `error_category`.
- `completed_file` claimed to pick "the shortest completed file" but passed `limit=1` where the endpoint takes `page_size`; FastAPI ignores unknown params, so it used the default page of 20 and could latch onto a file another test had already driven into `error`. Now filters `status=completed` server-side.

**Result: the phase went from >30 min (hanging) to 3 m 51 s.**

## Gate results

| phase | result |
|---|---|
| Unit/API | ✅ **9,478 passed** |
| Gated security (FIPS off) | ✅ 374 passed |
| Gated security (FIPS on) | ✅ 374 passed |
| GPU-marked | ✅ passed (includes the #487 boundary fixture) |
| Model-vs-schema drift | ✅ passed |
| DB session lifetime | ✅ passed |
| Collection determinism | ✅ passed |
| Mutation ratchet | ✅ passed |
| Integration-marked | ❌ 11 failed / 81 passed — **all pre-existing and environmental** |

### The 11 integration failures are not from this branch

- **10 × `test_selective_reprocess.py`** — a GPU OOM cascade. The shortest *completed* file in the dev database is **8168 s (2 h 16 m)**, and diarizing it exhausts the 12 GB RTX 3080 Ti at `batch_size=1` (3 OOM events in the worker log). The first test fails at 83 s on the real OOM; the rest fail at **0 s** because the module-scoped fixture reuses the file now stuck in `error`.
- **1 × `test_corpus_injection_synthetic_e2e`** — verified pre-existing by reproducing it identically from a clean `git archive master` tree.

None of the modules changed on this branch appear in any integration traceback. Filed as #493 (with the missing `--timeout` and a proposal to seed a short fixture file).

---

## Follow-ups filed

- **#491** — NLTK/offline: 12 remaining airgap gaps (offline overlay missing `nltk_data` mounts, `check_models_exist` never verifying NLTK, docs overstating coverage).
- **#493** — integration phase: no per-test timeout (the gate's `-o addopts=` strips `--timeout=300`), no short completed file to reprocess so the GPU stages OOM, and a pre-existing corpus-injection failure.
- **#492** — `requirements.txt` pins almost nothing: 61 of 68 specs are `>=` floors, and the venv and container had **diverged by 120 packages, 18 at a major version** (`starlette` 0.48 vs 1.6, `openai` 2.44 vs 3.2, `pandas` 2.2 vs 3.0). The gate was not testing what ships. Every `==`-pinned package matched exactly. The venv has been aligned by hand for this branch; the lockfile is the durable fix.

## Verification

- Full gate run against the live stack, on a venv aligned to the container's exact versions.
- `scripts/audit-tests.py tests` — no un-allowlisted findings.
- Every new test watched fail first against a `git archive HEAD` tree.
- #485 additionally verified live through the real admin endpoints; #486 over 6 repeated concurrent runs.

---

## Follow-up commits (test infrastructure)

**`817eb6b6` + `4a4a63e9` — integration phase: >30 min hanging → under 3 min, 0 failures.**

`test_selective_reprocess.py` reprocessed whichever completed file the dev database happened to hold. That mutated real user data (which `backend/tests/CLAUDE.md` forbids), it was ambient, and it could not pass here: the shortest *completed* file is 2 h 16 m and diarizing it OOMs a 12 GB GPU. The first stage OOM'd, left the file in `error`, and the module-scoped fixture then fed that poisoned file to every later test — 10 failures from one cause.

It now uploads `tests/fixtures/media/sample_short.wav` (the committed 10 s clip the fixtures README already documents), waits for it, and deletes it in a `finally`. `REPROCESS_TEST_MEDIA` overrides the source for local real-corpus runs (`test_videos/`, AMI) that CI cannot do. `_wait_for_completed` also now fails fast on terminal `error`/`cancelled` instead of polling a decided outcome for up to 20 minutes.

**Result: 16 passed in 80 s.**

**`605d9bf4`** — the last outstanding plan item for #486: the sync-sweep test asserted on an aggregate over every speaker row in the shared DB; it now measures its own delta.

**`2489dc54`** — `--timeout` restated on the integration and GPU phases (`-o addopts=""` was dropping pyproject's `--timeout=300`, so nothing bounded a stuck test), plus CI job/step timeouts after the "Backend Tests" job burned **6 hours** on an unreachable apt mirror without running a single test.

## One known failure, tracked not hidden

`test_the_indexed_chunk_text_is_the_generators_own_turn_content` is `xfail(strict=True)` against **#495**.

- **Not a product defect.** The live index holds 13,023 chunks across 18 real files; real search and retrieval are unaffected. Scope is the synthetic-corpus *eval harness*.
- **Not caused by this PR's code** — reproduces from a clean `git archive master` tree.
- **`strict=True`** so fixing #495 makes it XPASS and fail the suite, forcing the marker out rather than letting it outlive its bug. `audit-tests.py` enforces exactly that and rejected a non-strict version.

Documented on #495: chunks *are* computed and bulk-written for all 8 meetings with no errors; the live `transcript_chunks` index is on mapping **v4** while the code targets **v6**, because `start dev` preserves volumes (only `reset dev` wipes) — that is the prime lead. Also recorded honestly there: the master-tree control used the current venv, so the 120-package alignment is not excluded as a contributor, and it must be excluded by pinning **forward** (#492), never by downgrading.

## Final gate

| phase | result |
|---|---|
| Unit/API | ✅ 9,478 passed |
| Gated security, both FIPS modes | ✅ 374 + 374 passed |
| Integration | ✅ 91 passed, 1 xfail (#495) |
| GPU-marked | ✅ passed |
| Schema drift · session lifetime · collection determinism · mutation ratchet | ✅ passed |
| `audit-tests.py` | ✅ no un-allowlisted findings |
